### PR TITLE
feat(search): add Simeon bandit tuning

### DIFF
--- a/include/yams/search/search_engine_config.h
+++ b/include/yams/search/search_engine_config.h
@@ -33,6 +33,23 @@ struct SearchEngineConfig {
         CUSTOM
     } corpusProfile = CorpusProfile::MIXED;
 
+    [[nodiscard]] static constexpr const char*
+    corpusProfileToString(CorpusProfile profile) noexcept {
+        switch (profile) {
+            case CorpusProfile::CODE:
+                return "CODE";
+            case CorpusProfile::PROSE:
+                return "PROSE";
+            case CorpusProfile::DOCS:
+                return "DOCS";
+            case CorpusProfile::MIXED:
+                return "MIXED";
+            case CorpusProfile::CUSTOM:
+                return "CUSTOM";
+        }
+        return "MIXED";
+    }
+
     enum class NavigationZoomLevel {
         Auto,
         Map,
@@ -356,6 +373,13 @@ struct SearchEngineConfig {
         }
         return CorpusProfile::MIXED;
     }
+
+    // Per-query simeon bandit arm selection. When non-empty, the lexical
+    // pipeline calls SimeonLexicalBackend::scoreBanditRouted() with this
+    // arm name instead of the default strategy/router-based scoring.
+    // Training-free at inference: the arm name is selected by TunerMAB
+    // from qrel-free proxy rewards. Empty = use existing scoring path.
+    std::string simeonBanditArm;
 };
 
 } // namespace yams::search

--- a/include/yams/search/simeon_lexical_backend.h
+++ b/include/yams/search/simeon_lexical_backend.h
@@ -150,11 +150,10 @@ public:
         bool rm3_enabled = false;
         simeon::PrfConfig rm3_config{};
 
-        // When true, scoreBanditRouted() dispatches to a simeon scoring recipe
-        // selected by a per-query bandit arm name. The arm names map to preset
-        // combinations of BM25 variant + PRF + field structure. Currently
-        // supported arms: "sab_smooth", "sab_smooth_rm3_adaptive".
-        // Training-free at inference (arm names come from qrel-free bandit).
+        // Reserved for backend-owned bandit flows. Normal SearchEngine bandit
+        // routing is controlled per request by SearchEngineConfig::simeonBanditArm.
+        // Direct scoreBanditRouted() calls are available whenever the backend is
+        // ready and receive an explicit arm name from the caller.
         bool bandit_arm_enabled = false;
     };
 
@@ -221,9 +220,14 @@ public:
 
     // Bandit-driven rescore: selects the simeon scoring recipe for `arm_name`.
     // The arm names are preset keys that map to tested (R_q, R_d, S) combos
-    // from the simeon Omega search. Currently supported:
-    //   "sab_smooth"              — plain SAB-smooth γ=5
-    //   "sab_smooth_rm3_adaptive" — SAB-smooth γ=5 + adaptive PRF
+    // from the simeon Omega search. Recognized presets include:
+    //   "sab_smooth"              - plain SAB-smooth gamma=5
+    //   "sab_smooth_rm3_adaptive" - SAB-smooth gamma=5 + adaptive PRF
+    //   "sab_smooth_rm3_diverse"  - SAB-smooth gamma=5 + broader PRF
+    //   "bm25_variants_rrf"       - RRF over SAB-smooth + ATIRE when available
+    //   "atire"                   - ATIRE BM25 when available
+    //   "keyphrase"               - keyphrase strategy when available
+    //   "lead_field"              - lead-field strategy when available
     // Falls back to plain SAB when the arm name is unrecognized.
     // Training-free at inference: the arm name is selected by TunerMAB from
     // qrel-free proxy rewards.

--- a/include/yams/search/simeon_lexical_backend.h
+++ b/include/yams/search/simeon_lexical_backend.h
@@ -149,6 +149,13 @@ public:
         // benchmarks. Corpus-sensitive — defaults to off.
         bool rm3_enabled = false;
         simeon::PrfConfig rm3_config{};
+
+        // When true, scoreBanditRouted() dispatches to a simeon scoring recipe
+        // selected by a per-query bandit arm name. The arm names map to preset
+        // combinations of BM25 variant + PRF + field structure. Currently
+        // supported arms: "sab_smooth", "sab_smooth_rm3_adaptive".
+        // Training-free at inference (arm names come from qrel-free bandit).
+        bool bandit_arm_enabled = false;
     };
 
     explicit SimeonLexicalBackend(Config cfg);
@@ -211,6 +218,18 @@ public:
     Result<RescoreDecision>
     scoreStrategyRouted(std::string_view query,
                         std::span<const std::int64_t> candidate_doc_ids) const;
+
+    // Bandit-driven rescore: selects the simeon scoring recipe for `arm_name`.
+    // The arm names are preset keys that map to tested (R_q, R_d, S) combos
+    // from the simeon Omega search. Currently supported:
+    //   "sab_smooth"              — plain SAB-smooth γ=5
+    //   "sab_smooth_rm3_adaptive" — SAB-smooth γ=5 + adaptive PRF
+    // Falls back to plain SAB when the arm name is unrecognized.
+    // Training-free at inference: the arm name is selected by TunerMAB from
+    // qrel-free proxy rewards.
+    Result<RescoreDecision>
+    scoreBanditRouted(std::string_view query, std::string_view arm_name,
+                      std::span<const std::int64_t> candidate_doc_ids) const;
 
 private:
     Config cfg_;

--- a/plugins/zyp/zpdf_wrapper.cpp
+++ b/plugins/zyp/zpdf_wrapper.cpp
@@ -7,6 +7,7 @@
 #include "zpdf.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <future>
 #include <sstream>
@@ -19,24 +20,42 @@ namespace yams::zyp {
 // TextBuffer
 // ============================================================================
 
-TextBuffer::TextBuffer(uint8_t* data, size_t len) : data_(data), len_(len) {}
+TextBuffer::TextBuffer(uint8_t* data, size_t len)
+    : TextBuffer(data, len, TextBuffer::Deallocator::Zpdf) {}
+
+TextBuffer::TextBuffer(uint8_t* data, size_t len, TextBuffer::Deallocator deallocator)
+    : data_(data), len_(len), deallocator_(deallocator) {}
+
+TextBuffer TextBuffer::fromMalloc(uint8_t* data, size_t len) {
+    return TextBuffer(data, len, TextBuffer::Deallocator::Malloc);
+}
 
 TextBuffer::~TextBuffer() {
+    release();
+}
+
+void TextBuffer::release() noexcept {
     if (data_) {
-        zpdf_free_buffer(data_, len_);
+        if (deallocator_ == TextBuffer::Deallocator::Malloc) {
+            std::free(data_);
+        } else {
+            zpdf_free_buffer(data_, len_);
+        }
+        data_ = nullptr;
+        len_ = 0;
     }
 }
 
 TextBuffer::TextBuffer(TextBuffer&& other) noexcept
-    : data_(std::exchange(other.data_, nullptr)), len_(std::exchange(other.len_, 0)) {}
+    : data_(std::exchange(other.data_, nullptr)), len_(std::exchange(other.len_, 0)),
+      deallocator_(std::exchange(other.deallocator_, TextBuffer::Deallocator::Zpdf)) {}
 
 TextBuffer& TextBuffer::operator=(TextBuffer&& other) noexcept {
     if (this != &other) {
-        if (data_) {
-            zpdf_free_buffer(data_, len_);
-        }
+        release();
         data_ = std::exchange(other.data_, nullptr);
         len_ = std::exchange(other.len_, 0);
+        deallocator_ = std::exchange(other.deallocator_, TextBuffer::Deallocator::Zpdf);
     }
     return *this;
 }
@@ -255,7 +274,7 @@ TextBuffer Document::extractAllParallelized(std::span<const uint8_t> data, int n
         return {};
     std::memcpy(buf, finalText.data(), finalText.size());
     buf[finalText.size()] = '\0';
-    return TextBuffer(buf, finalText.size());
+    return TextBuffer::fromMalloc(buf, finalText.size());
 }
 
 } // namespace yams::zyp

--- a/plugins/zyp/zpdf_wrapper.h
+++ b/plugins/zyp/zpdf_wrapper.h
@@ -24,6 +24,7 @@ class TextBuffer {
 public:
     TextBuffer() = default;
     TextBuffer(uint8_t* data, size_t len);
+    static TextBuffer fromMalloc(uint8_t* data, size_t len);
     ~TextBuffer();
 
     // Move-only
@@ -48,8 +49,14 @@ public:
     [[nodiscard]] size_t size() const { return len_; }
 
 private:
+    enum class Deallocator { Zpdf, Malloc };
+
+    TextBuffer(uint8_t* data, size_t len, Deallocator deallocator);
+    void release() noexcept;
+
     uint8_t* data_ = nullptr;
     size_t len_ = 0;
+    Deallocator deallocator_ = Deallocator::Zpdf;
 };
 
 /**

--- a/src/cli/commands/doctor_command.cpp
+++ b/src/cli/commands/doctor_command.cpp
@@ -207,72 +207,11 @@ using SemanticDedupeMatch = doctor::SemanticDedupeMatch;
 using SemanticDedupeGroupPlan = doctor::SemanticDedupeGroupPlan;
 using SemanticDedupeAnalysis = doctor::SemanticDedupeAnalysis;
 
-float cosineSimilarity(const std::vector<float>& a, const std::vector<float>& b) {
-    if (a.empty() || b.empty() || a.size() != b.size()) {
-        return 0.0f;
-    }
-
-    const auto na = yams::vector::vector_utils::normalize(a);
-    const auto nb = yams::vector::vector_utils::normalize(b);
-    float dot = 0.0f;
-    for (size_t i = 0; i < na.size(); ++i) {
-        dot += na[i] * nb[i];
-    }
-    return dot;
-}
-
-std::string normalizeTextForTokens(std::string value) {
-    for (char& c : value) {
-        if (!std::isalnum(static_cast<unsigned char>(c))) {
-            c = ' ';
-        } else {
-            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-        }
-    }
-
-    std::ostringstream out;
-    std::istringstream in(value);
-    std::string token;
-    bool first = true;
-    while (in >> token) {
-        if (!first) {
-            out << ' ';
-        }
-        out << token;
-        first = false;
-    }
-    return out.str();
-}
-
-std::unordered_set<std::string> tokenSet(std::string_view text) {
-    std::unordered_set<std::string> tokens;
-    std::istringstream in{std::string(text)};
-    std::string token;
-    while (in >> token) {
-        tokens.insert(token);
-    }
-    return tokens;
-}
-
-double jaccardOverlap(std::string_view lhs, std::string_view rhs) {
-    const auto lt = tokenSet(lhs);
-    const auto rt = tokenSet(rhs);
-    if (lt.empty() || rt.empty()) {
-        return 0.0;
-    }
-
-    size_t intersection = 0;
-    for (const auto& token : lt) {
-        if (rt.contains(token)) {
-            ++intersection;
-        }
-    }
-    const size_t uni = lt.size() + rt.size() - intersection;
-    if (uni == 0) {
-        return 0.0;
-    }
-    return static_cast<double>(intersection) / static_cast<double>(uni);
-}
+// `cosineSimilarity`, `normalizeTextForTokens`, `tokenSet`, and
+// `jaccardOverlap` were copy-pasted into
+// `src/cli/commands/doctor/repairs/dedupe.cpp` (lines 53/60/93) and the
+// originals here became unused. Removed 2026-05-15 after the fold SAST
+// audit flagged them; the canonical definitions remain in dedupe.cpp.
 
 } // namespace
 

--- a/src/daemon/components/EmbeddingService.cpp
+++ b/src/daemon/components/EmbeddingService.cpp
@@ -790,6 +790,15 @@ void EmbeddingService::updateSemanticNeighborGraph(
             coord->enqueue(std::move(batch));
             recordPhaseTiming("semantic_edge_upsert", tEdgeUpsert);
             semanticEdgesCreated_.fetch_add(enqueuedCount, std::memory_order_relaxed);
+            spdlog::debug(
+                "EmbeddingService: streaming semantic neighbor graph added {} edges "
+                "(processed_docs={} candidate_docs={} similarity_pairs={} candidate_neighbors={} "
+                "missing_src_nodes={} missing_dst_nodes={} threshold_mode={} threshold_min={} "
+                "threshold_max={} topk={})",
+                enqueuedCount, sources.size(), candidateDocs, similarityPairCount,
+                candidateNeighborCount, missingSrcNodeCount, missingDstNodeCount,
+                explicitSemanticThreshold.has_value() ? "explicit" : "adaptive",
+                minEffectiveThreshold, maxEffectiveThreshold, semanticTopK);
             return;
         }
         recordPhaseTiming("semantic_edge_upsert", tEdgeUpsert);
@@ -797,17 +806,6 @@ void EmbeddingService::updateSemanticNeighborGraph(
         spdlog::warn("EmbeddingService: WriteCoordinator unavailable; dropping {} streaming "
                      "semantic_neighbor edges",
                      semanticEdges.size());
-        return;
-        spdlog::debug(
-            "EmbeddingService: streaming semantic neighbor graph added {} edges "
-            "(processed_docs={} candidate_docs={} similarity_pairs={} candidate_neighbors={} "
-            "missing_src_nodes={} missing_dst_nodes={} threshold_mode={} threshold_min={} "
-            "threshold_max={} topk={})",
-            semanticEdges.size(), sources.size(), candidateDocs, similarityPairCount,
-            candidateNeighborCount, missingSrcNodeCount, missingDstNodeCount,
-            explicitSemanticThreshold.has_value() ? "explicit" : "adaptive", minEffectiveThreshold,
-            maxEffectiveThreshold, semanticTopK);
-        return;
     }
 
     std::vector<CorpusVector> corpus;
@@ -1055,6 +1053,14 @@ void EmbeddingService::updateSemanticNeighborGraph(
         coord->enqueue(std::move(batch));
         recordPhaseTiming("semantic_edge_upsert", tEdgeUpsert);
         semanticEdgesCreated_.fetch_add(enqueuedCount, std::memory_order_relaxed);
+        spdlog::debug(
+            "EmbeddingService: semantic neighbor graph added {} edges (processed_docs={} "
+            "candidate_docs={} similarity_pairs={} candidate_neighbors={} missing_src_nodes={} "
+            "missing_dst_nodes={} threshold_mode={} threshold_min={} threshold_max={} topk={})",
+            enqueuedCount, sources.size(), corpus.size(), similarityPairCount,
+            candidateNeighborCount, missingSrcNodeCount, missingDstNodeCount,
+            explicitSemanticThreshold.has_value() ? "explicit" : "adaptive", minEffectiveThreshold,
+            maxEffectiveThreshold, semanticTopK);
         return;
     }
     recordPhaseTiming("semantic_edge_upsert", tEdgeUpsert);
@@ -1062,15 +1068,6 @@ void EmbeddingService::updateSemanticNeighborGraph(
     spdlog::warn("EmbeddingService: WriteCoordinator unavailable; dropping {} corpus "
                  "semantic_neighbor edges",
                  semanticEdges.size());
-    return;
-    spdlog::debug(
-        "EmbeddingService: semantic neighbor graph added {} edges (processed_docs={} "
-        "candidate_docs={} similarity_pairs={} candidate_neighbors={} missing_src_nodes={} "
-        "missing_dst_nodes={} threshold_mode={} threshold_min={} threshold_max={} topk={})",
-        semanticEdges.size(), sources.size(), corpus.size(), similarityPairCount,
-        candidateNeighborCount, missingSrcNodeCount, missingDstNodeCount,
-        explicitSemanticThreshold.has_value() ? "explicit" : "adaptive", minEffectiveThreshold,
-        maxEffectiveThreshold, semanticTopK);
 }
 
 Result<std::size_t>

--- a/src/search/search_engine.cpp
+++ b/src/search/search_engine.cpp
@@ -19,6 +19,7 @@
 #include <yams/search/search_execution_context.h>
 #include <yams/search/search_tracing.h>
 #include <yams/search/search_tuner.h>
+#include <yams/search/tuner_mab.h>
 #include <yams/search/simeon_lexical_backend.h>
 #include <yams/search/tuning_features.h>
 #include <yams/search/tuning_pipeline.h>
@@ -788,10 +789,17 @@ private:
     EntityExtractionFunc conceptExtractor_; // GLiNER concept extractor (optional)
     std::shared_ptr<SearchTuner> tuner_;    // Adaptive runtime tuner (optional)
     std::unique_ptr<SimeonLexicalBackend> simeonLexical_;
+    // Per-profile simeon bandit arms. Each corpus profile learns independently
+    // which simeon recipe works best via UCB1 from proxy rewards. Training-free.
+    using ProfileKey = std::string;
+    mutable std::unordered_map<ProfileKey, TunerMAB> simeonBandits_;
+    bool simeonBanditsInitialized_ = false;
     // Recipe label from the last simeon rescore call in this request; empty
     // when rescoring was skipped (backend off, not ready, or empty result set).
     // Surfaced to response.debugStats["simeon_route"] for per-query tracing.
     mutable std::string lastSimeonRouteRecipe_;
+    mutable std::string lastSimeonBanditArm_;
+    mutable ProfileKey lastSimeonBanditProfile_;
 };
 
 Result<std::vector<SearchResult>> SearchEngine::Impl::search(const std::string& query,
@@ -816,6 +824,43 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
     auto startTime = std::chrono::steady_clock::now();
     stats_.totalQueries.fetch_add(1, std::memory_order_relaxed);
     lastSimeonRouteRecipe_.clear();
+    lastSimeonBanditArm_.clear();
+    lastSimeonBanditProfile_.clear();
+
+    // Initialize per-profile simeon bandits once (training-free: proxy rewards).
+    if (!simeonBanditsInitialized_ && simeonLexical_ && simeonLexical_->ready()) {
+        std::vector<TunerMAB::Arm> arms;
+        arms.push_back({"sab_smooth", 0.0, {}});
+        arms.push_back({"sab_smooth_rm3_adaptive", 0.0, {}});
+        arms.push_back({"sab_smooth_rm3_diverse", 0.0, {}});
+        if (simeonLexical_->hasStrategyRouter()) {
+            arms.push_back({"keyphrase", 0.0, {}});
+            arms.push_back({"lead_field", 0.0, {}});
+        }
+        using CP = SearchEngineConfig::CorpusProfile;
+        for (auto profile : {CP::CODE, CP::PROSE, CP::DOCS, CP::MIXED, CP::CUSTOM}) {
+            std::vector<TunerMAB::Arm> profileArms = arms;
+            auto key = SearchEngineConfig::corpusProfileToString(profile);
+            simeonBandits_[key].setArms(std::move(profileArms));
+        }
+        simeonBanditsInitialized_ = true;
+    }
+
+    // Select simeon bandit arm for this query from the per-profile bandit.
+    if (simeonBanditsInitialized_) {
+        auto profileKey = SearchEngineConfig::corpusProfileToString(config_.corpusProfile);
+        lastSimeonBanditProfile_ = profileKey;
+        auto it = simeonBandits_.find(profileKey);
+        if (it == simeonBandits_.end())
+            it = simeonBandits_.find("MIXED");
+        if (it != simeonBandits_.end()) {
+            auto armIdx = it->second.selectArm();
+            if (armIdx.has_value() && *armIdx < it->second.arms().size()) {
+                config_.simeonBanditArm = it->second.arms()[*armIdx].id;
+                lastSimeonBanditArm_ = config_.simeonBanditArm;
+            }
+        }
+    }
 
     SearchResponse response;
     std::vector<std::string> timedOut;
@@ -2334,6 +2379,43 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
         response.debugStats["simeon_recipe"] = recipe;
         if (!lastSimeonRouteRecipe_.empty()) {
             response.debugStats["simeon_route"] = lastSimeonRouteRecipe_;
+        }
+        if (!lastSimeonBanditArm_.empty()) {
+            response.debugStats["simeon_bandit_arm"] = lastSimeonBanditArm_;
+        }
+        if (!lastSimeonBanditProfile_.empty()) {
+            response.debugStats["simeon_bandit_profile"] = lastSimeonBanditProfile_;
+        }
+    }
+
+    // Record simeon bandit reward for the arm selected this query.
+    // Training-free: uses proxy signals (result density per ms).
+    if (!lastSimeonBanditArm_.empty() && !lastSimeonBanditProfile_.empty()) {
+        auto profileIt = simeonBandits_.find(lastSimeonBanditProfile_);
+        if (profileIt == simeonBandits_.end())
+            profileIt = simeonBandits_.find("MIXED");
+        if (profileIt != simeonBandits_.end()) {
+            auto& bandit = profileIt->second;
+            std::optional<std::size_t> armIdx;
+            const auto& arms = bandit.arms();
+            for (std::size_t i = 0; i < arms.size(); ++i) {
+                if (arms[i].id == lastSimeonBanditArm_) {
+                    armIdx = i;
+                    break;
+                }
+            }
+            if (armIdx.has_value()) {
+                double elapsedMs = std::chrono::duration<double, std::milli>(
+                                       std::chrono::steady_clock::now() - startTime)
+                                       .count();
+                double resultCount = static_cast<double>(response.results.size());
+                double resultRate =
+                    std::clamp(resultCount / std::max(1.0, elapsedMs) * 10.0, 0.0, 0.95);
+                double armBonus =
+                    (lastSimeonBanditArm_.find("rm3") != std::string::npos) ? 0.05 : 0.0;
+                double reward = std::clamp(resultRate + armBonus, 0.0, 1.0);
+                bandit.recordReward(*armIdx, reward, TunerMAB::RewardSource::Proxy);
+            }
         }
     }
 

--- a/src/search/search_engine.cpp
+++ b/src/search/search_engine.cpp
@@ -37,6 +37,7 @@
 #include <fstream>
 #include <future>
 #include <limits>
+#include <mutex>
 #include <set>
 #include <sstream>
 #include <string>
@@ -757,7 +758,8 @@ private:
     queryFullText(const std::string& query, QueryIntent queryIntent,
                   const SearchEngineConfig& config, size_t limit,
                   QueryExpansionStats* expansionStats = nullptr,
-                  const std::vector<GraphExpansionTerm>* graphExpansionTerms = nullptr);
+                  const std::vector<GraphExpansionTerm>* graphExpansionTerms = nullptr,
+                  std::string* simeonRouteRecipe = nullptr);
 
     Result<std::vector<ComponentResult>> queryPathTree(const std::string& query, size_t limit);
     Result<std::vector<ComponentResult>>
@@ -792,14 +794,9 @@ private:
     // Per-profile simeon bandit arms. Each corpus profile learns independently
     // which simeon recipe works best via UCB1 from proxy rewards. Training-free.
     using ProfileKey = std::string;
-    mutable std::unordered_map<ProfileKey, TunerMAB> simeonBandits_;
+    std::mutex simeonBanditsMutex_;
+    std::unordered_map<ProfileKey, TunerMAB> simeonBandits_;
     bool simeonBanditsInitialized_ = false;
-    // Recipe label from the last simeon rescore call in this request; empty
-    // when rescoring was skipped (backend off, not ready, or empty result set).
-    // Surfaced to response.debugStats["simeon_route"] for per-query tracing.
-    mutable std::string lastSimeonRouteRecipe_;
-    mutable std::string lastSimeonBanditArm_;
-    mutable ProfileKey lastSimeonBanditProfile_;
 };
 
 Result<std::vector<SearchResult>> SearchEngine::Impl::search(const std::string& query,
@@ -823,44 +820,9 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
 
     auto startTime = std::chrono::steady_clock::now();
     stats_.totalQueries.fetch_add(1, std::memory_order_relaxed);
-    lastSimeonRouteRecipe_.clear();
-    lastSimeonBanditArm_.clear();
-    lastSimeonBanditProfile_.clear();
-
-    // Initialize per-profile simeon bandits once (training-free: proxy rewards).
-    if (!simeonBanditsInitialized_ && simeonLexical_ && simeonLexical_->ready()) {
-        std::vector<TunerMAB::Arm> arms;
-        arms.push_back({"sab_smooth", 0.0, {}});
-        arms.push_back({"sab_smooth_rm3_adaptive", 0.0, {}});
-        arms.push_back({"sab_smooth_rm3_diverse", 0.0, {}});
-        if (simeonLexical_->hasStrategyRouter()) {
-            arms.push_back({"keyphrase", 0.0, {}});
-            arms.push_back({"lead_field", 0.0, {}});
-        }
-        using CP = SearchEngineConfig::CorpusProfile;
-        for (auto profile : {CP::CODE, CP::PROSE, CP::DOCS, CP::MIXED, CP::CUSTOM}) {
-            std::vector<TunerMAB::Arm> profileArms = arms;
-            auto key = SearchEngineConfig::corpusProfileToString(profile);
-            simeonBandits_[key].setArms(std::move(profileArms));
-        }
-        simeonBanditsInitialized_ = true;
-    }
-
-    // Select simeon bandit arm for this query from the per-profile bandit.
-    if (simeonBanditsInitialized_) {
-        auto profileKey = SearchEngineConfig::corpusProfileToString(config_.corpusProfile);
-        lastSimeonBanditProfile_ = profileKey;
-        auto it = simeonBandits_.find(profileKey);
-        if (it == simeonBandits_.end())
-            it = simeonBandits_.find("MIXED");
-        if (it != simeonBandits_.end()) {
-            auto armIdx = it->second.selectArm();
-            if (armIdx.has_value() && *armIdx < it->second.arms().size()) {
-                config_.simeonBanditArm = it->second.arms()[*armIdx].id;
-                lastSimeonBanditArm_ = config_.simeonBanditArm;
-            }
-        }
-    }
+    std::string simeonRouteRecipe;
+    std::string selectedSimeonBanditArm;
+    ProfileKey selectedSimeonBanditProfile;
 
     SearchResponse response;
     std::vector<std::string> timedOut;
@@ -970,6 +932,45 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
     const auto effectiveZoomLevel = policy.effectiveZoomLevel;
     const bool zoomLevelInferredFromIntent = policy.zoomLevelInferredFromIntent;
     workingConfig = std::move(policy.config);
+
+    // Select a Simeon bandit arm after tuner/policy resolution so the arm is
+    // request-local and cannot leak through shared config_ state.
+    if (simeonLexical_ && simeonLexical_->ready()) {
+        std::lock_guard<std::mutex> lock(simeonBanditsMutex_);
+        if (!simeonBanditsInitialized_) {
+            std::vector<TunerMAB::Arm> arms;
+            arms.push_back({"sab_smooth", 0.0, {}});
+            arms.push_back({"sab_smooth_rm3_adaptive", 0.0, {}});
+            arms.push_back({"sab_smooth_rm3_diverse", 0.0, {}});
+            if (simeonLexical_->hasStrategyRouter()) {
+                arms.push_back({"keyphrase", 0.0, {}});
+                arms.push_back({"lead_field", 0.0, {}});
+            }
+            using CP = SearchEngineConfig::CorpusProfile;
+            for (auto profile : {CP::CODE, CP::PROSE, CP::DOCS, CP::MIXED, CP::CUSTOM}) {
+                std::vector<TunerMAB::Arm> profileArms = arms;
+                auto key = SearchEngineConfig::corpusProfileToString(profile);
+                simeonBandits_[key].setArms(std::move(profileArms));
+            }
+            simeonBanditsInitialized_ = true;
+        }
+
+        ProfileKey profileKey =
+            std::string{SearchEngineConfig::corpusProfileToString(workingConfig.corpusProfile)};
+        auto it = simeonBandits_.find(profileKey);
+        if (it == simeonBandits_.end()) {
+            profileKey = "MIXED";
+            it = simeonBandits_.find(profileKey);
+        }
+        if (it != simeonBandits_.end()) {
+            auto armIdx = it->second.selectArm();
+            if (armIdx.has_value() && *armIdx < it->second.arms().size()) {
+                selectedSimeonBanditArm = it->second.arms()[*armIdx].id;
+                selectedSimeonBanditProfile = std::move(profileKey);
+                workingConfig.simeonBanditArm = selectedSimeonBanditArm;
+            }
+        }
+    }
 
     // R2/audit: route-derived query-fast features populated after
     // classification so R4+ contextual policies see real signals instead
@@ -1557,11 +1558,12 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
             // --- TIER 1: Text + Path (fast, high precision) ---
             textFuture = schedule(
                 "text", workingConfig.textWeight, stats_.textQueries, stats_.avgTextTimeMicros,
-                [this, &query, intent, &workingConfig, &textExpansionStats,
-                 &graphExpansionTerms]() {
+                [this, &query, intent, &workingConfig, &textExpansionStats, &graphExpansionTerms,
+                 &simeonRouteRecipe]() {
                     YAMS_ZONE_SCOPED_N("component::text");
                     return queryFullText(query, intent, workingConfig, workingConfig.textMaxResults,
-                                         &textExpansionStats, &graphExpansionTerms);
+                                         &textExpansionStats, &graphExpansionTerms,
+                                         &simeonRouteRecipe);
                 });
 
             pathFuture = schedule("path", workingConfig.pathTreeWeight, stats_.pathTreeQueries,
@@ -1756,11 +1758,12 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
             // All components run in parallel
             textFuture = schedule(
                 "text", workingConfig.textWeight, stats_.textQueries, stats_.avgTextTimeMicros,
-                [this, &query, intent, &workingConfig, &textExpansionStats,
-                 &graphExpansionTerms]() {
+                [this, &query, intent, &workingConfig, &textExpansionStats, &graphExpansionTerms,
+                 &simeonRouteRecipe]() {
                     YAMS_ZONE_SCOPED_N("component::text");
                     return queryFullText(query, intent, workingConfig, workingConfig.textMaxResults,
-                                         &textExpansionStats, &graphExpansionTerms);
+                                         &textExpansionStats, &graphExpansionTerms,
+                                         &simeonRouteRecipe);
                 });
 
             const bool deferSemanticStages = semanticBudgetActive;
@@ -1904,7 +1907,7 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
         runSequential(
             [&]() {
                 return queryFullText(query, intent, workingConfig, workingConfig.textMaxResults,
-                                     &textExpansionStats, &graphExpansionTerms);
+                                     &textExpansionStats, &graphExpansionTerms, &simeonRouteRecipe);
             },
             "text", workingConfig.textWeight, stats_.textQueries, stats_.avgTextTimeMicros);
 
@@ -2377,43 +2380,44 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
             recipe += std::to_string(workingConfig.weightedLinearZScorePoolSize);
         }
         response.debugStats["simeon_recipe"] = recipe;
-        if (!lastSimeonRouteRecipe_.empty()) {
-            response.debugStats["simeon_route"] = lastSimeonRouteRecipe_;
+        if (!simeonRouteRecipe.empty()) {
+            response.debugStats["simeon_route"] = simeonRouteRecipe;
         }
-        if (!lastSimeonBanditArm_.empty()) {
-            response.debugStats["simeon_bandit_arm"] = lastSimeonBanditArm_;
+        if (!selectedSimeonBanditArm.empty()) {
+            response.debugStats["simeon_bandit_arm"] = selectedSimeonBanditArm;
         }
-        if (!lastSimeonBanditProfile_.empty()) {
-            response.debugStats["simeon_bandit_profile"] = lastSimeonBanditProfile_;
+        if (!selectedSimeonBanditProfile.empty()) {
+            response.debugStats["simeon_bandit_profile"] = selectedSimeonBanditProfile;
         }
     }
 
     // Record simeon bandit reward for the arm selected this query.
     // Training-free: uses proxy signals (result density per ms).
-    if (!lastSimeonBanditArm_.empty() && !lastSimeonBanditProfile_.empty()) {
-        auto profileIt = simeonBandits_.find(lastSimeonBanditProfile_);
-        if (profileIt == simeonBandits_.end())
+    if (!selectedSimeonBanditArm.empty() && !selectedSimeonBanditProfile.empty()) {
+        double elapsedMs =
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - startTime)
+                .count();
+        double resultCount = static_cast<double>(response.results.size());
+        double resultRate = std::clamp(resultCount / std::max(1.0, elapsedMs) * 10.0, 0.0, 0.95);
+        double armBonus = (selectedSimeonBanditArm.find("rm3") != std::string::npos) ? 0.05 : 0.0;
+        double reward = std::clamp(resultRate + armBonus, 0.0, 1.0);
+
+        std::lock_guard<std::mutex> lock(simeonBanditsMutex_);
+        auto profileIt = simeonBandits_.find(selectedSimeonBanditProfile);
+        if (profileIt == simeonBandits_.end()) {
             profileIt = simeonBandits_.find("MIXED");
+        }
         if (profileIt != simeonBandits_.end()) {
             auto& bandit = profileIt->second;
             std::optional<std::size_t> armIdx;
             const auto& arms = bandit.arms();
             for (std::size_t i = 0; i < arms.size(); ++i) {
-                if (arms[i].id == lastSimeonBanditArm_) {
+                if (arms[i].id == selectedSimeonBanditArm) {
                     armIdx = i;
                     break;
                 }
             }
             if (armIdx.has_value()) {
-                double elapsedMs = std::chrono::duration<double, std::milli>(
-                                       std::chrono::steady_clock::now() - startTime)
-                                       .count();
-                double resultCount = static_cast<double>(response.results.size());
-                double resultRate =
-                    std::clamp(resultCount / std::max(1.0, elapsedMs) * 10.0, 0.0, 0.95);
-                double armBonus =
-                    (lastSimeonBanditArm_.find("rm3") != std::string::npos) ? 0.05 : 0.0;
-                double reward = std::clamp(resultRate + armBonus, 0.0, 1.0);
                 bandit.recordReward(*armIdx, reward, TunerMAB::RewardSource::Proxy);
             }
         }
@@ -4203,11 +4207,10 @@ Result<std::vector<ComponentResult>> SearchEngine::Impl::queryPathTree(const std
     return results;
 }
 
-Result<std::vector<ComponentResult>>
-SearchEngine::Impl::queryFullText(const std::string& query, QueryIntent queryIntent,
-                                  const SearchEngineConfig& config, size_t limit,
-                                  QueryExpansionStats* expansionStats,
-                                  const std::vector<GraphExpansionTerm>* graphExpansionTerms) {
+Result<std::vector<ComponentResult>> SearchEngine::Impl::queryFullText(
+    const std::string& query, QueryIntent queryIntent, const SearchEngineConfig& config,
+    size_t limit, QueryExpansionStats* expansionStats,
+    const std::vector<GraphExpansionTerm>* graphExpansionTerms, std::string* simeonRouteRecipe) {
     try {
         return detail::queryFullTextPipeline(
             metadataRepo_, query, queryIntent, config, limit, expansionStats,
@@ -4229,7 +4232,7 @@ SearchEngine::Impl::queryFullText(const std::string& query, QueryIntent queryInt
                                          .maxSeeds = config.graphExpansionMaxSeeds,
                                          .maxNeighbors = config.graphMaxNeighbors});
             },
-            simeonLexical_.get(), &lastSimeonRouteRecipe_);
+            simeonLexical_.get(), simeonRouteRecipe);
     } catch (const std::exception& e) {
         spdlog::warn("Full-text query exception: {}", e.what());
         return std::vector<ComponentResult>{};

--- a/src/search/search_lexical_pipeline.cpp
+++ b/src/search/search_lexical_pipeline.cpp
@@ -78,7 +78,7 @@ void appendLexicalBatchAtRank(const std::string& query, QueryIntent queryIntent,
 std::optional<yams::metadata::SearchResults>
 makeSimeonLexicalResults(const std::string& query, SimeonLexicalBackend* backend,
                          const yams::metadata::SearchResults& searchResults,
-                         std::string* lastSimeonRouteRecipe) {
+                         std::string* lastSimeonRouteRecipe, const SearchEngineConfig& config) {
     if (!backend || !backend->ready() || searchResults.results.empty()) {
         return std::nullopt;
     }
@@ -89,8 +89,15 @@ makeSimeonLexicalResults(const std::string& query, SimeonLexicalBackend* backend
         ids.push_back(r.document.id);
     }
 
-    auto decision = backend->hasStrategyRouter() ? backend->scoreStrategyRouted(query, ids)
-                                                 : backend->scoreRouted(query, ids);
+    auto decision = [&]() -> Result<SimeonLexicalBackend::RescoreDecision> {
+        if (!config.simeonBanditArm.empty()) {
+            return backend->scoreBanditRouted(query, config.simeonBanditArm, ids);
+        }
+        if (backend->hasStrategyRouter()) {
+            return backend->scoreStrategyRouted(query, ids);
+        }
+        return backend->scoreRouted(query, ids);
+    }();
     if (!decision) {
         spdlog::debug("[simeon-lexical] score failed, keeping FTS5 scores: {}",
                       decision.error().message);
@@ -125,7 +132,7 @@ void appendSimeonLexicalBatch(const std::string& query, SimeonLexicalBackend* ba
                               std::vector<ComponentResult>& results,
                               QueryExpansionStats* expansionStats) {
     auto simeonResults =
-        makeSimeonLexicalResults(query, backend, searchResults, lastSimeonRouteRecipe);
+        makeSimeonLexicalResults(query, backend, searchResults, lastSimeonRouteRecipe, config);
     if (!simeonResults) {
         return;
     }

--- a/src/search/simeon_lexical_backend.cpp
+++ b/src/search/simeon_lexical_backend.cpp
@@ -874,4 +874,92 @@ SimeonLexicalBackend::scoreStrategyRouted(std::string_view query,
     return decision;
 }
 
+Result<SimeonLexicalBackend::RescoreDecision>
+SimeonLexicalBackend::scoreBanditRouted(std::string_view query, std::string_view arm_name,
+                                        std::span<const std::int64_t> candidate_doc_ids) const {
+    if (!ready_.load(std::memory_order_acquire) || !index_) {
+        return Error{ErrorCode::NotInitialized, "SimeonLexicalBackend: not ready"};
+    }
+
+    std::vector<float> full(doc_count_, 0.0f);
+    const char* recipe_label = "Bm25SabSmooth";
+
+    // Dispatch on bandit arm name. Each arm corresponds to a simeon scoring
+    // recipe tested in the Omega benchmark. Training-free at inference.
+    if (arm_name == "sab_smooth") {
+        index_->score(query, std::span<float>{full});
+        recipe_label = "Bm25SabSmooth";
+    } else if (arm_name == "sab_smooth_rm3_adaptive") {
+        simeon::PrfConfig pc;
+        pc.k = 10;
+        pc.n_terms = 20;
+        pc.alpha = 0.5f;
+        simeon::score_with_prf(*index_, query, std::span<float>{full}, pc);
+        recipe_label = "Bm25SabRm3Adaptive";
+    } else if (arm_name == "sab_smooth_rm3_diverse") {
+        // Diverse RM3: larger feedback set, MMR-style diversity (not exposed
+        // here via the simple PrfConfig; we approximate with higher k/n_terms).
+        simeon::PrfConfig pc;
+        pc.k = 20;
+        pc.n_terms = 40;
+        pc.alpha = 0.5f;
+        simeon::score_with_prf(*index_, query, std::span<float>{full}, pc);
+        recipe_label = "Bm25SabRm3Diverse";
+    } else if (arm_name == "bm25_variants_rrf" && atire_index_) {
+        const simeon::Bm25Index* variants[2] = {index_.get(), atire_index_.get()};
+        simeon::score_bm25_variants_rrf(std::span<const simeon::Bm25Index* const>(variants, 2),
+                                        query, std::span<float>{full});
+        recipe_label = "Bm25VariantsRrf";
+    } else if (arm_name == "atire" && atire_index_) {
+        atire_index_->score(query, std::span<float>{full});
+        recipe_label = "Bm25Atire";
+    } else if (arm_name == "keyphrase" && strategy_router_ && !strategies_.empty()) {
+        // Use the KeyphraseStrategy (#1) from the strategy router pool.
+        simeon::AdapterEvidence ev;
+        simeon::QueryProfile profile;
+        std::vector<simeon::RetrievalStrategy*> pool;
+        pool.reserve(strategies_.size());
+        for (const auto& s : strategies_)
+            pool.push_back(s.get());
+        // Route to Keyphrase strategy directly (index 1 in the pool).
+        auto& kp = (pool.size() > 1) ? pool[1] : pool[0];
+        kp->score_indexed(query, 0, ev, std::span<float>{full});
+        recipe_label = "Keyphrase";
+    } else if (arm_name == "lead_field" && strategy_router_ && strategies_.size() > 2) {
+        simeon::AdapterEvidence ev;
+        auto& lead = strategies_[2];
+        lead->score_indexed(query, 0, ev, std::span<float>{full});
+        recipe_label = "LeadField";
+    } else {
+        // Unrecognized or unavailable arm: fall back to plain SAB.
+        index_->score(query, std::span<float>{full});
+        recipe_label = "Bm25SabSmooth";
+    }
+
+    // Blend concept scores when available.
+    if (concept_index_ && cfg_.concept_config.concept_weight > 0.0f) {
+        std::vector<float> conceptScores(doc_count_, 0.0f);
+        concept_index_->score(query, std::span<float>{conceptScores});
+        const float cw = cfg_.concept_config.concept_weight;
+        for (size_t i = 0; i < doc_count_; ++i) {
+            full[i] += cw * conceptScores[i];
+        }
+    }
+
+    RescoreDecision decision;
+    decision.recipe_name = recipe_label;
+    decision.scores.reserve(candidate_doc_ids.size());
+    for (auto id : candidate_doc_ids) {
+        auto it = doc_id_to_index_.find(id);
+        if (it == doc_id_to_index_.end()) {
+            decision.scores.push_back(0.0f);
+            continue;
+        }
+        const auto di = it->second;
+        const float score = std::isfinite(full[di]) ? full[di] : 0.0f;
+        decision.scores.push_back(score);
+    }
+    return decision;
+}
+
 } // namespace yams::search

--- a/src/vector/turboquant.cpp
+++ b/src/vector/turboquant.cpp
@@ -179,18 +179,9 @@ static void fwht(std::vector<float>& data) {
     }
 }
 
-// Pad vector to next power of 2
-static std::vector<float> padToPowerOf2(const std::vector<float>& data, size_t target_dim) {
-    size_t n = 1;
-    while (n < target_dim) {
-        n *= 2;
-    }
-    std::vector<float> padded(n, 0.0f);
-    for (size_t i = 0; i < target_dim; ++i) {
-        padded[i] = data[i];
-    }
-    return padded;
-}
+// `padToPowerOf2` (previously here) was unused — removed 2026-05-15 after
+// the fold SAST audit flagged it. The current encode/score paths size
+// vectors directly to `bits_per_channel` and never need power-of-2 padding.
 
 void TurboQuantMSE::generateCentroids() {
     const uint8_t bits = config_.bits_per_channel;

--- a/tests/benchmarks/search_bandit_bench.cpp
+++ b/tests/benchmarks/search_bandit_bench.cpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2025 YAMS Contributors
+//
+// Micro-benchmarks for simeon bandit overhead.
+// Measures: arm selection, reward recording, init, and dispatch latency.
+
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include <yams/search/search_engine_config.h>
+#include <yams/search/tuner_mab.h>
+
+using namespace yams::search;
+
+namespace {
+
+std::vector<TunerMAB::Arm> standardArms() {
+    std::vector<TunerMAB::Arm> arms;
+    arms.push_back({"sab_smooth", 0.0, {}});
+    arms.push_back({"sab_smooth_rm3_adaptive", 0.0, {}});
+    arms.push_back({"sab_smooth_rm3_diverse", 0.0, {}});
+    arms.push_back({"keyphrase", 0.0, {}});
+    arms.push_back({"lead_field", 0.0, {}});
+    return arms;
+}
+
+} // namespace
+
+TEST_CASE("Bench: bandit arm selection on warm bandit", "[.bench][search][bandit][bench]") {
+    TunerMAB mab;
+    mab.setArms(standardArms());
+
+    // Warm up: pull each arm once.
+    for (size_t i = 0; i < mab.arms().size(); ++i) {
+        auto idx = mab.selectArm();
+        mab.recordReward(*idx, 0.5, TunerMAB::RewardSource::Proxy);
+    }
+
+    BENCHMARK("selectArm warm") {
+        return mab.selectArm();
+    };
+}
+
+TEST_CASE("Bench: bandit reward recording", "[.bench][search][bandit][bench]") {
+    TunerMAB mab;
+    mab.setArms(standardArms());
+
+    // Ensure at least one arm has been pulled.
+    auto idx = mab.selectArm();
+    REQUIRE(idx.has_value());
+
+    BENCHMARK("recordReward") {
+        mab.recordReward(0, 0.5, TunerMAB::RewardSource::Proxy);
+    };
+}
+
+TEST_CASE("Bench: bandit init with 5 profiles × 5 arms", "[.bench][search][bandit][bench]") {
+    using ProfileKey = std::string;
+
+    BENCHMARK("init 5x5 bandits") {
+        std::unordered_map<ProfileKey, TunerMAB> bandits;
+        using CP = SearchEngineConfig::CorpusProfile;
+        for (auto profile : {CP::CODE, CP::PROSE, CP::DOCS, CP::MIXED, CP::CUSTOM}) {
+            bandits[SearchEngineConfig::corpusProfileToString(profile)].setArms(standardArms());
+        }
+        return bandits.size();
+    };
+}
+
+TEST_CASE("Bench: per-profile arm selection + reward", "[.bench][search][bandit][bench]") {
+    using ProfileKey = std::string;
+    std::unordered_map<ProfileKey, TunerMAB> bandits;
+    using CP = SearchEngineConfig::CorpusProfile;
+    for (auto profile : {CP::CODE, CP::PROSE, CP::DOCS, CP::MIXED, CP::CUSTOM}) {
+        bandits[SearchEngineConfig::corpusProfileToString(profile)].setArms(standardArms());
+    }
+
+    // Warm all bandits.
+    for (auto& [_, mab] : bandits) {
+        for (size_t i = 0; i < mab.arms().size(); ++i) {
+            auto idx = mab.selectArm();
+            mab.recordReward(*idx, 0.5, TunerMAB::RewardSource::Proxy);
+        }
+    }
+
+    BENCHMARK("select+record per-profile") {
+        std::string profileKey = "MIXED";
+        auto it = bandits.find(profileKey);
+        auto idx = it->second.selectArm();
+        if (idx.has_value()) {
+            it->second.recordReward(*idx, 0.5, TunerMAB::RewardSource::Proxy);
+        }
+        return idx.has_value();
+    };
+}
+
+TEST_CASE("Bench: corpusProfileToString lookup", "[.bench][search][bandit][bench]") {
+    BENCHMARK("corpusProfileToString") {
+        return SearchEngineConfig::corpusProfileToString(SearchEngineConfig::CorpusProfile::MIXED);
+    };
+}
+
+TEST_CASE("Bench: bandit UCB1 score computation (150 iterations)",
+          "[.bench][search][bandit][bench]") {
+    TunerMAB mab;
+    mab.setArms(standardArms());
+
+    // Warm up: 10 pulls per arm with varying rewards.
+    for (int round = 0; round < 10; ++round) {
+        for (size_t i = 0; i < mab.arms().size(); ++i) {
+            auto idx = mab.selectArm();
+            double reward = (i == 0) ? 0.9 : 0.5; // arm 0 is best
+            mab.recordReward(*idx, reward, TunerMAB::RewardSource::Proxy);
+        }
+    }
+
+    BENCHMARK("bestArmId after convergence") {
+        return mab.bestArmId();
+    };
+}

--- a/tests/benchmarks/search_bandit_bench.cpp
+++ b/tests/benchmarks/search_bandit_bench.cpp
@@ -9,6 +9,7 @@
 
 #include <chrono>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <yams/search/search_engine_config.h>

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1159,6 +1159,8 @@ if catch2_dep.found()
       'unit/search/lexical_scoring_catch2_test.cpp',
       'unit/search/simeon_lexical_backend_catch2_test.cpp',
       'unit/search/search_engine_simeon_lexical_catch2_test.cpp',
+      'unit/search/simeon_bandit_catch2_test.cpp',
+      'unit/search/simeon_bandit_backend_catch2_test.cpp',
       'unit/search/query_helpers_catch2_test.cpp',
       'unit/search/query_router_catch2_test.cpp',
       'unit/search/query_parser_catch2_test.cpp',
@@ -1223,6 +1225,15 @@ if catch2_dep.found()
 
   catch2_benchmark_history_store_exe = executable('catch2_benchmark_history_store',
     files('unit/search/benchmark_history_store_catch2_test.cpp'),
+    include_directories: incs,
+    dependencies: [catch2_dep, catch2_main_dep] + test_deps,
+    cpp_args: test_cpp_noerror_args + ['-DYAMS_TESTING=1'],
+    build_rpath: ':'.join(_test_rpaths),
+    install: false,
+  )
+
+  catch2_search_bandit_bench_exe = executable('catch2_search_bandit_bench',
+    files('benchmarks/search_bandit_bench.cpp'),
     include_directories: incs,
     dependencies: [catch2_dep, catch2_main_dep] + test_deps,
     cpp_args: test_cpp_noerror_args + ['-DYAMS_TESTING=1'],

--- a/tests/plugins/zyp/zyp_plugin_catch2_test.cpp
+++ b/tests/plugins/zyp/zyp_plugin_catch2_test.cpp
@@ -6,6 +6,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <yams/compat/dlfcn.h>
 
+#include <cstdio>
 #include <cstring>
 #include <map>
 #include <string>
@@ -121,6 +122,44 @@ startxref
 650
 %%EOF
 )";
+
+    return {pdf.begin(), pdf.end()};
+}
+
+std::vector<uint8_t> buildTwoPagePdf() {
+    std::string pdf = "%PDF-1.4\n";
+    std::vector<size_t> offsets;
+
+    auto addObject = [&](int number, const std::string& body) {
+        offsets.push_back(pdf.size());
+        pdf += std::to_string(number) + " 0 obj\n" + body + "\nendobj\n";
+    };
+
+    addObject(1, "<< /Type /Catalog /Pages 2 0 R >>");
+    addObject(2, "<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>");
+    addObject(3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+                 "/Contents 5 0 R /Resources << /Font << /F1 7 0 R >> >> >>");
+    addObject(4, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+                 "/Contents 6 0 R /Resources << /Font << /F1 7 0 R >> >> >>");
+
+    const std::string firstStream = "BT\n/F1 12 Tf\n100 700 Td\n(First Page Text) Tj\nET\n";
+    const std::string secondStream = "BT\n/F1 12 Tf\n100 700 Td\n(Second Page Text) Tj\nET\n";
+    addObject(5, "<< /Length " + std::to_string(firstStream.size()) + " >>\nstream\n" +
+                     firstStream + "endstream");
+    addObject(6, "<< /Length " + std::to_string(secondStream.size()) + " >>\nstream\n" +
+                     secondStream + "endstream");
+    addObject(7, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+
+    const size_t xrefOffset = pdf.size();
+    pdf += "xref\n0 " + std::to_string(offsets.size() + 1) + "\n";
+    pdf += "0000000000 65535 f \n";
+    for (size_t offset : offsets) {
+        char entry[24]{};
+        std::snprintf(entry, sizeof(entry), "%010zu 00000 n \n", offset);
+        pdf += entry;
+    }
+    pdf += "trailer\n<< /Size " + std::to_string(offsets.size() + 1) +
+           " /Root 1 0 R >>\nstartxref\n" + std::to_string(xrefOffset) + "\n%%EOF\n";
 
     return {pdf.begin(), pdf.end()};
 }
@@ -346,6 +385,29 @@ TEST_CASE_METHOD(ZypPluginTest, "ExtractPdfWithMetadata", "[plugin][zyp]") {
     }
 
     extractor_->free_result(result);
+}
+
+TEST_CASE_METHOD(ZypPluginTest, "ExtractMultiPagePdfRepeatedly", "[plugin][zyp][memory]") {
+    if (!pluginAvailable()) {
+        SKIP("zyp plugin not available");
+    }
+
+    auto pdf = buildTwoPagePdf();
+    for (int i = 0; i < 10; ++i) {
+        INFO("iteration=" << i);
+        yams_extraction_result_t* result = nullptr;
+        int rc = extractor_->extract(pdf.data(), pdf.size(), &result);
+
+        REQUIRE(rc == YAMS_PLUGIN_OK);
+        REQUIRE(result != nullptr);
+        REQUIRE(result->text != nullptr);
+
+        std::string text = result->text;
+        CHECK(text.find("First Page Text") != std::string::npos);
+        CHECK(text.find("Second Page Text") != std::string::npos);
+
+        extractor_->free_result(result);
+    }
 }
 
 // ============================================================================

--- a/tests/unit/search/simeon_bandit_backend_catch2_test.cpp
+++ b/tests/unit/search/simeon_bandit_backend_catch2_test.cpp
@@ -2,7 +2,8 @@
 // Copyright 2025 YAMS Contributors
 //
 // Unit tests for bandit-driven simeon backend dispatch (scoreBanditRouted).
-// Tests cover all 5 implemented arms with a real backend on a small corpus.
+// Tests cover the core SAB/RM3 arms plus fallback and not-ready behavior with
+// a real backend on a small corpus.
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/tests/unit/search/simeon_bandit_backend_catch2_test.cpp
+++ b/tests/unit/search/simeon_bandit_backend_catch2_test.cpp
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2025 YAMS Contributors
+//
+// Unit tests for bandit-driven simeon backend dispatch (scoreBanditRouted).
+// Tests cover all 5 implemented arms with a real backend on a small corpus.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <yams/metadata/metadata_repository.h>
+#include <yams/search/search_engine_config.h>
+#include <yams/search/simeon_lexical_backend.h>
+
+using namespace yams;
+using namespace yams::metadata;
+using namespace yams::search;
+
+namespace {
+
+std::filesystem::path tempDbPath(const char* prefix) {
+    const char* t = std::getenv("YAMS_TEST_TMPDIR");
+    auto base = (t && *t) ? std::filesystem::path(t) : std::filesystem::temp_directory_path();
+    std::error_code ec;
+    std::filesystem::create_directories(base, ec);
+    auto ts = std::chrono::steady_clock::now().time_since_epoch().count();
+    auto p = base / (std::string(prefix) + std::to_string(ts) + ".db");
+    std::filesystem::remove(p, ec);
+    return p;
+}
+
+struct TempCorpus {
+    std::filesystem::path dbPath;
+    std::unique_ptr<ConnectionPool> pool;
+    std::shared_ptr<MetadataRepository> repo;
+    std::vector<std::int64_t> docIds;
+};
+
+TempCorpus makeCorpus(const std::vector<std::pair<std::string, std::string>>& docs) {
+    TempCorpus corpus;
+    corpus.dbPath = tempDbPath("search_sbandit_");
+    ConnectionPoolConfig pcfg;
+    corpus.pool = std::make_unique<ConnectionPool>(corpus.dbPath.string(), pcfg);
+    REQUIRE(corpus.pool->initialize().has_value());
+    corpus.repo = std::make_shared<MetadataRepository>(*corpus.pool);
+
+    for (const auto& [hash, content] : docs) {
+        DocumentInfo d;
+        d.filePath = "/tmp/" + hash + ".txt";
+        d.fileName = hash + ".txt";
+        d.fileExtension = ".txt";
+        d.fileSize = static_cast<int64_t>(content.size());
+        d.sha256Hash = hash;
+        d.mimeType = "text/plain";
+        d.createdTime = std::chrono::floor<std::chrono::seconds>(std::chrono::system_clock::now());
+        d.modifiedTime = d.createdTime;
+        d.indexedTime = d.createdTime;
+        auto did = corpus.repo->insertDocument(d);
+        REQUIRE(did.has_value());
+        corpus.docIds.push_back(did.value());
+
+        REQUIRE(corpus.repo->indexDocumentContent(did.value(), hash, content, "text/plain")
+                    .has_value());
+
+        DocumentContent dc;
+        dc.documentId = did.value();
+        dc.contentText = content;
+        dc.contentLength = static_cast<int64_t>(content.size());
+        dc.extractionMethod = "test";
+        dc.language = "en";
+        REQUIRE(corpus.repo->insertContent(dc).has_value());
+    }
+    return corpus;
+}
+
+bool waitReady(const SimeonLexicalBackend& backend, std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (backend.ready())
+            return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    return backend.ready();
+}
+
+const std::vector<std::pair<std::string, std::string>> kCorpus = {
+    {"hash_a", "alpha beta gamma delta"}, {"hash_b", "beta gamma epsilon zeta"},
+    {"hash_c", "omega sigma tau"},        {"hash_d", "beta beta beta filler content filler"},
+    {"hash_e", "alpha sigma tau"},
+};
+
+std::vector<std::int64_t> fakeCandidateIds() {
+    return {1, 2, 3, 4, 5};
+}
+
+std::unique_ptr<SimeonLexicalBackend> buildBackend(const TempCorpus& corpus,
+                                                   SimeonLexicalBackend::Config cfg = {}) {
+    cfg.variant = SimeonLexicalBackend::Variant::SabSmooth;
+    auto backend = std::make_unique<SimeonLexicalBackend>(cfg);
+    auto result = backend->buildAsync(corpus.repo);
+    REQUIRE(result.has_value());
+    REQUIRE(waitReady(*backend, std::chrono::seconds(15)));
+    return backend;
+}
+
+} // namespace
+
+TEST_CASE("scoreBanditRouted: sab_smooth arm returns results",
+          "[search][simeon][bandit][backend][dispatch]") {
+    auto corpus = makeCorpus(kCorpus);
+    auto backend = buildBackend(corpus);
+
+    auto ids = fakeCandidateIds();
+    auto result = backend->scoreBanditRouted("beta", "sab_smooth", ids);
+    REQUIRE(result.has_value());
+    CHECK(std::string(result.value().recipe_name) == "Bm25SabSmooth");
+    CHECK(result.value().scores.size() == ids.size());
+}
+
+TEST_CASE("scoreBanditRouted: sab_smooth_rm3_adaptive arm returns results",
+          "[search][simeon][bandit][backend][dispatch]") {
+    auto corpus = makeCorpus(kCorpus);
+    auto backend = buildBackend(corpus);
+
+    auto ids = fakeCandidateIds();
+    auto result = backend->scoreBanditRouted("beta", "sab_smooth_rm3_adaptive", ids);
+    REQUIRE(result.has_value());
+    CHECK(std::string(result.value().recipe_name) == "Bm25SabRm3Adaptive");
+    CHECK(result.value().scores.size() == ids.size());
+}
+
+TEST_CASE("scoreBanditRouted: sab_smooth_rm3_diverse arm returns results",
+          "[search][simeon][bandit][backend][dispatch]") {
+    auto corpus = makeCorpus(kCorpus);
+    auto backend = buildBackend(corpus);
+
+    auto ids = fakeCandidateIds();
+    auto result = backend->scoreBanditRouted("beta", "sab_smooth_rm3_diverse", ids);
+    REQUIRE(result.has_value());
+    CHECK(std::string(result.value().recipe_name) == "Bm25SabRm3Diverse");
+    CHECK(result.value().scores.size() == ids.size());
+}
+
+TEST_CASE("scoreBanditRouted: unknown arm falls back to sab_smooth",
+          "[search][simeon][bandit][backend][dispatch]") {
+    auto corpus = makeCorpus(kCorpus);
+    auto backend = buildBackend(corpus);
+
+    auto ids = fakeCandidateIds();
+    auto result = backend->scoreBanditRouted("beta", "bogus_arm_name", ids);
+    REQUIRE(result.has_value());
+    CHECK(std::string(result.value().recipe_name) == "Bm25SabSmooth");
+    CHECK(result.value().scores.size() == ids.size());
+}
+
+TEST_CASE("scoreBanditRouted: different arms produce different recipe labels",
+          "[search][simeon][bandit][backend][dispatch]") {
+    auto corpus = makeCorpus(kCorpus);
+    auto backend = buildBackend(corpus);
+
+    auto ids = fakeCandidateIds();
+
+    auto r1 = backend->scoreBanditRouted("beta", "sab_smooth", ids);
+    auto r2 = backend->scoreBanditRouted("beta", "sab_smooth_rm3_adaptive", ids);
+    auto r3 = backend->scoreBanditRouted("beta", "sab_smooth_rm3_diverse", ids);
+
+    REQUIRE(r1.has_value());
+    REQUIRE(r2.has_value());
+    REQUIRE(r3.has_value());
+
+    CHECK(std::string(r1.value().recipe_name) != std::string(r2.value().recipe_name));
+    CHECK(std::string(r1.value().recipe_name) != std::string(r3.value().recipe_name));
+    CHECK(std::string(r2.value().recipe_name) != std::string(r3.value().recipe_name));
+}
+
+TEST_CASE("scoreBanditRouted: returns zero for unknown candidate ids",
+          "[search][simeon][bandit][backend][dispatch]") {
+    auto corpus = makeCorpus(kCorpus);
+    auto backend = buildBackend(corpus);
+
+    // Send IDs that don't exist in the backend.
+    std::vector<std::int64_t> badIds = {99999, 88888};
+    auto result = backend->scoreBanditRouted("beta", "sab_smooth", badIds);
+    REQUIRE(result.has_value());
+    CHECK(result.value().scores.size() == badIds.size());
+    for (auto s : result.value().scores) {
+        CHECK(s == 0.0f);
+    }
+}
+
+TEST_CASE("scoreBanditRouted: not ready backend returns error",
+          "[search][simeon][bandit][backend][dispatch]") {
+    SimeonLexicalBackend::Config cfg;
+    auto backend = std::make_unique<SimeonLexicalBackend>(cfg);
+    // Don't build — backend is not ready.
+
+    auto ids = fakeCandidateIds();
+    auto result = backend->scoreBanditRouted("beta", "sab_smooth", ids);
+    CHECK_FALSE(result.has_value());
+}
+
+TEST_CASE("SearchEngineConfig: bandit arm flag absent uses existing routing",
+          "[search][simeon][bandit][config]") {
+    SearchEngineConfig cfg;
+    CHECK(cfg.simeonBanditArm.empty());
+
+    // When empty, the lexical pipeline should use scoreRouted or scoreStrategyRouted.
+    cfg.simeonBanditArm = "";
+    CHECK(cfg.simeonBanditArm.empty());
+}
+
+TEST_CASE("SearchEngineConfig: bandit arm set triggers scoreBanditRouted path",
+          "[search][simeon][bandit][config]") {
+    SearchEngineConfig cfg;
+    cfg.simeonBanditArm = "sab_smooth_rm3_adaptive";
+    CHECK_FALSE(cfg.simeonBanditArm.empty());
+    CHECK(cfg.simeonBanditArm == "sab_smooth_rm3_adaptive");
+}

--- a/tests/unit/search/simeon_bandit_catch2_test.cpp
+++ b/tests/unit/search/simeon_bandit_catch2_test.cpp
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2025 YAMS Contributors
+//
+// Unit tests for per-profile simeon bandit (TunerMAB integration + config).
+// Tests cover:
+//   - CorpusProfile string conversion
+//   - Bandit initialization (arms per profile, correct arm names)
+//   - Arm selection (UCB1 returns valid indices, MIXED fallback)
+//   - Reward recording (pull count + reward sum updates)
+//   - Per-request state clearing (arm, profile fields reset)
+//   - Both exploration and exploitation phases
+//   - Bandit state serialization round-trip
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <yams/search/search_engine_config.h>
+#include <yams/search/tuner_mab.h>
+
+using namespace yams::search;
+
+TEST_CASE("corpusProfileToString: all profiles map correctly", "[unit][search][bandit][config]") {
+    using CP = SearchEngineConfig::CorpusProfile;
+    CHECK(std::string(SearchEngineConfig::corpusProfileToString(CP::CODE)) == "CODE");
+    CHECK(std::string(SearchEngineConfig::corpusProfileToString(CP::PROSE)) == "PROSE");
+    CHECK(std::string(SearchEngineConfig::corpusProfileToString(CP::DOCS)) == "DOCS");
+    CHECK(std::string(SearchEngineConfig::corpusProfileToString(CP::MIXED)) == "MIXED");
+    CHECK(std::string(SearchEngineConfig::corpusProfileToString(CP::CUSTOM)) == "CUSTOM");
+}
+
+TEST_CASE("TunerMAB: setArms creates correct arm set", "[unit][search][bandit]") {
+    TunerMAB mab;
+
+    std::vector<TunerMAB::Arm> arms;
+    arms.push_back({"sab_smooth", 0.0, {}});
+    arms.push_back({"sab_smooth_rm3_adaptive", 0.0, {}});
+    arms.push_back({"sab_smooth_rm3_diverse", 0.0, {}});
+    mab.setArms(std::move(arms));
+
+    CHECK(mab.arms().size() == 3);
+    CHECK(mab.arms()[0].id == "sab_smooth");
+    CHECK(mab.arms()[1].id == "sab_smooth_rm3_adaptive");
+    CHECK(mab.arms()[2].id == "sab_smooth_rm3_diverse");
+    CHECK(mab.totalPulls() == 0);
+}
+
+TEST_CASE("TunerMAB: selectArm returns valid index", "[unit][search][bandit]") {
+    TunerMAB mab;
+    std::vector<TunerMAB::Arm> arms;
+    arms.push_back({"arm_a", 0.0, {}});
+    arms.push_back({"arm_b", 0.0, {}});
+    mab.setArms(std::move(arms));
+
+    auto idx = mab.selectArm();
+    REQUIRE(idx.has_value());
+    CHECK(*idx < mab.arms().size());
+}
+
+TEST_CASE("TunerMAB: selectArm explores all arms at least once", "[unit][search][bandit]") {
+    TunerMAB mab;
+    std::vector<TunerMAB::Arm> arms;
+    for (int i = 0; i < 5; ++i) {
+        arms.push_back({"arm_" + std::to_string(i), 0.0, {}});
+    }
+    mab.setArms(std::move(arms));
+
+    // After 5 selects, every arm should have been pulled at least once.
+    for (int i = 0; i < 5; ++i) {
+        auto idx = mab.selectArm();
+        REQUIRE(idx.has_value());
+        mab.recordReward(*idx, 0.5, TunerMAB::RewardSource::Proxy);
+    }
+
+    for (const auto& a : mab.arms()) {
+        CHECK(a.stats.pulls >= 1);
+    }
+}
+
+TEST_CASE("TunerMAB: recordReward updates arm stats", "[unit][search][bandit]") {
+    TunerMAB mab;
+    std::vector<TunerMAB::Arm> arms;
+    arms.push_back({"test_arm", 0.0, {}});
+    mab.setArms(std::move(arms));
+
+    auto idx = mab.selectArm();
+    REQUIRE(idx.has_value());
+    CHECK(*idx == 0);
+
+    mab.recordReward(0, 0.75, TunerMAB::RewardSource::Proxy);
+    CHECK(mab.arms()[0].stats.pulls == 1);
+    // Reward clamped to [0, 1]; 0.75 should pass through.
+    CHECK(mab.arms()[0].stats.rewardSum > 0.0);
+    CHECK(mab.totalPulls() == 1);
+}
+
+TEST_CASE("TunerMAB: bestArmId identifies highest-mean arm", "[unit][search][bandit]") {
+    TunerMAB mab;
+    std::vector<TunerMAB::Arm> arms;
+    arms.push_back({"low", 0.0, {}});
+    arms.push_back({"high", 0.0, {}});
+    mab.setArms(std::move(arms));
+
+    // Pull both arms once each.
+    for (int i = 0; i < 2; ++i) {
+        auto idx = mab.selectArm();
+        REQUIRE(idx.has_value());
+        double reward = (*idx == 0) ? 0.3 : 0.9;
+        mab.recordReward(*idx, reward, TunerMAB::RewardSource::Proxy);
+    }
+
+    auto best = mab.bestArmId();
+    REQUIRE(best.has_value());
+    CHECK(*best == "high");
+}
+
+TEST_CASE("TunerMAB: selectArm returns nullopt for empty arm set", "[unit][search][bandit]") {
+    TunerMAB mab;
+    auto idx = mab.selectArm();
+    CHECK_FALSE(idx.has_value());
+}
+
+TEST_CASE("TunerMAB: reward clamping to [0, 1]", "[unit][search][bandit]") {
+    TunerMAB mab;
+    std::vector<TunerMAB::Arm> arms;
+    arms.push_back({"a", 0.0, {}});
+    mab.setArms(std::move(arms));
+
+    mab.recordReward(0, 1.5, TunerMAB::RewardSource::Proxy);  // should clamp to 1.0
+    mab.recordReward(0, -0.5, TunerMAB::RewardSource::Proxy); // should clamp to 0.0
+
+    // Two pulls, sum should be 1.0 (clamped from 1.5 + 0.0).
+    CHECK(mab.arms()[0].stats.pulls == 2);
+    CHECK(mab.arms()[0].stats.rewardSum <= 1.01); // ~1.0
+}
+
+TEST_CASE("TunerMAB: serialization round-trip preserves arm state", "[unit][search][bandit]") {
+    TunerMAB mab;
+    std::vector<TunerMAB::Arm> arms;
+    arms.push_back({"keep", 0.0, {}});
+    arms.push_back({"drop", 0.0, {}});
+    mab.setArms(std::move(arms));
+
+    auto idx = mab.selectArm();
+    REQUIRE(idx.has_value());
+    mab.recordReward(*idx, 0.8, TunerMAB::RewardSource::Proxy);
+
+    auto json = mab.toJson();
+    REQUIRE(json.is_object());
+    CHECK(json.contains("arms"));
+    CHECK(json["arms"].is_array());
+    CHECK(json["arms"].size() == 2);
+
+    // Restore into a fresh bandit.
+    TunerMAB restored;
+    std::vector<TunerMAB::Arm> newArms;
+    newArms.push_back({"keep", 0.0, {}});
+    newArms.push_back({"drop", 0.0, {}});
+    restored.setArms(std::move(newArms));
+    auto result = restored.fromJson(json);
+    CHECK(result.has_value());
+
+    CHECK(restored.arms().size() == 2);
+    CHECK(restored.totalPulls() == 1);
+}
+
+TEST_CASE("TunerMAB: fromJson with mismatched schema resets cleanly", "[unit][search][bandit]") {
+    TunerMAB mab;
+    std::vector<TunerMAB::Arm> arms;
+    arms.push_back({"a", 0.0, {}});
+    mab.setArms(std::move(arms));
+
+    auto idx = mab.selectArm();
+    mab.recordReward(*idx, 0.5, TunerMAB::RewardSource::Proxy);
+
+    nlohmann::json bad;
+    bad["schema_version"] = 999;
+    bad["arms"] = nlohmann::json::array();
+
+    auto result = mab.fromJson(bad);
+    // Schema mismatch returns error but bandit keeps runtime state.
+    CHECK_FALSE(result.has_value());
+    CHECK(mab.totalPulls() == 1); // unchanged — runtime state preserved
+}
+
+TEST_CASE("per-profile bandits: each profile gets independent arms",
+          "[unit][search][bandit][profile]") {
+    using ProfileKey = std::string;
+    std::unordered_map<ProfileKey, TunerMAB> bandits;
+
+    std::vector<TunerMAB::Arm> arms;
+    arms.push_back({"sab_smooth", 0.0, {}});
+    arms.push_back({"sab_smooth_rm3_adaptive", 0.0, {}});
+
+    using CP = SearchEngineConfig::CorpusProfile;
+    for (auto profile : {CP::CODE, CP::PROSE, CP::DOCS, CP::MIXED, CP::CUSTOM}) {
+        bandits[SearchEngineConfig::corpusProfileToString(profile)].setArms(arms);
+    }
+
+    CHECK(bandits.size() == 5);
+    for (const auto& [key, mab] : bandits) {
+        CHECK(mab.arms().size() == 2);
+    }
+
+    // Pull arms differently on CODE vs MIXED profiles.
+    auto codeIdx = bandits["CODE"].selectArm();
+    REQUIRE(codeIdx.has_value());
+    bandits["CODE"].recordReward(*codeIdx, 0.8, TunerMAB::RewardSource::Proxy);
+    CHECK(bandits["CODE"].totalPulls() == 1);
+    // MIXED profile should be independent.
+    CHECK(bandits["MIXED"].totalPulls() == 0);
+}
+
+TEST_CASE("per-profile bandits: MIXED fallback for unknown profile",
+          "[unit][search][bandit][profile]") {
+    using ProfileKey = std::string;
+    std::unordered_map<ProfileKey, TunerMAB> bandits;
+
+    std::vector<TunerMAB::Arm> arms;
+    arms.push_back({"arm", 0.0, {}});
+    bandits["MIXED"].setArms(arms);
+
+    // Look up a non-existent profile, fall back to MIXED.
+    auto it = bandits.find("NONEXISTENT");
+    if (it == bandits.end()) {
+        it = bandits.find("MIXED");
+    }
+    REQUIRE(it != bandits.end());
+    CHECK(it->second.arms().size() == 1);
+}
+
+TEST_CASE("SearchEngineConfig: simeonBanditArm default empty", "[unit][search][bandit][config]") {
+    SearchEngineConfig cfg;
+    CHECK(cfg.simeonBanditArm.empty());
+}
+
+TEST_CASE("SearchEngineConfig: simeonBanditArm set and read", "[unit][search][bandit][config]") {
+    SearchEngineConfig cfg;
+    cfg.simeonBanditArm = "sab_smooth_rm3_adaptive";
+    CHECK(cfg.simeonBanditArm == "sab_smooth_rm3_adaptive");
+    CHECK_FALSE(cfg.simeonBanditArm.empty());
+}


### PR DESCRIPTION
## Summary
- add training-free per-profile Simeon lexical backend bandit tuning
- fix zyp parallel extraction buffer ownership and add a multi-page regression test
- include cleanup plus Simeon version bump from experimental

## Verification
- `meson compile -C build/debug -j4 yams_zyp`
- `meson compile -C build/debug -j4 yams_zyp_tests`
- `meson test -C build/debug zyp_plugin`
- `meson compile -C build/debug -j4 yams-daemon`
- `meson compile -C build/debug -j4 catch2_search_submodule`
- `meson test -C build/debug search_submodule`