### PR TITLE
fix(daemon): resolve Windows-only PostIngestQueue shutdown SIGSEGV

### DIFF
--- a/src/daemon/components/PostIngestQueue.cpp
+++ b/src/daemon/components/PostIngestQueue.cpp
@@ -429,7 +429,15 @@ void PostIngestQueue::signalWakeTimer(Stage stage) {
         }
     }
     if (timer) {
-        boost::asio::post(timer->get_executor(),
+        // NB: read the executor into a local BEFORE moving `timer` into the
+        // handler. Function-argument evaluation order is unspecified in C++,
+        // and MSVC evaluates the lambda capture (which moves `timer` to null)
+        // before `timer->get_executor()`, dereferencing a moved-from shared_ptr
+        // -> read from null+offset -> access violation. Left-to-right compilers
+        // (GCC/Clang on Linux) happened to evaluate get_executor() first, which
+        // is why this crash was Windows-only.
+        auto executor = timer->get_executor();
+        boost::asio::post(executor,
                           [timer = std::move(timer)]() mutable { (void)timer->cancel(); });
     }
 }


### PR DESCRIPTION
Fixes the Windows-only `Tests (windows-x86_64)` SIGSEGV cluster (integration_smoke, daemon_metrics_status, repair_service, daemon_background_processing, service_manager, cli_submodule), all crashing `0xC0000005` during teardown.

**Root cause:** `PostIngestQueue::signalWakeTimer` did
`boost::asio::post(timer->get_executor(), [timer = std::move(timer)]...)`. C++ leaves argument evaluation order unspecified; MSVC evaluates the `std::move(timer)` capture first, so `timer` is null when `timer->get_executor()` runs -> read from null+0x60 -> access violation. GCC/Clang evaluate left-to-right, which is why this was Windows-only (ASAN-green, UBSAN-skipped). Hit from `PostIngestQueue::stop()`/dtor during `ServiceManager` shutdown.

**Fix:** read the executor into a local before moving `timer` into the handler.

Root-caused against a local x86_64 (emulated) debug build with a custom debug-event stack walker; confirmed faulting frame `PostIngestQueue.cpp:432` reading null+0x60, then re-verified the previously-crashing tests pass.
