### PR TITLE
perf(metadata): profile write-path batching

### DIFF
--- a/include/yams/core/assert.hpp
+++ b/include/yams/core/assert.hpp
@@ -2,23 +2,32 @@
 
 #include <cstdio>
 #include <cstdlib>
-#include <source_location>
 #include <string_view>
-
-#if defined(__has_include)
-#if __has_include(<stacktrace>)
-#include <stacktrace>
-#if defined(__cpp_lib_stacktrace) && __cpp_lib_stacktrace >= 202011L
-#define YAMS_CORE_HAS_STACKTRACE 1
-#endif
-#endif
-#endif
 
 #ifndef YAMS_CORE_HAS_STACKTRACE
 #define YAMS_CORE_HAS_STACKTRACE 0
 #endif
 
+#if YAMS_CORE_HAS_STACKTRACE
+#include <stacktrace>
+#endif
+
 namespace yams::core::detail {
+
+struct SourceLocation {
+    const char* fileName{"(unknown)"};
+    unsigned lineNumber{0};
+    const char* functionName{"(unknown)"};
+
+    [[nodiscard]] static constexpr SourceLocation current(
+        const char* file = "(unknown)", unsigned line = 0,
+        const char* function = "(unknown)") noexcept {
+        return SourceLocation{file, line, function};
+    }
+};
+
+#define YAMS_SOURCE_LOCATION_CURRENT()                                                            \
+    ::yams::core::detail::SourceLocation::current(__FILE__, __LINE__, __func__)
 
 enum class AssertionKind {
     Assert,
@@ -74,12 +83,12 @@ inline void printStacktrace() noexcept {
 #endif
 }
 
-[[noreturn]] inline void
-reportAssertionFailure(AssertionKind kind, const char* expression, std::string_view message,
-                       std::source_location location = std::source_location::current()) noexcept {
+[[noreturn]] inline void reportAssertionFailure(
+    AssertionKind kind, const char* expression, std::string_view message,
+    SourceLocation location = SourceLocation::current()) noexcept {
     std::fprintf(stderr, "[YAMS] %s failed\n", assertionKindName(kind));
-    std::fprintf(stderr, "  file: %s:%u\n", location.file_name(), location.line());
-    std::fprintf(stderr, "  function: %s\n", location.function_name());
+    std::fprintf(stderr, "  file: %s:%u\n", location.fileName, location.lineNumber);
+    std::fprintf(stderr, "  function: %s\n", location.functionName);
     if (expression != nullptr && expression[0] != '\0') {
         std::fprintf(stderr, "  expression: %s\n", expression);
     }
@@ -98,7 +107,7 @@ reportAssertionFailure(AssertionKind kind, const char* expression, std::string_v
         if (!(condition)) [[unlikely]] {                                                           \
             ::yams::core::detail::reportAssertionFailure(                                          \
                 ::yams::core::detail::AssertionKind::Assert, #condition, (message),                \
-                std::source_location::current());                                                  \
+                YAMS_SOURCE_LOCATION_CURRENT());                                                   \
         }                                                                                          \
     } while (false)
 
@@ -107,7 +116,7 @@ reportAssertionFailure(AssertionKind kind, const char* expression, std::string_v
         if (!(condition)) [[unlikely]] {                                                           \
             ::yams::core::detail::reportAssertionFailure(                                          \
                 ::yams::core::detail::AssertionKind::Precondition, #condition, (message),          \
-                std::source_location::current());                                                  \
+                YAMS_SOURCE_LOCATION_CURRENT());                                                   \
         }                                                                                          \
     } while (false)
 
@@ -116,7 +125,7 @@ reportAssertionFailure(AssertionKind kind, const char* expression, std::string_v
         if (!(condition)) [[unlikely]] {                                                           \
             ::yams::core::detail::reportAssertionFailure(                                          \
                 ::yams::core::detail::AssertionKind::Postcondition, #condition, (message),         \
-                std::source_location::current());                                                  \
+                YAMS_SOURCE_LOCATION_CURRENT());                                                   \
         }                                                                                          \
     } while (false)
 
@@ -128,7 +137,7 @@ reportAssertionFailure(AssertionKind kind, const char* expression, std::string_v
         if (!(condition)) [[unlikely]] {                                                           \
             ::yams::core::detail::reportAssertionFailure(                                          \
                 ::yams::core::detail::AssertionKind::DebugCheck, #condition, (message),            \
-                std::source_location::current());                                                  \
+                YAMS_SOURCE_LOCATION_CURRENT());                                                   \
         }                                                                                          \
     } while (false)
 #else
@@ -139,5 +148,5 @@ reportAssertionFailure(AssertionKind kind, const char* expression, std::string_v
     do {                                                                                           \
         ::yams::core::detail::reportAssertionFailure(                                              \
             ::yams::core::detail::AssertionKind::Unreachable, nullptr, (message),                  \
-            std::source_location::current());                                                      \
+            YAMS_SOURCE_LOCATION_CURRENT());                                                       \
     } while (false)

--- a/include/yams/daemon/components/WriteCoordinator.h
+++ b/include/yams/daemon/components/WriteCoordinator.h
@@ -210,6 +210,7 @@ public:
         std::size_t maxBatchSize = 50;
         std::chrono::milliseconds maxBatchDelayMs{100};
         std::size_t channelCapacity = 1000;
+        std::size_t maxCoalescedOpsPerApply = 512;
     };
 
     struct Stats {

--- a/include/yams/daemon/components/WriteCoordinator.h
+++ b/include/yams/daemon/components/WriteCoordinator.h
@@ -272,6 +272,9 @@ public:
 
     void start();
     void shutdown();
+    [[nodiscard]] bool isShuttingDown() const noexcept {
+        return stop_.load(std::memory_order_acquire);
+    }
 
     std::size_t queuedBatches() const;
     std::size_t inFlight() const { return inFlight_.load(); }

--- a/include/yams/metadata/metadata_repository.h
+++ b/include/yams/metadata/metadata_repository.h
@@ -350,6 +350,20 @@ public:
             addSymSpellTerm(term);
         }
     }
+    virtual void addSymSpellTerms(const std::vector<std::pair<std::string, int64_t>>& terms) {
+        for (const auto& [term, frequency] : terms) {
+            addSymSpellTerm(term, frequency);
+        }
+    }
+    virtual Result<void> tryAddSymSpellTerms(const std::vector<std::string>& terms) {
+        addSymSpellTerms(terms);
+        return Result<void>();
+    }
+    virtual Result<void>
+    tryAddSymSpellTerms(const std::vector<std::pair<std::string, int64_t>>& terms) {
+        addSymSpellTerms(terms);
+        return Result<void>();
+    }
 
     // Bulk operations
     virtual Result<std::optional<DocumentInfo>>
@@ -635,6 +649,10 @@ public:
      */
     void addSymSpellTerm(std::string_view term, int64_t frequency = 1) override;
     void addSymSpellTerms(const std::vector<std::string>& terms) override;
+    void addSymSpellTerms(const std::vector<std::pair<std::string, int64_t>>& terms) override;
+    Result<void> tryAddSymSpellTerms(const std::vector<std::string>& terms) override;
+    Result<void>
+    tryAddSymSpellTerms(const std::vector<std::pair<std::string, int64_t>>& terms) override;
 
     /**
      * @brief Initialize SymSpell index (creates schema if needed)
@@ -912,6 +930,7 @@ private:
     mutable std::unique_ptr<Database> symspellDb_;
     mutable std::unique_ptr<search::SymSpellSearch> symspellIndex_;
     mutable std::atomic<bool> symspellInitialized_{false};
+    mutable std::atomic<bool> symspellSchemaReady_{false};
 
     struct PathCacheEntry {
         std::string path;

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,25 @@ if host_machine.system() == 'darwin'
   add_global_link_arguments('-Wl,-no_warn_duplicate_libraries', language: 'cpp')
 endif
 
+# std::stacktrace is optional diagnostic sugar for assertion failures. Some
+# libstdc++ releases expose the header/feature macro but keep the implementation
+# in an extra experimental library; that compiles but fails final executable
+# links. Probe compile+link, not just header availability.
+_stacktrace_probe = '''
+#include <stacktrace>
+int main() {
+  auto trace = std::stacktrace::current();
+  return static_cast<int>(trace.size());
+}
+'''
+if cpp.links(_stacktrace_probe, name: 'std::stacktrace compile+link')
+  add_project_arguments('-DYAMS_CORE_HAS_STACKTRACE=1', language: 'cpp')
+  message('std::stacktrace diagnostics enabled')
+else
+  add_project_arguments('-DYAMS_CORE_HAS_STACKTRACE=0', language: 'cpp')
+  message('std::stacktrace diagnostics disabled: stacktrace did not link')
+endif
+
 if host_machine.system() == 'windows'
   add_project_arguments('-D_WIN32_WINNT=0x0A00', language: 'cpp')
   add_project_arguments('-D_CRT_SECURE_NO_WARNINGS', language: 'cpp')

--- a/scripts/analyze_complexity.py
+++ b/scripts/analyze_complexity.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+DEFAULT_EXTENSIONS = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".m",
+    ".mm",
+    ".py",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".java",
+    ".go",
+    ".rs",
+    ".swift",
+    ".rb",
+    ".php",
+    ".cs",
+    ".kt",
+    ".kts",
+    ".scala",
+    ".sh",
+    ".bash",
+}
+
+DEFAULT_EXCLUDES = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".ccls-cache",
+    ".direnv",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "venv",
+    "node_modules",
+    "dist",
+    "vendor",
+    "third_party",
+    "external",
+    "site",
+    "subprojects",
+    "infer-out",
+    "build",
+    "builddir",
+    "build-debug",
+    "build-release",
+    "cmake-build-debug",
+    "cmake-build-release",
+}
+
+LINE_COMMENT_PREFIXES = {
+    ".c": "//",
+    ".cc": "//",
+    ".cpp": "//",
+    ".cxx": "//",
+    ".h": "//",
+    ".hh": "//",
+    ".hpp": "//",
+    ".hxx": "//",
+    ".m": "//",
+    ".mm": "//",
+    ".js": "//",
+    ".jsx": "//",
+    ".ts": "//",
+    ".tsx": "//",
+    ".java": "//",
+    ".go": "//",
+    ".rs": "//",
+    ".swift": "//",
+    ".cs": "//",
+    ".kt": "//",
+    ".kts": "//",
+    ".scala": "//",
+    ".php": "//",
+    ".py": "#",
+    ".rb": "#",
+    ".sh": "#",
+    ".bash": "#",
+}
+
+BLOCK_COMMENT_STYLES = {
+    ".c": ("/*", "*/"),
+    ".cc": ("/*", "*/"),
+    ".cpp": ("/*", "*/"),
+    ".cxx": ("/*", "*/"),
+    ".h": ("/*", "*/"),
+    ".hh": ("/*", "*/"),
+    ".hpp": ("/*", "*/"),
+    ".hxx": ("/*", "*/"),
+    ".m": ("/*", "*/"),
+    ".mm": ("/*", "*/"),
+    ".js": ("/*", "*/"),
+    ".jsx": ("/*", "*/"),
+    ".ts": ("/*", "*/"),
+    ".tsx": ("/*", "*/"),
+    ".java": ("/*", "*/"),
+    ".go": ("/*", "*/"),
+    ".rs": ("/*", "*/"),
+    ".swift": ("/*", "*/"),
+    ".cs": ("/*", "*/"),
+    ".kt": ("/*", "*/"),
+    ".kts": ("/*", "*/"),
+    ".scala": ("/*", "*/"),
+    ".php": ("/*", "*/"),
+}
+
+LANGUAGE_NAMES = {
+    ".c": "C",
+    ".cc": "C++",
+    ".cpp": "C++",
+    ".cxx": "C++",
+    ".h": "C/C++ Header",
+    ".hh": "C++ Header",
+    ".hpp": "C++ Header",
+    ".hxx": "C++ Header",
+    ".m": "Objective-C",
+    ".mm": "Objective-C++",
+    ".py": "Python",
+    ".js": "JavaScript",
+    ".jsx": "JSX",
+    ".ts": "TypeScript",
+    ".tsx": "TSX",
+    ".java": "Java",
+    ".go": "Go",
+    ".rs": "Rust",
+    ".swift": "Swift",
+    ".rb": "Ruby",
+    ".php": "PHP",
+    ".cs": "C#",
+    ".kt": "Kotlin",
+    ".kts": "Kotlin",
+    ".scala": "Scala",
+    ".sh": "Shell",
+    ".bash": "Shell",
+}
+
+
+@dataclass
+class FileMetric:
+    path: str
+    language: str
+    lines: int
+    code_lines: int
+    comment_lines: int
+    blank_lines: int
+
+
+@dataclass
+class DirectoryMetric:
+    path: str
+    files: int
+    lines: int
+    code_lines: int
+
+
+@dataclass
+class Summary:
+    root: str
+    files_analyzed: int
+    total_lines: int
+    total_code_lines: int
+    total_comment_lines: int
+    total_blank_lines: int
+    top_files: list[FileMetric]
+    top_directories: list[DirectoryMetric]
+
+
+def should_skip(path: Path, excluded_names: set[str]) -> bool:
+    for part in path.parts:
+        if part in excluded_names:
+            return True
+        if part.startswith(("build", "cmake-build")):
+            return True
+    return False
+
+
+def iter_source_files(
+    root: Path, extensions: set[str], excluded_names: set[str]
+) -> Iterable[Path]:
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if should_skip(path.relative_to(root), excluded_names):
+            continue
+        if path.suffix.lower() in extensions:
+            yield path
+
+
+def classify_language(path: Path) -> str:
+    return LANGUAGE_NAMES.get(
+        path.suffix.lower(), path.suffix.lower().lstrip(".") or "unknown"
+    )
+
+
+def count_lines(path: Path) -> FileMetric:
+    suffix = path.suffix.lower()
+    line_comment = LINE_COMMENT_PREFIXES.get(suffix)
+    block_comment = BLOCK_COMMENT_STYLES.get(suffix)
+    block_start, block_end = block_comment if block_comment else (None, None)
+
+    total = 0
+    code = 0
+    comment = 0
+    blank = 0
+    in_block_comment = False
+
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for raw_line in handle:
+            total += 1
+            stripped = raw_line.strip()
+            if not stripped:
+                blank += 1
+                continue
+
+            if in_block_comment:
+                comment += 1
+                if block_end and block_end in stripped:
+                    in_block_comment = False
+                continue
+
+            if line_comment and stripped.startswith(line_comment):
+                comment += 1
+                continue
+
+            if block_start and stripped.startswith(block_start):
+                comment += 1
+                if block_end and block_end not in stripped:
+                    in_block_comment = True
+                continue
+
+            code += 1
+
+    return FileMetric(
+        path=str(path),
+        language=classify_language(path),
+        lines=total,
+        code_lines=code,
+        comment_lines=comment,
+        blank_lines=blank,
+    )
+
+
+def aggregate_directories(
+    root: Path, metrics: list[FileMetric], limit: int
+) -> list[DirectoryMetric]:
+    buckets: dict[str, DirectoryMetric] = {}
+    for metric in metrics:
+        rel = Path(metric.path).relative_to(root)
+        key = str(rel.parent)
+        bucket = buckets.get(key)
+        if bucket is None:
+            bucket = DirectoryMetric(path=key, files=0, lines=0, code_lines=0)
+            buckets[key] = bucket
+        bucket.files += 1
+        bucket.lines += metric.lines
+        bucket.code_lines += metric.code_lines
+
+    return sorted(
+        buckets.values(),
+        key=lambda item: (item.code_lines, item.lines, item.files, item.path),
+        reverse=True,
+    )[:limit]
+
+
+def build_summary(root: Path, metrics: list[FileMetric], limit: int) -> Summary:
+    top_files = sorted(
+        metrics,
+        key=lambda item: (item.code_lines, item.lines, item.path),
+        reverse=True,
+    )[:limit]
+    return Summary(
+        root=str(root),
+        files_analyzed=len(metrics),
+        total_lines=sum(item.lines for item in metrics),
+        total_code_lines=sum(item.code_lines for item in metrics),
+        total_comment_lines=sum(item.comment_lines for item in metrics),
+        total_blank_lines=sum(item.blank_lines for item in metrics),
+        top_files=top_files,
+        top_directories=aggregate_directories(root, metrics, limit),
+    )
+
+
+def render_markdown(summary: Summary) -> str:
+    lines = [
+        "# Complexity Hotspots",
+        "",
+        f"- Root: `{summary.root}`",
+        f"- Files analyzed: `{summary.files_analyzed}`",
+        f"- Total lines: `{summary.total_lines}`",
+        f"- Code lines: `{summary.total_code_lines}`",
+        f"- Comment lines: `{summary.total_comment_lines}`",
+        f"- Blank lines: `{summary.total_blank_lines}`",
+        "",
+        "## Top files by code lines",
+        "",
+        "| Rank | Code LOC | Total LOC | Language | File |",
+        "| --- | ---: | ---: | --- | --- |",
+    ]
+    for index, metric in enumerate(summary.top_files, start=1):
+        rel = Path(metric.path).relative_to(summary.root)
+        lines.append(
+            f"| {index} | {metric.code_lines} | {metric.lines} | {metric.language} | `{rel}` |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Top directories by code lines",
+            "",
+            "| Rank | Code LOC | Total LOC | Files | Directory |",
+            "| --- | ---: | ---: | ---: | --- |",
+        ]
+    )
+    for index, metric in enumerate(summary.top_directories, start=1):
+        lines.append(
+            f"| {index} | {metric.code_lines} | {metric.lines} | {metric.files} | `{metric.path}` |"
+        )
+    return "\n".join(lines)
+
+
+def render_text(summary: Summary) -> str:
+    lines = [
+        f"root: {summary.root}",
+        f"files_analyzed: {summary.files_analyzed}",
+        f"total_lines: {summary.total_lines}",
+        f"total_code_lines: {summary.total_code_lines}",
+        "top_files:",
+    ]
+    for metric in summary.top_files:
+        rel = Path(metric.path).relative_to(summary.root)
+        lines.append(f"  {metric.code_lines:>6} code / {metric.lines:>6} total  {rel}")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Simple first-pass complexity hotspot scanner"
+    )
+    parser.add_argument("root", nargs="?", default=".", help="Repository root to scan")
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json", "text"),
+        default="text",
+        help="Output format",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=20, help="Rows to show for top files/dirs"
+    )
+    parser.add_argument(
+        "--exclude-dir",
+        action="append",
+        default=[],
+        help="Additional directory names to exclude",
+    )
+    parser.add_argument(
+        "--extension",
+        action="append",
+        default=[],
+        help="Additional file extension to include (example: .zig)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve()
+    excluded = set(DEFAULT_EXCLUDES)
+    excluded.update(args.exclude_dir)
+    extensions = set(DEFAULT_EXTENSIONS)
+    extensions.update(
+        ext if ext.startswith(".") else f".{ext}" for ext in args.extension
+    )
+
+    metrics = [
+        count_lines(path) for path in iter_source_files(root, extensions, excluded)
+    ]
+    summary = build_summary(root, metrics, max(1, args.limit))
+
+    if args.format == "json":
+        print(json.dumps(asdict(summary), indent=2))
+    elif args.format == "markdown":
+        print(render_markdown(summary))
+    else:
+        print(render_text(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_tracy_capture.sh
+++ b/scripts/check_tracy_capture.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Detect Tracy capture/export tooling for benchmark automation.
+# Writes a small JSON status artifact that benchmark loops can consume.
+
+out="${1:-bench_results/tracy_capture_status.json}"
+mkdir -p "$(dirname "$out")"
+
+json_escape() {
+	python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
+}
+
+find_tool() {
+	local name
+	for name in "$@"; do
+		if command -v "$name" >/dev/null 2>&1; then
+			command -v "$name"
+			return 0
+		fi
+	done
+	return 1
+}
+
+profiler=""
+if profiler_path=$(find_tool tracy-profiler Tracy); then
+	profiler="$profiler_path"
+fi
+
+capture=""
+if capture_path=$(find_tool tracy-capture capture); then
+	capture="$capture_path"
+fi
+
+csvexport=""
+if csv_path=$(find_tool tracy-csvexport csvexport); then
+	csvexport="$csv_path"
+fi
+
+status="gui-only"
+if [[ -n "$capture" ]]; then
+	status="headless-capture-available"
+elif [[ -z "$profiler" ]]; then
+	status="missing-tracy-tools"
+fi
+
+cat >"$out" <<JSON
+{
+  "status": "$status",
+  "profiler": $(printf '%s' "$profiler" | json_escape),
+  "capture": $(printf '%s' "$capture" | json_escape),
+  "csvexport": $(printf '%s' "$csvexport" | json_escape),
+  "headless_capture_available": $([[ -n "$capture" ]] && echo true || echo false),
+  "gui_available": $([[ -n "$profiler" ]] && echo true || echo false),
+  "notes": "Set YAMS_TRACY_CAPTURE_CMD and YAMS_TRACY_CAPTURE_ARGS for scripts/run_tracy_benchmark.sh when a Tracy capture tool is installed."
+}
+JSON
+
+cat "$out"
+
+if [[ -z "$capture" ]]; then
+	cat >&2 <<'EOF'
+
+No headless Tracy capture tool was found.
+Validated fallback:
+  1. Build benchmarks with Tracy enabled when available:
+     meson setup --reconfigure build/release -Denable-profiling=true
+  2. Start the GUI profiler in another terminal:
+     tracy-profiler
+  3. Run the benchmark wrapper:
+     scripts/run_tracy_benchmark.sh write_coordinator_bench
+
+For fully programmatic capture, install/build Tracy's capture tool and run:
+  YAMS_TRACY_CAPTURE_CMD=/path/to/capture \
+  YAMS_TRACY_CAPTURE_ARGS='<version-specific output args>' \
+  scripts/run_tracy_benchmark.sh write_coordinator_bench
+EOF
+fi

--- a/scripts/run_benchmark_profile_suite.py
+++ b/scripts/run_benchmark_profile_suite.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass
+class BenchRun:
+    name: str
+    group: str
+    command: list[str]
+    env: dict[str, str] = field(default_factory=dict)
+    timeout_sec: int = 300
+    output_hint: str = ""
+
+
+@dataclass
+class BenchResult:
+    name: str
+    group: str
+    command: str
+    timeout_sec: int
+    duration_sec: float
+    exit_code: int | None
+    status: str
+    stdout_log: str
+    stderr_log: str
+    output_hint: str = ""
+
+
+def stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def run_command(run: BenchRun, outdir: Path, base_env: dict[str, str]) -> BenchResult:
+    safe = run.name.replace("/", "_").replace(" ", "_")
+    stdout_path = outdir / f"{safe}.stdout.log"
+    stderr_path = outdir / f"{safe}.stderr.log"
+    env = dict(base_env)
+    env.update(run.env)
+    start = time.monotonic()
+    status = "unknown"
+    code: int | None = None
+    try:
+        proc = subprocess.run(
+            run.command,
+            cwd=Path.cwd(),
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=run.timeout_sec,
+        )
+        code = proc.returncode
+        status = "ok" if code == 0 else "failed"
+        stdout_path.write_text(proc.stdout, encoding="utf-8", errors="replace")
+        stderr_path.write_text(proc.stderr, encoding="utf-8", errors="replace")
+    except subprocess.TimeoutExpired as exc:
+        status = "timeout"
+        code = None
+        stdout = (
+            exc.stdout.decode("utf-8", errors="replace")
+            if isinstance(exc.stdout, bytes)
+            else (exc.stdout or "")
+        )
+        stderr = (
+            exc.stderr.decode("utf-8", errors="replace")
+            if isinstance(exc.stderr, bytes)
+            else (exc.stderr or "")
+        )
+        stdout_path.write_text(stdout, encoding="utf-8", errors="replace")
+        stderr_path.write_text(stderr, encoding="utf-8", errors="replace")
+    dur = time.monotonic() - start
+    return BenchResult(
+        name=run.name,
+        group=run.group,
+        command=" ".join(shlex.quote(x) for x in run.command),
+        timeout_sec=run.timeout_sec,
+        duration_sec=round(dur, 3),
+        exit_code=code,
+        status=status,
+        stdout_log=str(stdout_path),
+        stderr_log=str(stderr_path),
+        output_hint=run.output_hint,
+    )
+
+
+def write_markdown(
+    results: list[BenchResult], outdir: Path, tracy_status: Path
+) -> None:
+    lines = [
+        "# Benchmark profiling suite run",
+        "",
+        f"- Run directory: `{outdir}`",
+        f"- Tracy status: `{tracy_status}`",
+        "",
+        "## Results",
+        "",
+        "| Group | Name | Status | Duration (s) | Exit | Output | Logs |",
+        "| --- | --- | --- | ---: | ---: | --- | --- |",
+    ]
+    for r in results:
+        logs = f"[`stdout`]({Path(r.stdout_log).name}) / [`stderr`]({Path(r.stderr_log).name})"
+        lines.append(
+            f"| {r.group} | `{r.name}` | {r.status} | {r.duration_sec:.3f} | "
+            f"{'' if r.exit_code is None else r.exit_code} | `{r.output_hint}` | {logs} |"
+        )
+    lines += [
+        "",
+        "## Notes",
+        "",
+        "- `timeout` means the command was bounded by the suite runner, not necessarily broken.",
+        "- This smoke suite is for coverage of benchmark tooling and artifact plumbing; use larger repeat counts for optimization decisions.",
+        "- If Tracy status is `gui-only`, no `.tracy` file is expected from this automated run.",
+    ]
+    (outdir / "summary.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run bounded YAMS benchmark profiling smoke suite"
+    )
+    parser.add_argument("--build-dir", default="build/release")
+    parser.add_argument("--out-dir", default="")
+    parser.add_argument("--timeout", type=int, default=240)
+    parser.add_argument("--skip-build", action="store_true")
+    args = parser.parse_args()
+
+    build_dir = Path(args.build_dir).resolve()
+    outdir = (
+        Path(args.out_dir)
+        if args.out_dir
+        else Path("audit_artifacts/benchmark_runs") / stamp()
+    ).resolve()
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    base_env = os.environ.copy()
+    base_env.update(
+        {
+            "YAMS_TESTING": "1",
+            "YAMS_DISABLE_VECTORS": "1",
+            "YAMS_DISABLE_SESSION_WATCHER": "1",
+            "YAMS_SKIP_MODEL_LOADING": "1",
+            "YAMS_TEST_SAFE_SINGLE_INSTANCE": "1",
+        }
+    )
+
+    tracy_status = outdir / "tracy_capture_status.json"
+    subprocess.run(
+        ["scripts/check_tracy_capture.sh", str(tracy_status)], text=True, check=False
+    )
+
+    targets = [
+        "bench_write_coordinator",
+        "metadata_contention_bench",
+        "symspell_bench",
+        "ipc_stream_bench",
+        "yams_core_benchmarks",
+        "yams_search_benchmarks",
+        "yams_api_benchmarks",
+        "multi_client_ingestion_bench",
+        "symbol_extraction_bench",
+    ]
+    if not args.skip_build:
+        build_cmd = ["meson", "compile", "-C", str(build_dir), "-j4", *targets]
+        build_run = BenchRun(
+            "build_selected_benchmarks", "setup", build_cmd, timeout_sec=900
+        )
+        build_result = run_command(build_run, outdir, base_env)
+        results: list[BenchResult] = [build_result]
+        if build_result.status != "ok":
+            (outdir / "results.json").write_text(
+                json.dumps([asdict(x) for x in results], indent=2)
+            )
+            write_markdown(results, outdir, tracy_status)
+            print(outdir)
+            return 1
+    else:
+        results = []
+
+    bench_results = outdir / "json"
+    bench_results.mkdir(exist_ok=True)
+
+    runs = [
+        BenchRun(
+            "write_coordinator_bench",
+            "metadata/write-path",
+            ["scripts/run_tracy_benchmark.sh", "write_coordinator_bench"],
+            env={
+                "YAMS_BENCH_NUM_FILES": "2",
+                "YAMS_BENCH_FILE_SIZE_BYTES": "128",
+                "YAMS_BENCH_VERSION_ITERATIONS": "1",
+                "YAMS_BENCH_REPEAT": "1",
+                "YAMS_BENCH_OUTPUT": str(bench_results / "write_coordinator.jsonl"),
+            },
+            timeout_sec=args.timeout,
+            output_hint=str(bench_results / "write_coordinator.jsonl"),
+        ),
+        BenchRun(
+            "metadata_contention_bench",
+            "metadata/write-path",
+            [
+                "meson",
+                "test",
+                "-C",
+                str(build_dir),
+                "metadata_contention_bench",
+                "--print-errorlogs",
+            ],
+            env={
+                "YAMS_BENCH_SEED_DOCS": "50",
+                "YAMS_BENCH_WRITER_THREADS": "1",
+                "YAMS_BENCH_READER_THREADS": "2",
+                "YAMS_BENCH_LONG_READERS": "0",
+                "YAMS_BENCH_RUNTIME_S": "1",
+                "YAMS_BENCH_REPEAT": "1",
+                "YAMS_BENCH_OUTPUT": str(bench_results / "metadata_contention.jsonl"),
+            },
+            timeout_sec=args.timeout,
+            output_hint=str(bench_results / "metadata_contention.jsonl"),
+        ),
+        BenchRun(
+            "symspell_bench",
+            "vector/fuzzy",
+            [
+                "meson",
+                "test",
+                "-C",
+                str(build_dir),
+                "symspell_bench",
+                "--print-errorlogs",
+            ],
+            timeout_sec=args.timeout,
+        ),
+        BenchRun(
+            "ipc_stream_bench",
+            "core/ipc/storage",
+            [
+                str(build_dir / "tests/benchmarks/ipc_stream_bench"),
+                "--quiet",
+                "--iterations",
+                "1",
+                "--output",
+                str(bench_results / "ipc_stream.json"),
+            ],
+            timeout_sec=args.timeout,
+            output_hint=str(bench_results / "ipc_stream.json"),
+        ),
+        BenchRun(
+            "yams_core_benchmarks",
+            "other/core",
+            [
+                str(build_dir / "tests/benchmarks/yams_core_benchmarks"),
+                "--quiet",
+                "--warmup",
+                "0",
+                "--iterations",
+                "1",
+                "--out-dir",
+                str(bench_results / "core"),
+            ],
+            timeout_sec=args.timeout,
+            output_hint=str(bench_results / "core"),
+        ),
+        BenchRun(
+            "yams_search_benchmarks",
+            "search/retrieval",
+            [
+                str(build_dir / "tests/benchmarks/yams_search_benchmarks"),
+                "--quiet",
+                "--warmup",
+                "0",
+                "--iterations",
+                "1",
+                "--out-dir",
+                str(bench_results / "search"),
+            ],
+            timeout_sec=args.timeout,
+            output_hint=str(bench_results / "search"),
+        ),
+        BenchRun(
+            "yams_api_benchmarks",
+            "other/api",
+            [
+                str(build_dir / "tests/benchmarks/yams_api_benchmarks"),
+                "--quiet",
+                "--warmup",
+                "0",
+                "--iterations",
+                "1",
+                "--out-dir",
+                str(bench_results / "api"),
+            ],
+            timeout_sec=args.timeout,
+            output_hint=str(bench_results / "api"),
+        ),
+        BenchRun(
+            "multi_client_ingestion_bench",
+            "ingestion/pipeline",
+            [
+                "meson",
+                "test",
+                "-C",
+                str(build_dir),
+                "multi_client_ingestion_bench",
+                "--print-errorlogs",
+            ],
+            timeout_sec=args.timeout,
+        ),
+        BenchRun(
+            "symbol_extraction_bench",
+            "extraction/plugins",
+            [
+                "meson",
+                "test",
+                "-C",
+                str(build_dir),
+                "symbol_extraction_bench",
+                "--print-errorlogs",
+            ],
+            timeout_sec=args.timeout,
+        ),
+    ]
+
+    for run in runs:
+        print(f"running {run.name}...", flush=True)
+        results.append(run_command(run, outdir, base_env))
+
+    (outdir / "results.json").write_text(
+        json.dumps([asdict(x) for x in results], indent=2), encoding="utf-8"
+    )
+    write_markdown(results, outdir, tracy_status)
+    print(outdir)
+    failures = [r for r in results if r.status not in {"ok"}]
+    return 0 if not failures else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_metadata_stable_baselines.py
+++ b/scripts/run_metadata_stable_baselines.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class CommandResult:
+    name: str
+    command: str
+    duration_sec: float
+    status: str
+    exit_code: int | None
+    stdout_log: str
+    stderr_log: str
+    output_path: str = ""
+    env_overrides: dict[str, str] = field(default_factory=dict)
+
+
+def utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def text_from_timeout(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def run_command(
+    name: str,
+    command: list[str],
+    outdir: Path,
+    env: dict[str, str],
+    timeout_sec: int,
+    output_path: Path | None = None,
+    env_overrides: dict[str, str] | None = None,
+) -> CommandResult:
+    safe_name = name.replace("/", "_").replace(" ", "_")
+    stdout_log = outdir / f"{safe_name}.stdout.log"
+    stderr_log = outdir / f"{safe_name}.stderr.log"
+    start = time.monotonic()
+    status = "unknown"
+    exit_code: int | None = None
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=Path.cwd(),
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=timeout_sec,
+        )
+        status = "ok" if proc.returncode == 0 else "failed"
+        exit_code = proc.returncode
+        stdout_log.write_text(proc.stdout, encoding="utf-8", errors="replace")
+        stderr_log.write_text(proc.stderr, encoding="utf-8", errors="replace")
+    except subprocess.TimeoutExpired as exc:
+        status = "timeout"
+        stdout_log.write_text(
+            text_from_timeout(exc.stdout), encoding="utf-8", errors="replace"
+        )
+        stderr_log.write_text(
+            text_from_timeout(exc.stderr), encoding="utf-8", errors="replace"
+        )
+    return CommandResult(
+        name=name,
+        command=" ".join(shlex.quote(part) for part in command),
+        duration_sec=round(time.monotonic() - start, 3),
+        status=status,
+        exit_code=exit_code,
+        stdout_log=str(stdout_log),
+        stderr_log=str(stderr_log),
+        output_path=str(output_path or ""),
+        env_overrides=env_overrides or {},
+    )
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.strip():
+            continue
+        records.append(json.loads(line))
+    return records
+
+
+def latency_summary(record: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for key, value in record.items():
+        if not isinstance(value, dict):
+            continue
+        if "latency_p95_us" not in value or not value.get("attempts"):
+            continue
+        rows.append(
+            {
+                "operation": key,
+                "attempts": value.get("attempts", 0),
+                "mean_us": value.get("latency_mean_us", 0.0),
+                "p95_us": value.get("latency_p95_us", 0.0),
+                "p99_us": value.get("latency_p99_us", 0.0),
+                "max_us": value.get("latency_max_us", 0.0),
+                "errors": value.get("errors", 0),
+                "lock_errors": value.get("lock_errors", 0),
+            }
+        )
+    rows.sort(key=lambda row: float(row["p95_us"]), reverse=True)
+    return rows
+
+
+def summarize_api(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    for record in load_jsonl(path):
+        rows.append(
+            {
+                "name": record.get("name", ""),
+                "duration_ms": record.get("duration_ms", 0.0),
+                "duration_ms_median": record.get("duration_ms_median", 0.0),
+                "duration_ms_p95": record.get("duration_ms_p95", 0.0),
+                "operations": record.get("operations", 0),
+                "ops_per_sec": record.get("ops_per_sec", 0.0),
+            }
+        )
+    rows.sort(key=lambda row: float(row["duration_ms_p95"]), reverse=True)
+    return rows
+
+
+def write_summary(
+    outdir: Path, results: list[CommandResult], analysis: dict[str, Any]
+) -> None:
+    lines = [
+        "# Stable metadata baseline run",
+        "",
+        f"Run directory: `{outdir}`",
+        "",
+        "## Commands",
+        "",
+        "| Name | Status | Duration (s) | Exit | Output | Logs |",
+        "| --- | --- | ---: | ---: | --- | --- |",
+    ]
+    for result in results:
+        logs = f"[`stdout`]({Path(result.stdout_log).name}) / [`stderr`]({Path(result.stderr_log).name})"
+        exit_code = "" if result.exit_code is None else str(result.exit_code)
+        lines.append(
+            f"| `{result.name}` | {result.status} | {result.duration_sec:.3f} | "
+            f"{exit_code} | `{result.output_path}` | {logs} |"
+        )
+    lines.extend(["", "## API repeated baseline", ""])
+    for row in analysis.get("api", []):
+        lines.append(
+            f"- `{row['name']}`: p95 `{row['duration_ms_p95']:.3f} ms`, "
+            f"median `{row['duration_ms_median']:.3f} ms`, operations `{row['operations']}`"
+        )
+    lines.extend(["", "## Metadata contention matrix top p95 rows", ""])
+    for matrix in analysis.get("metadata_matrix", []):
+        lines.append(
+            f"### mode={matrix['write_mode']} checkpoint={matrix['checkpoint_every_ms']}ms"
+        )
+        for row in matrix.get("top_latencies", [])[:5]:
+            lines.append(
+                f"- `{row['operation']}`: attempts `{row['attempts']}`, "
+                f"p95 `{row['p95_us']:.0f} us`, p99 `{row['p99_us']:.0f} us`, "
+                f"max `{row['max_us']:.0f} us`, lock_errors `{row['lock_errors']}`"
+            )
+        lines.append("")
+    lines.extend(
+        [
+            "## Notes",
+            "",
+            "- These runs strengthen the prior smoke data but still share one local workstation environment.",
+            "- Use identical commands for before/after comparisons when implementing a patch.",
+        ]
+    )
+    (outdir / "summary.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run stable metadata/API optimization baselines"
+    )
+    parser.add_argument("--build-dir", default="build/release")
+    parser.add_argument("--out-dir", default="")
+    parser.add_argument("--runtime-sec", type=int, default=8)
+    parser.add_argument("--repeat", type=int, default=3)
+    parser.add_argument("--api-iterations", type=int, default=10)
+    parser.add_argument("--timeout-sec", type=int, default=420)
+    parser.add_argument("--skip-build", action="store_true")
+    args = parser.parse_args()
+
+    build_dir = Path(args.build_dir).resolve()
+    outdir = (
+        Path(args.out_dir)
+        if args.out_dir
+        else Path("audit_artifacts/benchmark_runs") / f"metadata_stable_{utc_stamp()}"
+    ).resolve()
+    outdir.mkdir(parents=True, exist_ok=True)
+    data_dir = outdir / "json"
+    data_dir.mkdir(exist_ok=True)
+
+    base_env = os.environ.copy()
+    base_env.update(
+        {
+            "YAMS_TESTING": "1",
+            "YAMS_DISABLE_VECTORS": "1",
+            "YAMS_DISABLE_SESSION_WATCHER": "1",
+            "YAMS_SKIP_MODEL_LOADING": "1",
+            "YAMS_TEST_SAFE_SINGLE_INSTANCE": "1",
+        }
+    )
+
+    results: list[CommandResult] = []
+    if not args.skip_build:
+        results.append(
+            run_command(
+                "build_metadata_targets",
+                [
+                    "meson",
+                    "compile",
+                    "-C",
+                    str(build_dir),
+                    "-j4",
+                    "yams_api_benchmarks",
+                    "metadata_contention_bench",
+                ],
+                outdir,
+                base_env,
+                timeout_sec=900,
+            )
+        )
+        if results[-1].status != "ok":
+            (outdir / "results.json").write_text(
+                json.dumps([asdict(r) for r in results], indent=2), encoding="utf-8"
+            )
+            write_summary(outdir, results, {"api": [], "metadata_matrix": []})
+            print(outdir)
+            return 1
+
+    api_exe = build_dir / "tests/benchmarks/yams_api_benchmarks"
+    metadata_exe = build_dir / "tests/benchmarks/metadata_contention_bench"
+
+    results.append(
+        run_command(
+            "smoke_api_benchmarks",
+            [
+                str(api_exe),
+                "--quiet",
+                "--warmup",
+                "0",
+                "--iterations",
+                "1",
+                "--out-dir",
+                str(data_dir / "api_smoke"),
+            ],
+            outdir,
+            base_env,
+            timeout_sec=120,
+            output_path=data_dir / "api_smoke",
+        )
+    )
+
+    smoke_output = data_dir / "metadata_smoke.jsonl"
+    smoke_env = dict(base_env)
+    smoke_overrides = {
+        "YAMS_BENCH_WRITE_MODE": "mixed",
+        "YAMS_BENCH_SEED_DOCS": "100",
+        "YAMS_BENCH_WRITER_THREADS": "1",
+        "YAMS_BENCH_READER_THREADS": "2",
+        "YAMS_BENCH_RUNTIME_S": "1",
+        "YAMS_BENCH_REPEAT": "1",
+        "YAMS_BENCH_CHECKPOINT_EVERY_MS": "500",
+        "YAMS_BENCH_OUTPUT": str(smoke_output),
+    }
+    smoke_env.update(smoke_overrides)
+    results.append(
+        run_command(
+            "smoke_metadata_contention",
+            [str(metadata_exe)],
+            outdir,
+            smoke_env,
+            timeout_sec=120,
+            output_path=smoke_output,
+            env_overrides=smoke_overrides,
+        )
+    )
+
+    api_out_dir = data_dir / "api_repeated"
+    results.append(
+        run_command(
+            "api_repeated_iterations",
+            [
+                str(api_exe),
+                "--quiet",
+                "--warmup",
+                "2",
+                "--iterations",
+                str(args.api_iterations),
+                "--out-dir",
+                str(api_out_dir),
+            ],
+            outdir,
+            base_env,
+            timeout_sec=args.timeout_sec,
+            output_path=api_out_dir,
+        )
+    )
+
+    matrix: list[dict[str, Any]] = []
+    for mode in ["batch_content", "repair_status", "metadata_batch"]:
+        for checkpoint in [0, 500, 2000]:
+            output = data_dir / f"metadata_{mode}_checkpoint_{checkpoint}.jsonl"
+            overrides = {
+                "YAMS_BENCH_WRITE_MODE": mode,
+                "YAMS_BENCH_SEED_DOCS": "2000",
+                "YAMS_BENCH_WRITER_THREADS": "2",
+                "YAMS_BENCH_READER_THREADS": "8",
+                "YAMS_BENCH_LONG_READERS": "0",
+                "YAMS_BENCH_RUNTIME_S": str(args.runtime_sec),
+                "YAMS_BENCH_REPEAT": str(args.repeat),
+                "YAMS_BENCH_CHECKPOINT_EVERY_MS": str(checkpoint),
+                "YAMS_BENCH_OUTPUT": str(output),
+            }
+            env = dict(base_env)
+            env.update(overrides)
+            name = f"metadata_{mode}_checkpoint_{checkpoint}"
+            results.append(
+                run_command(
+                    name,
+                    [str(metadata_exe)],
+                    outdir,
+                    env,
+                    timeout_sec=args.timeout_sec,
+                    output_path=output,
+                    env_overrides=overrides,
+                )
+            )
+            records = load_jsonl(output)
+            latest = records[-1] if records else {}
+            matrix.append(
+                {
+                    "write_mode": mode,
+                    "checkpoint_every_ms": checkpoint,
+                    "output": str(output),
+                    "top_latencies": latency_summary(latest),
+                }
+            )
+
+    api_jsonl = api_out_dir / "api_benchmarks.jsonl"
+    analysis = {"api": summarize_api(api_jsonl), "metadata_matrix": matrix}
+    (outdir / "analysis.json").write_text(
+        json.dumps(analysis, indent=2), encoding="utf-8"
+    )
+    (outdir / "results.json").write_text(
+        json.dumps([asdict(r) for r in results], indent=2), encoding="utf-8"
+    )
+    write_summary(outdir, results, analysis)
+    print(outdir)
+    failures = [result for result in results if result.status != "ok"]
+    return 0 if not failures else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_tracy_benchmark.sh
+++ b/scripts/run_tracy_benchmark.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run a YAMS benchmark with optional Tracy headless capture.
+#
+# Why this is env-driven:
+# Tracy's GUI/client integration is stable, but the packaged headless capture
+# tool name and flags vary by install/version (often `capture` or
+# `tracy-capture`). Set YAMS_TRACY_CAPTURE_CMD and YAMS_TRACY_CAPTURE_ARGS to
+# the exact capture invocation for your Tracy build.
+#
+# Example:
+#   YAMS_TRACY_CAPTURE_CMD=/path/to/tracy/capture \
+#   YAMS_TRACY_CAPTURE_ARGS='-o bench_results/write_coordinator.tracy' \
+#   scripts/run_tracy_benchmark.sh write_coordinator_bench
+
+bench_name="${1:-write_coordinator_bench}"
+build_dir="${YAMS_BUILD_DIR:-build/release}"
+output_dir="${YAMS_BENCH_RESULTS_DIR:-bench_results}"
+mkdir -p "$output_dir"
+
+capture_cmd="${YAMS_TRACY_CAPTURE_CMD:-}"
+if [[ -z "$capture_cmd" ]]; then
+	if command -v tracy-capture >/dev/null 2>&1; then
+		capture_cmd="$(command -v tracy-capture)"
+	elif command -v capture >/dev/null 2>&1; then
+		capture_cmd="$(command -v capture)"
+	fi
+fi
+
+capture_pid=""
+if [[ -n "$capture_cmd" ]]; then
+	capture_args="${YAMS_TRACY_CAPTURE_ARGS:-}"
+	if [[ -z "$capture_args" ]]; then
+		cat >&2 <<EOF
+Found Tracy capture tool: $capture_cmd
+Set YAMS_TRACY_CAPTURE_ARGS for your Tracy version, for example an output path
+argument such as: -o $output_dir/${bench_name}.tracy
+EOF
+		exit 2
+	fi
+	echo "Starting Tracy capture: $capture_cmd $capture_args" >&2
+	# shellcheck disable=SC2086 # intentional user-provided args string
+	"$capture_cmd" $capture_args &
+	capture_pid="$!"
+	sleep "${YAMS_TRACY_CAPTURE_STARTUP_SEC:-1}"
+else
+	cat >&2 <<EOF
+No headless Tracy capture tool found on PATH.
+The benchmark will still run. To capture a trace programmatically, install/build
+Tracy's capture tool and set:
+  YAMS_TRACY_CAPTURE_CMD=/path/to/capture
+  YAMS_TRACY_CAPTURE_ARGS='<version-specific capture args>'
+Or open tracy-profiler/Tracy GUI before running this script.
+EOF
+fi
+
+cleanup() {
+	if [[ -n "$capture_pid" ]] && kill -0 "$capture_pid" >/dev/null 2>&1; then
+		kill "$capture_pid" >/dev/null 2>&1 || true
+		wait "$capture_pid" >/dev/null 2>&1 || true
+	fi
+}
+trap cleanup EXIT
+
+case "$bench_name" in
+write_coordinator_bench)
+	: "${YAMS_BENCH_OUTPUT:=$output_dir/write_coordinator_tracy.jsonl}"
+	export YAMS_BENCH_OUTPUT
+	: "${YAMS_BENCH_NUM_FILES:=1000}"
+	: "${YAMS_BENCH_FILE_SIZE_BYTES:=4096}"
+	: "${YAMS_BENCH_VERSION_ITERATIONS:=3}"
+	: "${YAMS_BENCH_REPEAT:=3}"
+	export YAMS_BENCH_NUM_FILES YAMS_BENCH_FILE_SIZE_BYTES YAMS_BENCH_VERSION_ITERATIONS YAMS_BENCH_REPEAT
+	;;
+esac
+
+echo "Running benchmark '$bench_name' in $build_dir" >&2
+meson test -C "$build_dir" "$bench_name" --print-errorlogs
+
+echo "Benchmark complete. JSON output: ${YAMS_BENCH_OUTPUT:-<benchmark default>}" >&2

--- a/src/app/services/document_service.cpp
+++ b/src/app/services/document_service.cpp
@@ -1337,6 +1337,7 @@ public:
 
             // Single-transaction insert: document + metadata + snapshot in one
             // BEGIN IMMEDIATE, reducing 15-20 lock acquisitions to 1.
+            metadata::MetadataOpScope metadataScope("app_store_document");
             auto ins =
                 ctx_.metadataRepo->insertDocumentWithMetadata(info, tagPairs, &snapshotRecord);
             if (ins) {

--- a/src/app/services/document_service.cpp
+++ b/src/app/services/document_service.cpp
@@ -1361,7 +1361,14 @@ public:
                                 if (verRes && verRes.value().has_value()) {
                                     try {
                                         maxVersion = verRes.value().value().asInteger();
+                                    } catch (const std::exception& ex) {
+                                        spdlog::debug(
+                                            "Ignoring invalid prior version metadata for {}: {}",
+                                            prior.id, ex.what());
                                     } catch (...) {
+                                        spdlog::debug(
+                                            "Ignoring invalid prior version metadata for {}",
+                                            prior.id);
                                     }
                                 }
                             }
@@ -1385,7 +1392,14 @@ public:
                                             int64_t v = verRes.value().value().asInteger();
                                             if (v > maxVersion)
                                                 maxVersion = v;
+                                        } catch (const std::exception& ex) {
+                                            spdlog::debug("Ignoring invalid candidate version "
+                                                          "metadata for {}: {}",
+                                                          d.id, ex.what());
                                         } catch (...) {
+                                            spdlog::debug("Ignoring invalid candidate version "
+                                                          "metadata for {}",
+                                                          d.id);
                                         }
                                     }
                                     if (prevLatestId.has_value())
@@ -1430,7 +1444,11 @@ public:
                                                                 docId, std::nullopt);
                         }
                     }
+                } catch (const std::exception& ex) {
+                    spdlog::debug("Failed to update versioning metadata for {}: {}", info.filePath,
+                                  ex.what());
                 } catch (...) {
+                    spdlog::debug("Failed to update versioning metadata for {}", info.filePath);
                 }
 
                 // Update path tree for this document (best-effort, separate txn)
@@ -1441,8 +1459,13 @@ public:
                         spdlog::debug("Failed to update path tree for {}: {}", info.filePath,
                                       treeRes.error().message);
                     }
+                } catch (const std::exception& ex) {
+                    // Non-fatal: path tree update is opportunistic
+                    spdlog::debug("Exception updating path tree for {}: {}", info.filePath,
+                                  ex.what());
                 } catch (...) {
                     // Non-fatal: path tree update is opportunistic
+                    spdlog::debug("Unknown exception updating path tree for {}", info.filePath);
                 }
 
                 // Keep the lightweight corpus graph in sync for single-document stores so
@@ -2458,50 +2481,106 @@ public:
                 resp.hash = *pendingContentHash;
             }
         } else {
-            for (const auto& [k, v] : req.keyValues) {
-                auto u = ctx_.metadataRepo->setMetadata(target.id, k, metadata::MetadataValue(v));
-                if (!u) {
-                    errors.push_back("Failed to update metadata: " + k);
-                } else {
-                    count++;
+            auto applyIndividually = [&]() {
+                for (const auto& [k, v] : req.keyValues) {
+                    auto u =
+                        ctx_.metadataRepo->setMetadata(target.id, k, metadata::MetadataValue(v));
+                    if (!u) {
+                        errors.push_back("Failed to update metadata: " + k);
+                    } else {
+                        count++;
+                    }
                 }
-            }
 
+                for (const auto& p : req.pairs) {
+                    auto pos = p.find('=');
+                    if (pos == std::string::npos) {
+                        continue;
+                    }
+                    std::string k = p.substr(0, pos);
+                    std::string v = p.substr(pos + 1);
+                    auto u =
+                        ctx_.metadataRepo->setMetadata(target.id, k, metadata::MetadataValue(v));
+                    if (!u) {
+                        errors.push_back("Failed to update metadata: " + k);
+                    } else {
+                        count++;
+                    }
+                }
+
+                for (const auto& tag : req.addTags) {
+                    auto u = ctx_.metadataRepo->setMetadata(target.id, "tag:" + tag,
+                                                            metadata::MetadataValue(tag));
+                    if (!u) {
+                        errors.push_back("Failed to add tag: " + tag);
+                    } else {
+                        resp.tagsAdded++;
+                    }
+                }
+
+                for (const auto& tag : req.removeTags) {
+                    if (!currentTagSet.contains(tag)) {
+                        continue;
+                    }
+                    auto u = ctx_.metadataRepo->setMetadata(target.id, "tag:" + tag,
+                                                            metadata::MetadataValue(""));
+                    if (!u) {
+                        errors.push_back("Failed to remove tag: " + tag);
+                    } else {
+                        resp.tagsRemoved++;
+                    }
+                }
+            };
+
+            std::vector<std::tuple<int64_t, std::string, metadata::MetadataValue>> metadataEntries;
+            metadataEntries.reserve(static_cast<std::size_t>(req.keyValues.size() +
+                                                             req.pairs.size() + req.addTags.size() +
+                                                             req.removeTags.size()));
+            std::size_t batchUpdateCount = 0;
+            std::size_t batchTagsAdded = 0;
+            std::size_t batchTagsRemoved = 0;
+
+            for (const auto& [k, v] : req.keyValues) {
+                metadataEntries.emplace_back(target.id, k, metadata::MetadataValue(v));
+                batchUpdateCount++;
+            }
             for (const auto& p : req.pairs) {
                 auto pos = p.find('=');
-                if (pos == std::string::npos)
+                if (pos == std::string::npos) {
                     continue;
-                std::string k = p.substr(0, pos);
-                std::string v = p.substr(pos + 1);
-                auto u = ctx_.metadataRepo->setMetadata(target.id, k, metadata::MetadataValue(v));
-                if (!u) {
-                    errors.push_back("Failed to update metadata: " + k);
-                } else {
-                    count++;
                 }
+                metadataEntries.emplace_back(target.id, p.substr(0, pos),
+                                             metadata::MetadataValue(p.substr(pos + 1)));
+                batchUpdateCount++;
             }
-
             for (const auto& tag : req.addTags) {
-                auto u = ctx_.metadataRepo->setMetadata(target.id, "tag:" + tag,
-                                                        metadata::MetadataValue(tag));
-                if (!u) {
-                    errors.push_back("Failed to add tag: " + tag);
-                } else {
-                    resp.tagsAdded++;
-                }
+                metadataEntries.emplace_back(target.id, "tag:" + tag, metadata::MetadataValue(tag));
+                batchTagsAdded++;
             }
-
             for (const auto& tag : req.removeTags) {
                 if (!currentTagSet.contains(tag)) {
                     continue;
                 }
-                auto u = ctx_.metadataRepo->setMetadata(target.id, "tag:" + tag,
-                                                        metadata::MetadataValue(""));
-                if (!u) {
-                    errors.push_back("Failed to remove tag: " + tag);
+                metadataEntries.emplace_back(target.id, "tag:" + tag, metadata::MetadataValue(""));
+                batchTagsRemoved++;
+            }
+
+            if (metadataEntries.size() > 1) {
+                metadata::MetadataOpScope metadataScope("app_document_update_metadata_non_atomic");
+                auto metadataResult = ctx_.metadataRepo->setMetadataBatch(metadataEntries);
+                if (metadataResult) {
+                    count += batchUpdateCount;
+                    resp.tagsAdded += batchTagsAdded;
+                    resp.tagsRemoved += batchTagsRemoved;
                 } else {
-                    resp.tagsRemoved++;
+                    spdlog::debug(
+                        "DocumentService: non-atomic metadata batch failed for doc {}: {}; "
+                        "falling back to per-entry writes",
+                        target.id, metadataResult.error().message);
+                    applyIndividually();
                 }
+            } else {
+                applyIndividually();
             }
         }
 

--- a/src/cli/commands/update_command.cpp
+++ b/src/cli/commands/update_command.cpp
@@ -2,6 +2,7 @@
 #include <spdlog/spdlog.h>
 #include <iostream>
 #include <sstream>
+#include <tuple>
 #include <yams/cli/commands/update_command.h>
 #include <yams/cli/ui_helpers.hpp>
 #include <yams/cli/yams_cli.h>
@@ -346,23 +347,19 @@ Result<void> UpdateCommand::executeLocal() {
     size_t successCount = 0;
     size_t failureCount = 0;
 
+    struct ParsedMetadataUpdate {
+        std::string key;
+        std::string value;
+        bool verboseEcho{false};
+    };
+    std::vector<ParsedMetadataUpdate> parsedUpdates;
+    parsedUpdates.reserve(metadata_.size() + 1);
+
     for (const auto& kv : metadata_) {
         auto pos = kv.find('=');
         if (pos != std::string::npos) {
-            std::string key = kv.substr(0, pos);
-            std::string value = kv.substr(pos + 1);
-
-            // Set the metadata
-            auto setResult = metadataRepo->setMetadata(docId, key, metadata::MetadataValue(value));
-            if (setResult) {
-                successCount++;
-                if (verbose_ || (cli_ && cli_->getVerbose())) {
-                    std::cout << "Set " << key << " = " << value << std::endl;
-                }
-            } else {
-                failureCount++;
-                spdlog::warn("Failed to set metadata {}: {}", key, setResult.error().message);
-            }
+            parsedUpdates.push_back(
+                ParsedMetadataUpdate{kv.substr(0, pos), kv.substr(pos + 1), true});
         } else {
             spdlog::warn("Invalid metadata format: {} (expected key=value)", kv);
             failureCount++;
@@ -378,8 +375,9 @@ Result<void> UpdateCommand::executeLocal() {
                 std::stringstream ss(s);
                 std::string item;
                 while (std::getline(ss, item, ',')) {
-                    if (!item.empty())
+                    if (!item.empty()) {
                         all.push_back(item);
+                    }
                 }
             }
         };
@@ -390,24 +388,62 @@ Result<void> UpdateCommand::executeLocal() {
             std::stringstream ss(s);
             std::string item;
             while (std::getline(ss, item, ',')) {
-                if (!item.empty())
+                if (!item.empty()) {
                     all.push_back(std::string("-") + item);
+                }
             }
         }
         if (!all.empty()) {
             std::string joined;
             for (size_t i = 0; i < all.size(); ++i) {
-                if (i)
+                if (i) {
                     joined += ",";
+                }
                 joined += all[i];
             }
-            auto setResult =
-                metadataRepo->setMetadata(docId, "tags", metadata::MetadataValue(joined));
-            if (setResult)
-                successCount++;
-            else
-                failureCount++;
+            parsedUpdates.push_back(ParsedMetadataUpdate{"tags", std::move(joined), false});
         }
+    }
+
+    auto recordSuccess = [&](const ParsedMetadataUpdate& update) {
+        successCount++;
+        if (update.verboseEcho && (verbose_ || (cli_ && cli_->getVerbose()))) {
+            std::cout << "Set " << update.key << " = " << update.value << std::endl;
+        }
+    };
+    auto applyIndividually = [&]() {
+        for (const auto& update : parsedUpdates) {
+            auto setResult =
+                metadataRepo->setMetadata(docId, update.key, metadata::MetadataValue(update.value));
+            if (setResult) {
+                recordSuccess(update);
+            } else {
+                failureCount++;
+                spdlog::warn("Failed to set metadata {}: {}", update.key,
+                             setResult.error().message);
+            }
+        }
+    };
+
+    if (parsedUpdates.size() > 1) {
+        std::vector<std::tuple<int64_t, std::string, metadata::MetadataValue>> entries;
+        entries.reserve(parsedUpdates.size());
+        for (const auto& update : parsedUpdates) {
+            entries.emplace_back(docId, update.key, metadata::MetadataValue(update.value));
+        }
+        auto batchResult = metadataRepo->setMetadataBatch(entries);
+        if (batchResult) {
+            for (const auto& update : parsedUpdates) {
+                recordSuccess(update);
+            }
+        } else {
+            spdlog::debug("UpdateCommand: local metadata batch failed for doc {}: {}; falling back "
+                          "to per-entry writes",
+                          docId, batchResult.error().message);
+            applyIndividually();
+        }
+    } else {
+        applyIndividually();
     }
 
     // Output results
@@ -442,6 +478,12 @@ void UpdateCommand::parseArguments(const std::vector<std::string>& args) {
             hash_ = args[++i];
         } else if (args[i] == "--name" && i + 1 < args.size()) {
             name_ = args[++i];
+        } else if ((args[i] == "--metadata" || args[i] == "-m") && i + 1 < args.size()) {
+            metadata_.push_back(args[++i]);
+        } else if (args[i] == "--tags" && i + 1 < args.size()) {
+            add_tags_.push_back(args[++i]);
+        } else if (args[i] == "--remove-tags" && i + 1 < args.size()) {
+            remove_tags_.push_back(args[++i]);
         } else if (args[i] == "--key" && i + 1 < args.size()) {
             if (i + 2 < args.size() && args[i + 2] == "--value") {
                 metadata_.push_back(args[i + 1] + "=" + args[i + 3]);
@@ -528,12 +570,16 @@ Result<std::string> UpdateCommand::resolveNameToHashSmart(const std::string& nam
     std::string nm = name;
     try {
         if (!nm.empty() && nm.front() == '~') {
-            if (const char* home = std::getenv("HOME")) {
+            if (const char* home = std::getenv("HOME")) { // NOLINT(concurrency-mt-unsafe)
                 nm = std::string(home) + nm.substr(1);
             }
         }
+    } catch (const std::exception& ex) {
+        // Intentional best-effort path; keep the primary operation unaffected.
+        spdlog::debug("Update: failed to expand home in '{}': {}", name, ex.what());
     } catch (...) {
         // Intentional best-effort path; keep the primary operation unaffected.
+        spdlog::debug("Update: failed to expand home in '{}'", name);
     }
 
     // Glob shortcut: resolve via glob-to-SQL conversion directly
@@ -559,10 +605,11 @@ Result<std::string> UpdateCommand::resolveNameToHashSmart(const std::string& nam
                 const metadata::DocumentInfo* chosen = &docs[0];
                 if (latest_ || oldest_) {
                     for (const auto& d : docs) {
-                        if (oldest_ && d.indexedTime < chosen->indexedTime)
+                        const bool betterMatch = oldest_ ? d.indexedTime < chosen->indexedTime
+                                                         : d.indexedTime > chosen->indexedTime;
+                        if (betterMatch) {
                             chosen = &d;
-                        else if (latest_ && d.indexedTime > chosen->indexedTime)
-                            chosen = &d;
+                        }
                     }
                 }
                 return chosen->sha256Hash;
@@ -635,8 +682,12 @@ Result<std::string> UpdateCommand::resolveNameToHashSmart(const std::string& nam
         std::string stem = nm;
         try {
             stem = std::filesystem::path(nm).stem().string();
+        } catch (const std::exception& ex) {
+            // Intentional best-effort path; keep the primary operation unaffected.
+            spdlog::debug("Update: failed to derive stem for '{}': {}", nm, ex.what());
         } catch (...) {
             // Intentional best-effort path; keep the primary operation unaffected.
+            spdlog::debug("Update: failed to derive stem for '{}'", nm);
         }
         lr = tryList(std::string("%/") + stem + "%");
     }

--- a/src/cli/commands/update_command.cpp
+++ b/src/cli/commands/update_command.cpp
@@ -485,7 +485,7 @@ void UpdateCommand::parseArguments(const std::vector<std::string>& args) {
         } else if (args[i] == "--remove-tags" && i + 1 < args.size()) {
             remove_tags_.push_back(args[++i]);
         } else if (args[i] == "--key" && i + 1 < args.size()) {
-            if (i + 2 < args.size() && args[i + 2] == "--value") {
+            if (i + 3 < args.size() && args[i + 2] == "--value") {
                 metadata_.push_back(args[i + 1] + "=" + args[i + 3]);
                 i += 3;
             }

--- a/src/daemon/components/PostIngestQueue.cpp
+++ b/src/daemon/components/PostIngestQueue.cpp
@@ -1,9 +1,9 @@
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <mutex>
-#include <sstream>
 #include <string_view>
 #include <thread>
 #include <unordered_map>
@@ -1223,15 +1223,23 @@ inline bool extensionSupportsEntityProviders(
 }
 
 void enqueueWithBackpressure(yams::daemon::WriteCoordinator& coordinator,
-                             std::unique_ptr<yams::daemon::WriteBatch> batch,
-                             std::string_view what) {
+                             std::unique_ptr<yams::daemon::WriteBatch> batch, std::string_view what,
+                             const std::atomic_bool& stopRequested) {
     constexpr int kMaxRetryRounds = 40;
     constexpr auto kRetryDelay = std::chrono::milliseconds(50);
     for (int round = 0; round < kMaxRetryRounds; ++round) {
         if (coordinator.tryEnqueue(batch)) {
             return;
         }
+        if (stopRequested.load(std::memory_order_acquire) || coordinator.isShuttingDown()) {
+            spdlog::debug("[PostIngestQueue] Dropping {} write batch during shutdown", what);
+            return;
+        }
         std::this_thread::sleep_for(kRetryDelay);
+    }
+    if (stopRequested.load(std::memory_order_acquire) || coordinator.isShuttingDown()) {
+        spdlog::debug("[PostIngestQueue] Dropping {} write batch during shutdown", what);
+        return;
     }
     spdlog::warn("[PostIngestQueue] WriteCoordinator queue full after {}ms backoff; forcing "
                  "enqueue of {}",
@@ -2058,7 +2066,7 @@ void PostIngestQueue::processEntityExtractionStage(const std::string& hash, int6
 
                 if (writeCoordinator_) {
                     enqueueWithBackpressure(*writeCoordinator_, std::move(wb),
-                                            "entity extraction KG batch");
+                                            "entity extraction KG batch", stop_);
                     totalNodesInserted += batchNodesInserted;
                     totalEdgesInserted += batchEdgesQueued;
                     totalAliasesInserted += batchAliasesQueued;
@@ -2335,7 +2343,7 @@ void PostIngestQueue::processTitleExtractionStage(const std::string& hash, int64
                         wb->ops.emplace_back(SetMetadataBatchOp{
                             {{docId, "title", metadata::MetadataValue(newTitle)}}});
                         enqueueWithBackpressure(*writeCoordinator_, std::move(wb),
-                                                "title extraction update");
+                                                "title extraction update", stop_);
                     } else {
                         updateRes = Error{ErrorCode::InvalidState, "WriteCoordinator unavailable"};
                     }
@@ -2822,8 +2830,8 @@ void PostIngestQueue::processTitleExtractionStage(const std::string& hash, int64
                     auto source = "PostIngestQueue::nlEntityKg/" + batch->sourceFile;
                     auto wb =
                         makeWriteBatchFromDeferredKGBatch(std::move(batch), std::move(source));
-                    enqueueWithBackpressure(*writeCoordinator_, std::move(wb),
-                                            "NL entity KG batch");
+                    enqueueWithBackpressure(*writeCoordinator_, std::move(wb), "NL entity KG batch",
+                                            stop_);
                 }
                 spdlog::debug("[PostIngestQueue] Queued {} NL entities for KG from {}",
                               nlEntities.size(), hash.substr(0, 12));
@@ -3153,8 +3161,8 @@ void PostIngestQueue::commitBatchResults(std::vector<PreparedMetadataEntry>& suc
                         }
                     }
                     if (!wb->ops.empty()) {
-                        enqueueWithBackpressure(*writeCoordinator_, std::move(wb),
-                                                "title metadata");
+                        enqueueWithBackpressure(*writeCoordinator_, std::move(wb), "title metadata",
+                                                stop_);
                     } else {
                         spdlog::debug("[PostIngestQueue] Skipping empty title metadata batch");
                     }
@@ -3190,7 +3198,8 @@ void PostIngestQueue::commitBatchResults(std::vector<PreparedMetadataEntry>& suc
                     UpdateRepairStatusOp{std::move(failedHashes), metadata::RepairStatus::Failed});
             }
             if (!wb->ops.empty()) {
-                enqueueWithBackpressure(*writeCoordinator_, std::move(wb), "extraction failures");
+                enqueueWithBackpressure(*writeCoordinator_, std::move(wb), "extraction failures",
+                                        stop_);
             }
         } else {
             spdlog::warn("[PostIngestQueue] WriteCoordinator unavailable; cannot mark {} "

--- a/src/daemon/components/PostIngestQueue.cpp
+++ b/src/daemon/components/PostIngestQueue.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <chrono>
 #include <mutex>
 #include <string_view>
 #include <thread>

--- a/src/daemon/components/PostIngestQueue.cpp
+++ b/src/daemon/components/PostIngestQueue.cpp
@@ -1222,6 +1222,23 @@ inline bool extensionSupportsEntityProviders(
     return false;
 }
 
+void enqueueWithBackpressure(yams::daemon::WriteCoordinator& coordinator,
+                             std::unique_ptr<yams::daemon::WriteBatch> batch,
+                             std::string_view what) {
+    constexpr int kMaxRetryRounds = 40;
+    constexpr auto kRetryDelay = std::chrono::milliseconds(50);
+    for (int round = 0; round < kMaxRetryRounds; ++round) {
+        if (coordinator.tryEnqueue(batch)) {
+            return;
+        }
+        std::this_thread::sleep_for(kRetryDelay);
+    }
+    spdlog::warn("[PostIngestQueue] WriteCoordinator queue full after {}ms backoff; forcing "
+                 "enqueue of {}",
+                 kMaxRetryRounds * kRetryDelay.count(), what);
+    coordinator.enqueue(std::move(batch));
+}
+
 } // namespace
 
 std::variant<PostIngestQueue::PreparedMetadataEntry, PostIngestQueue::ExtractionFailure>
@@ -2040,7 +2057,8 @@ void PostIngestQueue::processEntityExtractionStage(const std::string& hash, int6
                 }
 
                 if (writeCoordinator_) {
-                    writeCoordinator_->tryEnqueue(wb);
+                    enqueueWithBackpressure(*writeCoordinator_, std::move(wb),
+                                            "entity extraction KG batch");
                     totalNodesInserted += batchNodesInserted;
                     totalEdgesInserted += batchEdgesQueued;
                     totalAliasesInserted += batchAliasesQueued;
@@ -2316,7 +2334,8 @@ void PostIngestQueue::processTitleExtractionStage(const std::string& hash, int64
                         wb->source = "PostIngestQueue::titleExtraction/title";
                         wb->ops.emplace_back(SetMetadataBatchOp{
                             {{docId, "title", metadata::MetadataValue(newTitle)}}});
-                        writeCoordinator_->tryEnqueue(wb);
+                        enqueueWithBackpressure(*writeCoordinator_, std::move(wb),
+                                                "title extraction update");
                     } else {
                         updateRes = Error{ErrorCode::InvalidState, "WriteCoordinator unavailable"};
                     }
@@ -2803,7 +2822,8 @@ void PostIngestQueue::processTitleExtractionStage(const std::string& hash, int64
                     auto source = "PostIngestQueue::nlEntityKg/" + batch->sourceFile;
                     auto wb =
                         makeWriteBatchFromDeferredKGBatch(std::move(batch), std::move(source));
-                    writeCoordinator_->tryEnqueue(wb);
+                    enqueueWithBackpressure(*writeCoordinator_, std::move(wb),
+                                            "NL entity KG batch");
                 }
                 spdlog::debug("[PostIngestQueue] Queued {} NL entities for KG from {}",
                               nlEntities.size(), hash.substr(0, 12));
@@ -3075,23 +3095,41 @@ void PostIngestQueue::commitBatchResults(std::vector<PreparedMetadataEntry>& suc
         }
 
         const auto contentWriteStart = std::chrono::steady_clock::now();
-        metadata::MetadataOpScope metadataScope("daemon_post_ingest_batch_content");
-        auto batchResult = meta_->batchInsertContentAndIndex(entries);
+        constexpr std::size_t kMaxContentEntriesPerTxn = 128;
+        std::vector<PreparedMetadataEntry> committed;
+        committed.reserve(successes.size());
+        {
+            metadata::MetadataOpScope metadataScope("daemon_post_ingest_batch_content");
+            for (std::size_t off = 0; off < entries.size(); off += kMaxContentEntriesPerTxn) {
+                const auto end = std::min(entries.size(), off + kMaxContentEntriesPerTxn);
+                std::vector<metadata::BatchContentEntry> chunk(
+                    std::make_move_iterator(entries.begin() + static_cast<long>(off)),
+                    std::make_move_iterator(entries.begin() + static_cast<long>(end)));
+                auto batchResult = meta_->batchInsertContentAndIndex(chunk);
+                if (!batchResult) {
+                    spdlog::error("[PostIngestQueue] Batch DB write failed for {} documents: {}",
+                                  chunk.size(), batchResult.error().message);
+                    if (batchResult.error().message.find("database is locked") !=
+                        std::string::npos) {
+                        TuneAdvisor::reportDbLockError();
+                    }
+                    for (std::size_t i = off; i < end; ++i) {
+                        failures.push_back(ExtractionFailure{successes[i].documentId,
+                                                             successes[i].hash,
+                                                             batchResult.error().message});
+                    }
+                } else {
+                    for (std::size_t i = off; i < end; ++i) {
+                        committed.push_back(std::move(successes[i]));
+                    }
+                }
+            }
+        }
+        successes = std::move(committed);
         recordTiming("commit_content_index", contentWriteStart);
-        if (!batchResult) {
-            spdlog::error("[PostIngestQueue] Batch DB write failed: {}",
-                          batchResult.error().message);
-            if (batchResult.error().message.find("database is locked") != std::string::npos) {
-                TuneAdvisor::reportDbLockError();
-            }
-            for (const auto& prepared : successes) {
-                failures.push_back(ExtractionFailure{prepared.documentId, prepared.hash,
-                                                     batchResult.error().message});
-            }
-            successes.clear();
-        } else {
+        if (!successes.empty()) {
             spdlog::debug("[PostIngestQueue] Batch DB write succeeded for {} documents",
-                          entries.size());
+                          successes.size());
             std::vector<std::tuple<int64_t, std::string, metadata::MetadataValue>> titleUpdates;
             titleUpdates.reserve(successes.size());
             for (const auto& prepared : successes) {
@@ -3115,11 +3153,8 @@ void PostIngestQueue::commitBatchResults(std::vector<PreparedMetadataEntry>& suc
                         }
                     }
                     if (!wb->ops.empty()) {
-                        if (!writeCoordinator_->tryEnqueue(wb)) {
-                            spdlog::warn("[PostIngestQueue] WriteCoordinator queue full while "
-                                         "enqueuing title metadata; forcing enqueue");
-                            writeCoordinator_->enqueue(std::move(wb));
-                        }
+                        enqueueWithBackpressure(*writeCoordinator_, std::move(wb),
+                                                "title metadata");
                     } else {
                         spdlog::debug("[PostIngestQueue] Skipping empty title metadata batch");
                     }
@@ -3155,11 +3190,7 @@ void PostIngestQueue::commitBatchResults(std::vector<PreparedMetadataEntry>& suc
                     UpdateRepairStatusOp{std::move(failedHashes), metadata::RepairStatus::Failed});
             }
             if (!wb->ops.empty()) {
-                if (!writeCoordinator_->tryEnqueue(wb)) {
-                    spdlog::warn("[PostIngestQueue] WriteCoordinator queue full while enqueuing "
-                                 "extraction failures; forcing enqueue");
-                    writeCoordinator_->enqueue(std::move(wb));
-                }
+                enqueueWithBackpressure(*writeCoordinator_, std::move(wb), "extraction failures");
             }
         } else {
             spdlog::warn("[PostIngestQueue] WriteCoordinator unavailable; cannot mark {} "

--- a/src/daemon/components/RepairService.cpp
+++ b/src/daemon/components/RepairService.cpp
@@ -1592,6 +1592,7 @@ RepairService::recoverStuckDocumentsAsync(const RepairRequest& req, const Progre
                 doc.repairAttempts = s.repairAttempts + 1;
                 doc.repairAttemptedAt = std::chrono::time_point_cast<std::chrono::seconds>(
                     std::chrono::system_clock::now());
+                metadata::MetadataOpScope opScope("repair_attempt_update");
                 (void)meta->updateDocument(doc);
             }
 
@@ -1702,6 +1703,7 @@ RepairOperationResult RepairService::recoverStuckDocuments(const RepairRequest& 
                 doc.repairAttempts = s.repairAttempts + 1;
                 doc.repairAttemptedAt = std::chrono::time_point_cast<std::chrono::seconds>(
                     std::chrono::system_clock::now());
+                metadata::MetadataOpScope opScope("repair_attempt_update");
                 (void)meta->updateDocument(doc);
             }
 
@@ -1825,6 +1827,7 @@ RepairOperationResult RepairService::cleanOrphanedMetadata(bool dryRun, bool ver
         result.skipped = orphanedIds.size();
         result.message = "Would clean " + std::to_string(orphanedIds.size()) + " orphans";
     } else {
+        metadata::MetadataOpScope opScope("repair_orphan_cleanup");
         auto batchResult = meta->deleteDocumentsBatch(orphanedIds);
         if (batchResult) {
             result.succeeded = batchResult.value();
@@ -1942,6 +1945,7 @@ RepairOperationResult RepairService::repairMimeTypes(bool dryRun, bool verbose,
                 const bool newIsText = detector.isTextMimeType(mimeType);
                 doc.mimeType = std::move(mimeType);
 
+                metadata::MetadataOpScope opScope("repair_mime_update");
                 if (meta->updateDocument(doc)) {
                     if (oldWasText && !newIsText) {
                         (void)meta->deleteContent(id);
@@ -2047,10 +2051,13 @@ RepairOperationResult RepairService::repairDownloads(bool dryRun, bool verbose,
         doc.filePath = std::move(filename);
         doc.fileExtension = std::move(ext);
 
-        if (auto up = meta->updateDocument(doc); up) {
-            result.succeeded++;
-        } else {
-            result.failed++;
+        {
+            metadata::MetadataOpScope opScope("repair_download_url_update");
+            if (auto up = meta->updateDocument(doc); up) {
+                result.succeeded++;
+            } else {
+                result.failed++;
+            }
         }
 
         try {
@@ -2145,6 +2152,7 @@ RepairOperationResult RepairService::applySemanticDedupe(const RepairRequest& re
         if (req.dryRun) {
             result.skipped += toDelete.size();
         } else {
+            metadata::MetadataOpScope opScope("repair_dedupe_delete");
             if (!toDelete.empty()) {
                 auto batchDelete = meta->deleteDocumentsBatch(toDelete);
                 if (batchDelete) {
@@ -2902,6 +2910,7 @@ RepairOperationResult RepairService::rebuildFts5Index(const RepairRequest& req,
                     effectiveMime = bestEffortMimeForDocument(d, store);
                     auto updated = d;
                     updated.mimeType = effectiveMime;
+                    metadata::MetadataOpScope opScope("repair_mime_update");
                     (void)meta->updateDocument(updated);
                 }
 

--- a/src/daemon/components/WriteCoordinator.cpp
+++ b/src/daemon/components/WriteCoordinator.cpp
@@ -52,12 +52,19 @@ void WriteCoordinator::enqueue(std::unique_ptr<WriteBatch> batch) {
     batch->enqueueTime = std::chrono::steady_clock::now();
     {
         std::lock_guard<std::mutex> lock(queueMutex_);
+        if (stop_.load(std::memory_order_acquire)) {
+            spdlog::warn("[WriteCoordinator] Dropping batch from '{}' after shutdown requested",
+                         batch->source);
+            return;
+        }
         if (pendingBatches_.size() >= config_.channelCapacity) {
             spdlog::warn("[WriteCoordinator] Queue full ({} batches), applying backpressure",
                          pendingBatches_.size());
         }
         pendingBatches_.push_back(std::move(batch));
-        std::lock_guard<std::mutex> slock(statsMutex_);
+    }
+    {
+        std::lock_guard<std::mutex> lock(statsMutex_);
         stats_.batchesEnqueued++;
     }
     wakeWriter();
@@ -68,15 +75,16 @@ bool WriteCoordinator::tryEnqueue(std::unique_ptr<WriteBatch>& batch) {
         return false;
     {
         std::lock_guard<std::mutex> lock(queueMutex_);
-        if (pendingBatches_.size() >= config_.channelCapacity) {
+        if (stop_.load(std::memory_order_acquire) ||
+            pendingBatches_.size() >= config_.channelCapacity) {
             return false;
         }
         batch->enqueueTime = std::chrono::steady_clock::now();
         pendingBatches_.push_back(std::move(batch));
-        {
-            std::lock_guard<std::mutex> slock(statsMutex_);
-            stats_.batchesEnqueued++;
-        }
+    }
+    {
+        std::lock_guard<std::mutex> lock(statsMutex_);
+        stats_.batchesEnqueued++;
     }
     wakeWriter();
     return true;
@@ -105,8 +113,9 @@ Result<void> WriteCoordinator::flush(std::chrono::milliseconds timeout) {
     }
     auto deadline = std::chrono::steady_clock::now() + timeout;
     std::unique_lock<std::mutex> lock(queueMutex_);
-    bool drained = drainCv_.wait_until(
-        lock, deadline, [this] { return pendingBatches_.empty() && inFlight_.load() == 0; });
+    bool drained = drainCv_.wait_until(lock, deadline, [this] {
+        return pendingBatches_.empty() && inFlight_.load(std::memory_order_acquire) == 0;
+    });
     if (!drained) {
         return Error{ErrorCode::Timeout, "WriteCoordinator::flush timed out"};
     }
@@ -210,12 +219,14 @@ boost::asio::awaitable<void> WriteCoordinator::writerLoop() {
     spdlog::info("[WriteCoordinator] Writer loop started");
     auto pollTimer = wakeTimer_;
 
-    while (!stop_.load()) {
+    while (true) {
         std::vector<std::unique_ptr<WriteBatch>> batchesToProcess;
         {
             std::lock_guard<std::mutex> lock(queueMutex_);
-            if (stop_.load() && pendingBatches_.empty())
+            if (stop_.load(std::memory_order_acquire) && pendingBatches_.empty() &&
+                inFlight_.load(std::memory_order_acquire) == 0) {
                 break;
+            }
 
             std::size_t effectiveMax = std::min(config_.maxBatchSize, kMaxBatchesPerIteration);
             if (ResourceGovernor::instance().getPressureLevel() == ResourcePressureLevel::Warning) {
@@ -223,13 +234,13 @@ boost::asio::awaitable<void> WriteCoordinator::writerLoop() {
             }
             std::size_t count = std::min(pendingBatches_.size(), effectiveMax);
             if (count > 0) {
+                inFlight_.store(count, std::memory_order_release);
                 batchesToProcess.reserve(count);
                 for (std::size_t i = 0; i < count; ++i)
                     batchesToProcess.push_back(std::move(pendingBatches_[i]));
                 pendingBatches_.erase(pendingBatches_.begin(),
                                       pendingBatches_.begin() + static_cast<long>(count));
-                if (pendingBatches_.empty())
-                    drainCv_.notify_all();
+                drainCv_.notify_all();
             }
         }
 
@@ -247,7 +258,6 @@ boost::asio::awaitable<void> WriteCoordinator::writerLoop() {
             continue;
         }
 
-        inFlight_.store(batchesToProcess.size());
         spdlog::debug("[WriteCoordinator] Processing {} batches", batchesToProcess.size());
         auto result = applyBatches(batchesToProcess);
         if (!result) {
@@ -257,10 +267,10 @@ boost::asio::awaitable<void> WriteCoordinator::writerLoop() {
             }
             spdlog::warn("[WriteCoordinator] Batch apply failed: {}", result.error().message);
         }
-        inFlight_.store(0);
         bool hasPendingAfterApply = false;
         {
             std::lock_guard<std::mutex> lock(queueMutex_);
+            inFlight_.store(0, std::memory_order_release);
             hasPendingAfterApply = !pendingBatches_.empty();
             drainCv_.notify_all();
         }
@@ -285,15 +295,9 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
 
     const auto applyStart = std::chrono::steady_clock::now();
 
-    auto stopped = [this]() { return stop_.load(std::memory_order_acquire); };
-
     for (const auto& batch : batches) {
         if (!batch)
             continue;
-        if (stopped()) {
-            spdlog::info("[WriteCoordinator] applyBatches aborted (stop requested)");
-            return Result<void>();
-        }
         const auto waitMs = static_cast<std::uint64_t>(
             std::chrono::duration_cast<std::chrono::milliseconds>(applyStart - batch->enqueueTime)
                 .count());
@@ -333,7 +337,7 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
     std::unordered_map<std::string, std::int64_t> nodeKeyToId;
     std::optional<Error> firstOpError;
 
-    if (hasKgOps && kg_ && !stopped()) {
+    if (hasKgOps && kg_) {
         auto batchResult = kg_->beginWriteBatch();
         if (!batchResult) {
             spdlog::error("[WriteCoordinator] beginWriteBatch failed: {}",
@@ -382,11 +386,13 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
                                          r.error().message);
                         } else {
                             sourceOps++;
-                            std::lock_guard<std::mutex> lock(statsMutex_);
-                            stats_.opsApplied++;
                         }
                     },
                     op);
+            }
+            if (sourceOps > 0) {
+                std::lock_guard<std::mutex> lock(statsMutex_);
+                stats_.opsApplied += sourceOps;
             }
             const auto sourceApplyMs =
                 static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -415,7 +421,7 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
         }
     }
 
-    if (hasMetaOps && meta_ && !stopped()) {
+    if (hasMetaOps && meta_) {
         struct RepairStatusGroup {
             std::string source;
             metadata::RepairStatus status;
@@ -439,6 +445,8 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
         std::unordered_map<std::string, RepairStatusGroup> repairStatusBySourceAndStatus;
         std::unordered_map<std::string, EmbeddingStatusGroup> embeddingStatusBySourceAndState;
         std::unordered_map<std::string, ExtractionStatusGroup> extractionStatusBySource;
+        std::unordered_map<std::string, std::unordered_map<std::string, std::int64_t>>
+            symspellTermsBySource;
 
         auto recordMetaApply = [&](const std::string& source, std::uint64_t sourceOps,
                                    std::uint64_t sourceApplyMs, bool sourceError) {
@@ -464,8 +472,18 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
                         if constexpr (std::is_same_v<T, InsertDocumentOp> ||
                                       std::is_same_v<T, UpsertTreeSnapshotOp> ||
                                       std::is_same_v<T, InsertRelationshipOp> ||
-                                      std::is_same_v<T, AddSymSpellTermsOp>) {
+                                      std::is_same_v<T, UpsertSymbolExtractionStateOp>) {
                             r = applyMetadataOp(concrete);
+                        } else if constexpr (std::is_same_v<T, AddSymSpellTermsOp>) {
+                            if (concrete.terms.empty())
+                                return;
+                            auto& termFreqs = symspellTermsBySource[batch->source];
+                            for (auto& term : concrete.terms) {
+                                if (!term.empty())
+                                    termFreqs[std::move(term)]++;
+                            }
+                            concrete.terms.clear();
+                            return;
                         } else if constexpr (std::is_same_v<T, UpdateRepairStatusOp>) {
                             if (concrete.hashes.empty())
                                 return;
@@ -532,12 +550,6 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
                                                 std::make_move_iterator(concrete.hashes.end()));
                             concrete.hashes.clear();
                             return;
-                        } else if constexpr (std::is_same_v<T, UpsertSymbolExtractionStateOp>) {
-                            r = applyMetadataOp(concrete);
-                            if (!r &&
-                                r.error().message.find("database is locked") != std::string::npos) {
-                                return;
-                            }
                         } else {
                             return;
                         }
@@ -547,117 +559,157 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
                                          batch->source, r.error().message);
                         } else {
                             sourceOps++;
-                            std::lock_guard<std::mutex> lock(statsMutex_);
-                            stats_.opsApplied++;
                         }
                     },
                     op);
+            }
+            if (sourceOps > 0) {
+                std::lock_guard<std::mutex> lock(statsMutex_);
+                stats_.opsApplied += sourceOps;
             }
             const auto sourceApplyMs =
                 static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
                                                std::chrono::steady_clock::now() - sourceStart)
                                                .count());
             recordMetaApply(batch->source, sourceOps, sourceApplyMs, sourceError);
-            if (stopped()) {
-                spdlog::info("[WriteCoordinator] applyBatches meta scan aborted (stop requested)");
-                return Result<void>();
-            }
         }
 
+        const auto chunkMax = std::max<std::size_t>(1, config_.maxCoalescedOpsPerApply);
+
         for (auto& [_, group] : extractionStatusBySource) {
-            if (stopped()) {
-                spdlog::info("[WriteCoordinator] applyBatches extraction coalesce aborted "
-                             "(stop requested)");
-                return Result<void>();
+            for (std::size_t off = 0; off < group.updates.size(); off += chunkMax) {
+                const auto end = std::min(group.updates.size(), off + chunkMax);
+                std::vector<metadata::ExtractionStatusUpdate> chunk(
+                    std::make_move_iterator(group.updates.begin() + static_cast<long>(off)),
+                    std::make_move_iterator(group.updates.begin() + static_cast<long>(end)));
+                const auto sourceStart = std::chrono::steady_clock::now();
+                const auto updateCount = static_cast<std::uint64_t>(chunk.size());
+                metadata::MetadataOpScope opScope("wc_extraction_status_batch");
+                auto r = meta_->batchUpdateDocumentExtractionStatuses(chunk);
+                const auto sourceApplyMs = static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - sourceStart)
+                        .count());
+                if (!r) {
+                    spdlog::warn(
+                        "[WriteCoordinator] coalesced extraction-status op '{}' failed: {}",
+                        group.source, r.error().message);
+                } else {
+                    std::lock_guard<std::mutex> lock(statsMutex_);
+                    stats_.opsApplied += updateCount;
+                    stats_.extractionStatusesUpdated += updateCount;
+                }
+                recordMetaApply(group.source, updateCount, sourceApplyMs, !r);
             }
-            if (group.updates.empty()) {
-                continue;
-            }
-            const auto sourceStart = std::chrono::steady_clock::now();
-            const auto updateCount = static_cast<std::uint64_t>(group.updates.size());
-            auto r = meta_->batchUpdateDocumentExtractionStatuses(group.updates);
-            const auto sourceApplyMs =
-                static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
-                                               std::chrono::steady_clock::now() - sourceStart)
-                                               .count());
-            if (!r) {
-                spdlog::warn("[WriteCoordinator] coalesced extraction-status op '{}' failed: {}",
-                             group.source, r.error().message);
-            } else {
-                std::lock_guard<std::mutex> lock(statsMutex_);
-                stats_.opsApplied += updateCount;
-                stats_.extractionStatusesUpdated += updateCount;
-            }
-            recordMetaApply(group.source, updateCount, sourceApplyMs, !r);
         }
 
         for (auto& [source, entries] : metadataBySource) {
-            if (stopped()) {
-                spdlog::info(
-                    "[WriteCoordinator] applyBatches meta coalesce aborted (stop requested)");
-                return Result<void>();
+            for (std::size_t off = 0; off < entries.size(); off += chunkMax) {
+                const auto end = std::min(entries.size(), off + chunkMax);
+                const auto sourceStart = std::chrono::steady_clock::now();
+                SetMetadataBatchOp op{
+                    std::vector<std::tuple<std::int64_t, std::string, metadata::MetadataValue>>(
+                        std::make_move_iterator(entries.begin() + static_cast<long>(off)),
+                        std::make_move_iterator(entries.begin() + static_cast<long>(end)))};
+                const auto entryCount = static_cast<std::uint64_t>(op.entries.size());
+                auto r = applyMetadataOp(op);
+                const auto sourceApplyMs = static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - sourceStart)
+                        .count());
+                if (!r) {
+                    spdlog::warn("[WriteCoordinator] coalesced meta op '{}' failed: {}", source,
+                                 r.error().message);
+                } else {
+                    std::lock_guard<std::mutex> lock(statsMutex_);
+                    stats_.opsApplied += entryCount;
+                }
+                recordMetaApply(source, entryCount, sourceApplyMs, !r);
             }
-            const auto sourceStart = std::chrono::steady_clock::now();
-            const auto entryCount = static_cast<std::uint64_t>(entries.size());
-            SetMetadataBatchOp op{std::move(entries)};
-            auto r = applyMetadataOp(op);
-            const auto sourceApplyMs =
-                static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
-                                               std::chrono::steady_clock::now() - sourceStart)
-                                               .count());
-            if (!r) {
-                spdlog::warn("[WriteCoordinator] coalesced meta op '{}' failed: {}", source,
-                             r.error().message);
-            } else {
-                std::lock_guard<std::mutex> lock(statsMutex_);
-                stats_.opsApplied += entryCount;
-            }
-            recordMetaApply(source, entryCount, sourceApplyMs, !r);
         }
 
         for (auto& [_, group] : repairStatusBySourceAndStatus) {
-            if (group.hashes.empty()) {
-                continue;
+            for (std::size_t off = 0; off < group.hashes.size(); off += chunkMax) {
+                const auto end = std::min(group.hashes.size(), off + chunkMax);
+                const auto sourceStart = std::chrono::steady_clock::now();
+                UpdateRepairStatusOp op{
+                    std::vector<std::string>(
+                        std::make_move_iterator(group.hashes.begin() + static_cast<long>(off)),
+                        std::make_move_iterator(group.hashes.begin() + static_cast<long>(end))),
+                    group.status};
+                const auto hashCount = static_cast<std::uint64_t>(op.hashes.size());
+                auto r = applyMetadataOp(op);
+                const auto sourceApplyMs = static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - sourceStart)
+                        .count());
+                if (!r) {
+                    spdlog::warn("[WriteCoordinator] coalesced repair-status op '{}' failed: {}",
+                                 group.source, r.error().message);
+                } else {
+                    std::lock_guard<std::mutex> lock(statsMutex_);
+                    stats_.opsApplied += hashCount;
+                }
+                recordMetaApply(group.source, hashCount, sourceApplyMs, !r);
             }
-            const auto sourceStart = std::chrono::steady_clock::now();
-            const auto hashCount = static_cast<std::uint64_t>(group.hashes.size());
-            UpdateRepairStatusOp op{std::move(group.hashes), group.status};
-            auto r = applyMetadataOp(op);
-            const auto sourceApplyMs =
-                static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
-                                               std::chrono::steady_clock::now() - sourceStart)
-                                               .count());
-            if (!r) {
-                spdlog::warn("[WriteCoordinator] coalesced repair-status op '{}' failed: {}",
-                             group.source, r.error().message);
-            } else {
-                std::lock_guard<std::mutex> lock(statsMutex_);
-                stats_.opsApplied += hashCount;
-            }
-            recordMetaApply(group.source, hashCount, sourceApplyMs, !r);
         }
 
         for (auto& [_, group] : embeddingStatusBySourceAndState) {
-            if (group.hashes.empty()) {
+            for (std::size_t off = 0; off < group.hashes.size(); off += chunkMax) {
+                const auto end = std::min(group.hashes.size(), off + chunkMax);
+                const auto sourceStart = std::chrono::steady_clock::now();
+                UpdateEmbeddingStatusByHashesOp op{
+                    std::vector<std::string>(
+                        std::make_move_iterator(group.hashes.begin() + static_cast<long>(off)),
+                        std::make_move_iterator(group.hashes.begin() + static_cast<long>(end))),
+                    group.embedded, group.modelName};
+                const auto hashCount = static_cast<std::uint64_t>(op.hashes.size());
+                auto r = applyMetadataOp(op);
+                const auto sourceApplyMs = static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - sourceStart)
+                        .count());
+                if (!r) {
+                    spdlog::warn("[WriteCoordinator] coalesced embedding-status op '{}' failed: {}",
+                                 group.source, r.error().message);
+                } else {
+                    std::lock_guard<std::mutex> lock(statsMutex_);
+                    stats_.opsApplied += hashCount;
+                }
+                recordMetaApply(group.source, hashCount, sourceApplyMs, !r);
+            }
+        }
+
+        for (auto& [source, termFreqs] : symspellTermsBySource) {
+            if (termFreqs.empty()) {
                 continue;
             }
             const auto sourceStart = std::chrono::steady_clock::now();
-            const auto hashCount = static_cast<std::uint64_t>(group.hashes.size());
-            UpdateEmbeddingStatusByHashesOp op{std::move(group.hashes), group.embedded,
-                                               std::move(group.modelName)};
-            auto r = applyMetadataOp(op);
+            std::vector<std::pair<std::string, std::int64_t>> termPairs;
+            termPairs.reserve(termFreqs.size());
+            std::uint64_t termAddCount = 0;
+            for (auto& [term, freq] : termFreqs) {
+                termPairs.emplace_back(term, freq);
+                termAddCount += static_cast<std::uint64_t>(freq);
+            }
+            Result<void> r;
+            {
+                metadata::MetadataOpScope opScope("wc_symspell_terms");
+                r = meta_->tryAddSymSpellTerms(termPairs);
+            }
             const auto sourceApplyMs =
                 static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
                                                std::chrono::steady_clock::now() - sourceStart)
                                                .count());
             if (!r) {
-                spdlog::warn("[WriteCoordinator] coalesced embedding-status op '{}' failed: {}",
-                             group.source, r.error().message);
+                spdlog::warn("[WriteCoordinator] coalesced SymSpell op '{}' failed: {}", source,
+                             r.error().message);
             } else {
                 std::lock_guard<std::mutex> lock(statsMutex_);
-                stats_.opsApplied += hashCount;
+                stats_.opsApplied += termAddCount;
+                stats_.symSpellTermsAdded += termAddCount;
             }
-            recordMetaApply(group.source, hashCount, sourceApplyMs, !r);
+            recordMetaApply(source, termAddCount, sourceApplyMs, !r);
         }
     }
 
@@ -935,6 +987,7 @@ Result<void> WriteCoordinator::applyOp(metadata::KnowledgeGraphStore::WriteBatch
 Result<void> WriteCoordinator::applyMetadataOp(InsertDocumentOp& op) {
     if (!meta_)
         return Error{ErrorCode::InvalidState, "MetadataRepository unavailable"};
+    metadata::MetadataOpScope opScope("wc_insert_document");
     metadata::TreeSnapshotRecord* snapshotPtr =
         op.snapshot.has_value() ? &op.snapshot.value() : nullptr;
     auto r = meta_->insertDocumentWithMetadata(op.info, op.tags, snapshotPtr);
@@ -954,6 +1007,7 @@ Result<void> WriteCoordinator::applyMetadataOp(UpdateRepairStatusOp& op) {
         return Error{ErrorCode::InvalidState, "MetadataRepository unavailable"};
     if (op.hashes.empty())
         return Result<void>();
+    metadata::MetadataOpScope opScope("wc_repair_status_batch");
     auto r = meta_->batchUpdateDocumentRepairStatuses(op.hashes, op.status);
     if (r) {
         std::lock_guard<std::mutex> lock(statsMutex_);
@@ -965,6 +1019,7 @@ Result<void> WriteCoordinator::applyMetadataOp(UpdateRepairStatusOp& op) {
 Result<void> WriteCoordinator::applyMetadataOp(UpsertTreeSnapshotOp& op) {
     if (!meta_)
         return Error{ErrorCode::InvalidState, "MetadataRepository unavailable"};
+    metadata::MetadataOpScope opScope("wc_tree_snapshot");
     auto r = meta_->upsertTreeSnapshot(op.record);
     if (r) {
         std::lock_guard<std::mutex> lock(statsMutex_);
@@ -978,6 +1033,7 @@ Result<void> WriteCoordinator::applyMetadataOp(SetMetadataBatchOp& op) {
         return Error{ErrorCode::InvalidState, "MetadataRepository unavailable"};
     if (op.entries.empty())
         return Result<void>();
+    metadata::MetadataOpScope opScope("wc_set_metadata_batch");
     auto r = meta_->setMetadataBatch(op.entries);
     if (r) {
         std::lock_guard<std::mutex> lock(statsMutex_);
@@ -989,6 +1045,7 @@ Result<void> WriteCoordinator::applyMetadataOp(SetMetadataBatchOp& op) {
 Result<void> WriteCoordinator::applyMetadataOp(UpdateExtractionStatusOp& op) {
     if (!meta_)
         return Error{ErrorCode::InvalidState, "MetadataRepository unavailable"};
+    metadata::MetadataOpScope opScope("wc_extraction_status");
     auto r = meta_->updateDocumentExtractionStatus(op.documentId, op.contentExtracted, op.status,
                                                    op.error);
     if (r) {
@@ -1001,6 +1058,7 @@ Result<void> WriteCoordinator::applyMetadataOp(UpdateExtractionStatusOp& op) {
 Result<void> WriteCoordinator::applyMetadataOp(UpdateEmbeddingStatusByHashOp& op) {
     if (!meta_)
         return Error{ErrorCode::InvalidState, "MetadataRepository unavailable"};
+    metadata::MetadataOpScope opScope("wc_embedding_status");
     auto r = meta_->updateDocumentEmbeddingStatusByHash(op.hash, op.embedded, op.modelName);
     if (r) {
         std::lock_guard<std::mutex> lock(statsMutex_);
@@ -1014,6 +1072,7 @@ Result<void> WriteCoordinator::applyMetadataOp(UpdateEmbeddingStatusByHashesOp& 
         return Error{ErrorCode::InvalidState, "MetadataRepository unavailable"};
     if (op.hashes.empty())
         return Result<void>();
+    metadata::MetadataOpScope opScope("wc_embedding_status_batch");
     auto r =
         meta_->batchUpdateDocumentEmbeddingStatusByHashes(op.hashes, op.embedded, op.modelName);
     if (r) {
@@ -1039,6 +1098,7 @@ Result<void> WriteCoordinator::applyMetadataOp(UpsertSymbolExtractionStateOp& op
 Result<void> WriteCoordinator::applyMetadataOp(InsertRelationshipOp& op) {
     if (!meta_)
         return Error{ErrorCode::InvalidState, "MetadataRepository unavailable"};
+    metadata::MetadataOpScope opScope("wc_insert_relationship");
     auto r = meta_->insertRelationship(op.relationship);
     if (!r)
         return r.error();
@@ -1054,8 +1114,12 @@ Result<void> WriteCoordinator::applyMetadataOp(AddSymSpellTermsOp& op) {
         return Error{ErrorCode::InvalidState, "MetadataRepository unavailable"};
     if (op.terms.empty())
         return Result<void>();
+    metadata::MetadataOpScope opScope("wc_symspell_terms");
     const auto termCount = op.terms.size();
-    meta_->addSymSpellTerms(op.terms);
+    auto r = meta_->tryAddSymSpellTerms(op.terms);
+    if (!r) {
+        return r.error();
+    }
     {
         std::lock_guard<std::mutex> lock(statsMutex_);
         stats_.symSpellTermsAdded += termCount;

--- a/src/daemon/components/WriteCoordinator.cpp
+++ b/src/daemon/components/WriteCoordinator.cpp
@@ -4,6 +4,7 @@
 #include <yams/daemon/components/TuningSnapshot.h>
 #include <yams/daemon/components/WriteCoordinator.h>
 #include <yams/metadata/metadata_repository.h>
+#include <yams/profiling.h>
 
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
@@ -47,6 +48,7 @@ WriteCoordinator::~WriteCoordinator() {
 }
 
 void WriteCoordinator::enqueue(std::unique_ptr<WriteBatch> batch) {
+    YAMS_ZONE_SCOPED_N("WriteCoordinator::enqueue");
     if (!batch)
         return;
     batch->enqueueTime = std::chrono::steady_clock::now();
@@ -62,6 +64,7 @@ void WriteCoordinator::enqueue(std::unique_ptr<WriteBatch> batch) {
                          pendingBatches_.size());
         }
         pendingBatches_.push_back(std::move(batch));
+        YAMS_PLOT("wc.queue.depth", static_cast<int64_t>(pendingBatches_.size()));
     }
     {
         std::lock_guard<std::mutex> lock(statsMutex_);
@@ -71,6 +74,7 @@ void WriteCoordinator::enqueue(std::unique_ptr<WriteBatch> batch) {
 }
 
 bool WriteCoordinator::tryEnqueue(std::unique_ptr<WriteBatch>& batch) {
+    YAMS_ZONE_SCOPED_N("WriteCoordinator::tryEnqueue");
     if (!batch)
         return false;
     {
@@ -81,6 +85,7 @@ bool WriteCoordinator::tryEnqueue(std::unique_ptr<WriteBatch>& batch) {
         }
         batch->enqueueTime = std::chrono::steady_clock::now();
         pendingBatches_.push_back(std::move(batch));
+        YAMS_PLOT("wc.queue.depth", static_cast<int64_t>(pendingBatches_.size()));
     }
     {
         std::lock_guard<std::mutex> lock(statsMutex_);
@@ -108,6 +113,7 @@ void WriteCoordinator::start() {
 }
 
 Result<void> WriteCoordinator::flush(std::chrono::milliseconds timeout) {
+    YAMS_ZONE_SCOPED_N("WriteCoordinator::flush");
     if (stop_.load()) {
         return Error{ErrorCode::InvalidState, "WriteCoordinator is shutting down"};
     }
@@ -216,6 +222,7 @@ void WriteCoordinator::recordSourceApply(const std::string& source, std::uint64_
 }
 
 boost::asio::awaitable<void> WriteCoordinator::writerLoop() {
+    YAMS_SET_THREAD_NAME("yams-write-coordinator");
     spdlog::info("[WriteCoordinator] Writer loop started");
     auto pollTimer = wakeTimer_;
 
@@ -234,6 +241,10 @@ boost::asio::awaitable<void> WriteCoordinator::writerLoop() {
             }
             std::size_t count = std::min(pendingBatches_.size(), effectiveMax);
             if (count > 0) {
+                YAMS_ZONE_SCOPED_N("WriteCoordinator::dequeue");
+                YAMS_PLOT("wc.dequeue.batch_count", static_cast<int64_t>(count));
+                YAMS_PLOT("wc.queue.depth_after_dequeue",
+                          static_cast<int64_t>(pendingBatches_.size() - count));
                 inFlight_.store(count, std::memory_order_release);
                 batchesToProcess.reserve(count);
                 for (std::size_t i = 0; i < count; ++i)
@@ -259,6 +270,7 @@ boost::asio::awaitable<void> WriteCoordinator::writerLoop() {
         }
 
         spdlog::debug("[WriteCoordinator] Processing {} batches", batchesToProcess.size());
+        YAMS_PLOT("wc.in_flight.batches", static_cast<int64_t>(batchesToProcess.size()));
         auto result = applyBatches(batchesToProcess);
         if (!result) {
             {
@@ -289,6 +301,8 @@ boost::asio::awaitable<void> WriteCoordinator::writerLoop() {
 }
 
 Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBatch>>& batches) {
+    YAMS_ZONE_SCOPED_N("WriteCoordinator::applyBatches");
+    YAMS_PLOT("wc.apply.batch_count", static_cast<int64_t>(batches.size()));
     if (batches.empty()) {
         return Result<void>();
     }
@@ -302,6 +316,7 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
             std::chrono::duration_cast<std::chrono::milliseconds>(applyStart - batch->enqueueTime)
                 .count());
         recordSourceQueueWait(batch->source, waitMs);
+        YAMS_PLOT("wc.queue.wait_ms", static_cast<int64_t>(waitMs));
         if (waitMs >= 1000) {
             spdlog::warn("[WriteCoordinator] slow queue wait source='{}' wait_ms={} ops={}",
                          batch->source, waitMs, batch->ops.size());
@@ -338,6 +353,7 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
     std::optional<Error> firstOpError;
 
     if (hasKgOps && kg_) {
+        YAMS_ZONE_SCOPED_N("WriteCoordinator::applyKG");
         auto batchResult = kg_->beginWriteBatch();
         if (!batchResult) {
             spdlog::error("[WriteCoordinator] beginWriteBatch failed: {}",
@@ -422,6 +438,7 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
     }
 
     if (hasMetaOps && meta_) {
+        YAMS_ZONE_SCOPED_N("WriteCoordinator::applyMetadata");
         struct RepairStatusGroup {
             std::string source;
             metadata::RepairStatus status;
@@ -578,12 +595,14 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
 
         for (auto& [_, group] : extractionStatusBySource) {
             for (std::size_t off = 0; off < group.updates.size(); off += chunkMax) {
+                YAMS_ZONE_SCOPED_N("WriteCoordinator::coalesceExtractionStatus");
                 const auto end = std::min(group.updates.size(), off + chunkMax);
                 std::vector<metadata::ExtractionStatusUpdate> chunk(
                     std::make_move_iterator(group.updates.begin() + static_cast<long>(off)),
                     std::make_move_iterator(group.updates.begin() + static_cast<long>(end)));
                 const auto sourceStart = std::chrono::steady_clock::now();
                 const auto updateCount = static_cast<std::uint64_t>(chunk.size());
+                YAMS_PLOT("wc.coalesce.extraction_status", static_cast<int64_t>(updateCount));
                 metadata::MetadataOpScope opScope("wc_extraction_status_batch");
                 auto r = meta_->batchUpdateDocumentExtractionStatuses(chunk);
                 const auto sourceApplyMs = static_cast<std::uint64_t>(
@@ -605,6 +624,7 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
 
         for (auto& [source, entries] : metadataBySource) {
             for (std::size_t off = 0; off < entries.size(); off += chunkMax) {
+                YAMS_ZONE_SCOPED_N("WriteCoordinator::coalesceMetadata");
                 const auto end = std::min(entries.size(), off + chunkMax);
                 const auto sourceStart = std::chrono::steady_clock::now();
                 SetMetadataBatchOp op{
@@ -612,6 +632,7 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
                         std::make_move_iterator(entries.begin() + static_cast<long>(off)),
                         std::make_move_iterator(entries.begin() + static_cast<long>(end)))};
                 const auto entryCount = static_cast<std::uint64_t>(op.entries.size());
+                YAMS_PLOT("wc.coalesce.metadata_entries", static_cast<int64_t>(entryCount));
                 auto r = applyMetadataOp(op);
                 const auto sourceApplyMs = static_cast<std::uint64_t>(
                     std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -630,6 +651,7 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
 
         for (auto& [_, group] : repairStatusBySourceAndStatus) {
             for (std::size_t off = 0; off < group.hashes.size(); off += chunkMax) {
+                YAMS_ZONE_SCOPED_N("WriteCoordinator::coalesceRepairStatus");
                 const auto end = std::min(group.hashes.size(), off + chunkMax);
                 const auto sourceStart = std::chrono::steady_clock::now();
                 UpdateRepairStatusOp op{
@@ -638,6 +660,7 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
                         std::make_move_iterator(group.hashes.begin() + static_cast<long>(end))),
                     group.status};
                 const auto hashCount = static_cast<std::uint64_t>(op.hashes.size());
+                YAMS_PLOT("wc.coalesce.repair_status", static_cast<int64_t>(hashCount));
                 auto r = applyMetadataOp(op);
                 const auto sourceApplyMs = static_cast<std::uint64_t>(
                     std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -656,6 +679,7 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
 
         for (auto& [_, group] : embeddingStatusBySourceAndState) {
             for (std::size_t off = 0; off < group.hashes.size(); off += chunkMax) {
+                YAMS_ZONE_SCOPED_N("WriteCoordinator::coalesceEmbeddingStatus");
                 const auto end = std::min(group.hashes.size(), off + chunkMax);
                 const auto sourceStart = std::chrono::steady_clock::now();
                 UpdateEmbeddingStatusByHashesOp op{
@@ -664,6 +688,7 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
                         std::make_move_iterator(group.hashes.begin() + static_cast<long>(end))),
                     group.embedded, group.modelName};
                 const auto hashCount = static_cast<std::uint64_t>(op.hashes.size());
+                YAMS_PLOT("wc.coalesce.embedding_status", static_cast<int64_t>(hashCount));
                 auto r = applyMetadataOp(op);
                 const auto sourceApplyMs = static_cast<std::uint64_t>(
                     std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -681,6 +706,7 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
         }
 
         for (auto& [source, termFreqs] : symspellTermsBySource) {
+            YAMS_ZONE_SCOPED_N("WriteCoordinator::coalesceSymSpell");
             if (termFreqs.empty()) {
                 continue;
             }
@@ -692,6 +718,8 @@ Result<void> WriteCoordinator::applyBatches(std::vector<std::unique_ptr<WriteBat
                 termPairs.emplace_back(term, freq);
                 termAddCount += static_cast<std::uint64_t>(freq);
             }
+            YAMS_PLOT("wc.coalesce.symspell_unique_terms", static_cast<int64_t>(termPairs.size()));
+            YAMS_PLOT("wc.coalesce.symspell_total_terms", static_cast<int64_t>(termAddCount));
             Result<void> r;
             {
                 metadata::MetadataOpScope opScope("wc_symspell_terms");

--- a/src/manifest/manifest_manager.cpp
+++ b/src/manifest/manifest_manager.cpp
@@ -18,7 +18,9 @@ namespace yamsfmt = fmt;
 #include <fstream>
 #include <limits>
 #include <mutex>
+#include <span>
 #include <thread>
+#include <type_traits>
 
 // Include generated protobuf headers
 #ifdef YAMS_USE_PROTOBUF
@@ -46,8 +48,10 @@ std::optional<uint32_t> checkedU32(std::size_t value) {
 }
 
 template <typename T> void appendPod(std::vector<std::byte>& out, const T& value) {
-    const auto* begin = reinterpret_cast<const std::byte*>(&value);
-    out.insert(out.end(), begin, begin + sizeof(T));
+    static_assert(std::is_trivially_copyable_v<T>,
+                  "appendPod requires a trivially copyable type");
+    const auto bytes = std::as_bytes(std::span<const T, 1>{&value, 1});
+    out.insert(out.end(), bytes.begin(), bytes.end());
 }
 
 bool appendString(std::vector<std::byte>& out, const std::string& value) {
@@ -56,8 +60,8 @@ bool appendString(std::vector<std::byte>& out, const std::string& value) {
         return false;
     }
     appendPod(out, *length);
-    const auto* begin = reinterpret_cast<const std::byte*>(value.data());
-    out.insert(out.end(), begin, begin + value.size());
+    const auto bytes = std::as_bytes(std::span{value.data(), value.size()});
+    out.insert(out.end(), bytes.begin(), bytes.end());
     return true;
 }
 
@@ -257,8 +261,8 @@ Result<std::vector<std::byte>> ManifestManager::serialize(const Manifest& manife
 
         // Magic header: "YAMS" + version
         const uint8_t magic[] = {'Y', 'A', 'M', 'S'};
-        result.insert(result.end(), reinterpret_cast<const std::byte*>(magic),
-                      reinterpret_cast<const std::byte*>(magic) + 4);
+        const auto magicBytes = std::as_bytes(std::span{magic});
+        result.insert(result.end(), magicBytes.begin(), magicBytes.end());
 
         // Version (4 bytes)
         uint32_t version = manifest.version;

--- a/src/metadata/metadata_repository.cpp
+++ b/src/metadata/metadata_repository.cpp
@@ -3073,10 +3073,15 @@ void MetadataRepository::addSymSpellTerm(std::string_view term, int64_t frequenc
 }
 
 void MetadataRepository::addSymSpellTerms(const std::vector<std::string>& terms) {
-    if (terms.empty()) {
-        return;
-    }
+    (void)tryAddSymSpellTerms(terms);
+}
 
+void MetadataRepository::addSymSpellTerms(
+    const std::vector<std::pair<std::string, int64_t>>& terms) {
+    (void)tryAddSymSpellTerms(terms);
+}
+
+Result<void> MetadataRepository::tryAddSymSpellTerms(const std::vector<std::string>& terms) {
     std::vector<std::pair<std::string, int64_t>> batch;
     batch.reserve(terms.size());
     for (const auto& term : terms) {
@@ -3084,28 +3089,52 @@ void MetadataRepository::addSymSpellTerms(const std::vector<std::string>& terms)
             batch.emplace_back(term, 1);
         }
     }
-    if (batch.empty()) {
-        return;
-    }
+    return tryAddSymSpellTerms(batch);
+}
 
-    auto result = executeWriteQuery<void>([&](Database& db) -> Result<void> {
-        sqlite3* rawDb = db.rawHandle();
-        if (!rawDb) {
-            return Error{ErrorCode::DatabaseError, "Failed to get raw SQLite handle"};
+Result<void>
+MetadataRepository::tryAddSymSpellTerms(const std::vector<std::pair<std::string, int64_t>>& terms) {
+    std::vector<std::pair<std::string, int64_t>> filtered;
+    filtered.reserve(terms.size());
+    for (const auto& [term, frequency] : terms) {
+        if (!term.empty() && frequency > 0) {
+            filtered.emplace_back(term, frequency);
         }
-        auto schemaResult = search::SymSpellSearch::initializeSchema(rawDb);
-        if (!schemaResult) {
-            return schemaResult.error();
-        }
-        search::SymSpellSearch writer(rawDb);
-        writer.addTermsBatch(batch);
+    }
+    if (filtered.empty()) {
         return Result<void>();
-    });
-
-    if (!result) {
-        spdlog::warn("SymSpell term batch write failed for {} terms: {}", batch.size(),
-                     result.error().message);
     }
+
+    constexpr std::size_t kTermsPerChunk = 512;
+
+    for (std::size_t offset = 0; offset < filtered.size(); offset += kTermsPerChunk) {
+        const std::size_t end = std::min(filtered.size(), offset + kTermsPerChunk);
+        std::vector<std::pair<std::string, int64_t>> chunk(filtered.begin() + offset,
+                                                           filtered.begin() + end);
+        auto result = executeWriteQuery<void>([&](Database& db) -> Result<void> {
+            sqlite3* rawDb = db.rawHandle();
+            if (!rawDb) {
+                return Error{ErrorCode::DatabaseError, "Failed to get raw SQLite handle"};
+            }
+            if (!symspellSchemaReady_.load(std::memory_order_acquire)) {
+                auto schemaResult = search::SymSpellSearch::initializeSchema(rawDb);
+                if (!schemaResult) {
+                    return schemaResult.error();
+                }
+                symspellSchemaReady_.store(true, std::memory_order_release);
+            }
+            search::SymSpellSearch writer(rawDb);
+            writer.addTermsBatch(chunk);
+            return Result<void>();
+        });
+
+        if (!result) {
+            spdlog::warn("SymSpell term batch write failed for {} terms: {}", chunk.size(),
+                         result.error().message);
+            return result.error();
+        }
+    }
+    return Result<void>();
 }
 
 // =============================================================================

--- a/src/metadata/metadata_repository.cpp
+++ b/src/metadata/metadata_repository.cpp
@@ -689,79 +689,122 @@ MetadataRepository::batchInsertContentAndIndex(const std::vector<BatchContentEnt
         bool priorStateKnown = false;
         bool priorContentExtracted = false;
     };
+    struct BatchContentPhaseTimings {
+        int64_t prepareInputUs{0};
+        int64_t transactionUs{0};
+        int64_t beginUs{0};
+        int64_t detectFtsUs{0};
+        int64_t prepareStatementsUs{0};
+        int64_t precheckUs{0};
+        int64_t contentUpsertUs{0};
+        int64_t ftsUpsertUs{0};
+        int64_t statusUpdateUs{0};
+        int64_t commitUs{0};
+        std::size_t prechecks{0};
+        std::size_t contentUpserts{0};
+        std::size_t ftsUpserts{0};
+        std::size_t statusUpdates{0};
+        std::size_t staleSkipped{0};
+    };
+
+    const bool traceBatchContent = metadata_trace_enabled();
+#ifdef TRACY_ENABLE
+    constexpr bool kCollectBatchContentTimingForTracy = true;
+#else
+    constexpr bool kCollectBatchContentTimingForTracy = false;
+#endif
+    const bool collectBatchContentTiming = traceBatchContent || kCollectBatchContentTimingForTracy;
+    BatchContentPhaseTimings phaseTimings;
+    auto addElapsedUs = [&](int64_t& target, std::chrono::steady_clock::time_point start) {
+        if (collectBatchContentTiming) {
+            target += std::chrono::duration_cast<std::chrono::microseconds>(
+                          std::chrono::steady_clock::now() - start)
+                          .count();
+        }
+    };
 
     constexpr size_t kMaxTextBytes = size_t{16} * 1024 * 1024; // 16 MiB
     constexpr std::size_t kMaxBoostedBytes = kMaxTextBytes;
     std::vector<PreparedBatchContentEntry> preparedEntries;
     preparedEntries.reserve(entries.size());
-    for (const auto& entry : entries) {
-        YAMS_DCHECK(entry.documentId != 0,
-                    "batch content entry should target a persisted document");
+    const auto prepareStart = std::chrono::steady_clock::now();
+    {
+        YAMS_ZONE_SCOPED_N("MetadataRepo::batchContentPrepare");
+        for (const auto& entry : entries) {
+            YAMS_DCHECK(entry.documentId != 0,
+                        "batch content entry should target a persisted document");
 
-        std::string_view contentView = entry.contentText;
-        if (contentView.size() > kMaxTextBytes) {
-            contentView = contentView.substr(0, kMaxTextBytes);
-        }
-
-        // Sanitize and build the boosted FTS payload before taking the write transaction so
-        // contention is dominated by SQLite work, not per-entry UTF-8 cleanup/string assembly.
-        preparedEntries.emplace_back();
-        auto& prepared = preparedEntries.back();
-        prepared.documentId = entry.documentId;
-        prepared.extractionMethod = entry.extractionMethod;
-        prepared.language = entry.language;
-        prepared.priorStateKnown = entry.priorStateKnown;
-        prepared.priorContentExtracted = entry.priorContentExtracted;
-
-        std::string contentStorage;
-        prepared.sanitizedContent = common::ensureValidUtf8(contentView, contentStorage);
-
-        std::string titleStorage;
-        prepared.sanitizedTitle = common::ensureValidUtf8(entry.title, titleStorage);
-
-        prepared.boostedContent.reserve(
-            std::min<std::size_t>(prepared.sanitizedContent.size() + 512, kMaxBoostedBytes));
-        auto append_repeated = [&](std::string_view text, int times) {
-            if (text.empty())
-                return;
-            for (int t = 0; t < times; ++t) {
-                if (prepared.boostedContent.size() >= kMaxBoostedBytes)
-                    break;
-                if (!prepared.boostedContent.empty() && prepared.boostedContent.back() != ' ') {
-                    prepared.boostedContent.push_back(' ');
-                }
-                std::size_t avail = kMaxBoostedBytes - prepared.boostedContent.size();
-                if (avail < text.size() + 1) {
-                    prepared.boostedContent.append(text.substr(0, std::min(text.size(), avail)));
-                    break;
-                }
-                prepared.boostedContent.append(text);
+            std::string_view contentView = entry.contentText;
+            if (contentView.size() > kMaxTextBytes) {
+                contentView = contentView.substr(0, kMaxTextBytes);
             }
-        };
 
-        append_repeated(prepared.sanitizedTitle, 3);
-        if (!entry.abstract.empty()) {
-            std::string absStorage;
-            auto sanitizedAbstract = common::ensureValidUtf8(entry.abstract, absStorage);
-            append_repeated(sanitizedAbstract, 2);
+            // Sanitize and build the boosted FTS payload before taking the write transaction so
+            // contention is dominated by SQLite work, not per-entry UTF-8 cleanup/string assembly.
+            preparedEntries.emplace_back();
+            auto& prepared = preparedEntries.back();
+            prepared.documentId = entry.documentId;
+            prepared.extractionMethod = entry.extractionMethod;
+            prepared.language = entry.language;
+            prepared.priorStateKnown = entry.priorStateKnown;
+            prepared.priorContentExtracted = entry.priorContentExtracted;
+
+            std::string contentStorage;
+            prepared.sanitizedContent = common::ensureValidUtf8(contentView, contentStorage);
+
+            std::string titleStorage;
+            prepared.sanitizedTitle = common::ensureValidUtf8(entry.title, titleStorage);
+
+            prepared.boostedContent.reserve(
+                std::min<std::size_t>(prepared.sanitizedContent.size() + 512, kMaxBoostedBytes));
+            auto append_repeated = [&](std::string_view text, int times) {
+                if (text.empty())
+                    return;
+                for (int t = 0; t < times; ++t) {
+                    if (prepared.boostedContent.size() >= kMaxBoostedBytes)
+                        break;
+                    if (!prepared.boostedContent.empty() && prepared.boostedContent.back() != ' ') {
+                        prepared.boostedContent.push_back(' ');
+                    }
+                    std::size_t avail = kMaxBoostedBytes - prepared.boostedContent.size();
+                    if (avail < text.size() + 1) {
+                        prepared.boostedContent.append(
+                            text.substr(0, std::min(text.size(), avail)));
+                        break;
+                    }
+                    prepared.boostedContent.append(text);
+                }
+            };
+
+            append_repeated(prepared.sanitizedTitle, 3);
+            if (!entry.abstract.empty()) {
+                std::string absStorage;
+                auto sanitizedAbstract = common::ensureValidUtf8(entry.abstract, absStorage);
+                append_repeated(sanitizedAbstract, 2);
+            }
+            if (!prepared.boostedContent.empty() && prepared.boostedContent.back() != ' ') {
+                prepared.boostedContent.push_back(' ');
+            }
+            const std::size_t bodySpace = kMaxBoostedBytes > prepared.boostedContent.size()
+                                              ? kMaxBoostedBytes - prepared.boostedContent.size()
+                                              : 0;
+            prepared.boostedContent.append(prepared.sanitizedContent.substr(
+                0, std::min(bodySpace, prepared.sanitizedContent.size())));
         }
-        if (!prepared.boostedContent.empty() && prepared.boostedContent.back() != ' ') {
-            prepared.boostedContent.push_back(' ');
-        }
-        const std::size_t bodySpace = kMaxBoostedBytes > prepared.boostedContent.size()
-                                          ? kMaxBoostedBytes - prepared.boostedContent.size()
-                                          : 0;
-        prepared.boostedContent.append(prepared.sanitizedContent.substr(
-            0, std::min(bodySpace, prepared.sanitizedContent.size())));
     }
+    addElapsedUs(phaseTimings.prepareInputUs, prepareStart);
 
     auto result = executeQuery<BatchContentDelta>([&](Database& db) -> Result<BatchContentDelta> {
+        YAMS_ZONE_SCOPED_N("MetadataRepo::batchContentTransaction");
+        const auto transactionStart = std::chrono::steady_clock::now();
         // Track counter deltas per attempt. executeQueryOnPool may retry the lambda
         // after lock/constraint races; deltas from failed attempts must not leak into
         // the final cache update.
         BatchContentDelta delta;
         delta.indexedDocIds.reserve(preparedEntries.size());
+        const auto beginStart = std::chrono::steady_clock::now();
         YAMS_TRY(beginTransaction(db));
+        addElapsedUs(phaseTimings.beginUs, beginStart);
         bool committed = false;
         auto rollback = scope_exit([&] {
             if (!committed) {
@@ -770,9 +813,12 @@ MetadataRepository::batchInsertContentAndIndex(const std::vector<BatchContentEnt
         });
 
         // Check if FTS5 is available once
+        const auto ftsDetectStart = std::chrono::steady_clock::now();
         YAMS_TRY_UNWRAP(hasFts5, db.hasFTS5());
+        addElapsedUs(phaseTimings.detectFtsUs, ftsDetectStart);
 
         // Prepare cached statements for reuse
+        const auto prepareStatementsStart = std::chrono::steady_clock::now();
         YAMS_TRY_UNWRAP(contentStmtResult, db.prepareCached(R"(
                 INSERT INTO document_content (
                     document_id, content_text, content_length,
@@ -809,19 +855,17 @@ MetadataRepository::batchInsertContentAndIndex(const std::vector<BatchContentEnt
             )"));
         auto& checkStmt = *checkStmtResult;
 
-        // Combined UPDATE: sets all extraction fields in a single statement
-        // (replaces 3 separate conditional UPDATEs per document).
-        YAMS_TRY_UNWRAP(combinedStmtResult, db.prepareCached(R"(
-                UPDATE documents
-                SET content_extracted = 1,
-                    extraction_status = 'Success',
-                    extraction_error = NULL,
-                    repair_status = 'completed',
-                    repair_attempted_at = unixepoch(),
-                    repair_attempts = repair_attempts + 1
-                WHERE id = ?
-            )"));
-        auto& combinedStmt = *combinedStmtResult;
+        addElapsedUs(phaseTimings.prepareStatementsUs, prepareStatementsStart);
+
+        std::vector<int64_t> statusUpdateIds;
+        statusUpdateIds.reserve(preparedEntries.size());
+        std::unordered_set<int64_t> uniqueStatusIds;
+        std::unordered_set<int64_t> newlyExtractedIds;
+        std::unordered_set<int64_t> newlyIndexedIds;
+        uniqueStatusIds.reserve(preparedEntries.size());
+        newlyExtractedIds.reserve(preparedEntries.size());
+        newlyIndexedIds.reserve(preparedEntries.size());
+        bool hasDuplicateStatusIds = false;
 
         for (const auto& entry : preparedEntries) {
             bool wasExtracted = entry.priorContentExtracted;
@@ -829,6 +873,8 @@ MetadataRepository::batchInsertContentAndIndex(const std::vector<BatchContentEnt
             // double-counting "indexed" documents in non-FTS builds.
             bool wasIndexed = !hasFts5;
             if (!entry.priorStateKnown || hasFts5) {
+                YAMS_ZONE_SCOPED_N("MetadataRepo::batchContentPrecheck");
+                const auto phaseStart = std::chrono::steady_clock::now();
                 YAMS_TRY(checkStmt.reset());
                 YAMS_TRY(checkStmt.clearBindings());
                 YAMS_TRY(checkStmt.bind(1, entry.documentId));
@@ -839,6 +885,7 @@ MetadataRepository::batchInsertContentAndIndex(const std::vector<BatchContentEnt
                 if (checkStep.value()) {
                     wasExtracted = checkStmt.getInt(0) == 1;
                     wasIndexed = checkStmt.getInt(1) == 1;
+                    phaseTimings.prechecks++;
                 } else {
                     // Post-ingest work can race with document deletion or duplicate-content
                     // resolution. Do not create orphan content/FTS rows or advance counters
@@ -846,18 +893,29 @@ MetadataRepository::batchInsertContentAndIndex(const std::vector<BatchContentEnt
                     spdlog::debug("MetadataRepository: skipping stale batch content entry for "
                                   "missing document id {}",
                                   entry.documentId);
+                    phaseTimings.staleSkipped++;
+                    addElapsedUs(phaseTimings.precheckUs, phaseStart);
                     continue;
                 }
+                addElapsedUs(phaseTimings.precheckUs, phaseStart);
             }
 
-            YAMS_TRY(contentStmt.reset());
-            YAMS_TRY(contentStmt.clearBindings());
-            YAMS_TRY(contentStmt.bindAll(entry.documentId, entry.sanitizedContent,
-                                         static_cast<int64_t>(entry.sanitizedContent.length()),
-                                         entry.extractionMethod, entry.language));
-            YAMS_TRY(contentStmt.execute());
+            {
+                YAMS_ZONE_SCOPED_N("MetadataRepo::batchContentUpsertContent");
+                const auto phaseStart = std::chrono::steady_clock::now();
+                YAMS_TRY(contentStmt.reset());
+                YAMS_TRY(contentStmt.clearBindings());
+                YAMS_TRY(contentStmt.bindAll(entry.documentId, entry.sanitizedContent,
+                                             static_cast<int64_t>(entry.sanitizedContent.length()),
+                                             entry.extractionMethod, entry.language));
+                YAMS_TRY(contentStmt.execute());
+                phaseTimings.contentUpserts++;
+                addElapsedUs(phaseTimings.contentUpsertUs, phaseStart);
+            }
 
             if (hasFts5 && ftsStmtOpt) {
+                YAMS_ZONE_SCOPED_N("MetadataRepo::batchContentUpsertFts");
+                const auto phaseStart = std::chrono::steady_clock::now();
                 auto& ftsStmt = **ftsStmtOpt;
                 YAMS_TRY(ftsStmt.reset());
                 YAMS_TRY(ftsStmt.clearBindings());
@@ -865,23 +923,91 @@ MetadataRepository::batchInsertContentAndIndex(const std::vector<BatchContentEnt
                     ftsStmt.bindAll(entry.documentId, entry.boostedContent, entry.sanitizedTitle));
                 YAMS_TRY(ftsStmt.execute());
                 delta.indexedDocIds.push_back(entry.documentId);
+                phaseTimings.ftsUpserts++;
+                addElapsedUs(phaseTimings.ftsUpsertUs, phaseStart);
             }
 
-            YAMS_TRY(combinedStmt.reset());
-            YAMS_TRY(combinedStmt.clearBindings());
-            YAMS_TRY(combinedStmt.bind(1, entry.documentId));
-            YAMS_TRY(combinedStmt.execute());
+            statusUpdateIds.push_back(entry.documentId);
+            if (!uniqueStatusIds.insert(entry.documentId).second) {
+                hasDuplicateStatusIds = true;
+            }
             if (!wasExtracted) {
-                delta.newlyExtracted++;
+                newlyExtractedIds.insert(entry.documentId);
             }
             if (!wasIndexed) {
-                delta.newlyIndexed++;
+                newlyIndexedIds.insert(entry.documentId);
             }
         }
+        delta.newlyExtracted = newlyExtractedIds.size();
+        delta.newlyIndexed = newlyIndexedIds.size();
 
+        if (!statusUpdateIds.empty()) {
+            YAMS_ZONE_SCOPED_N("MetadataRepo::batchContentStatusUpdate");
+            const auto phaseStart = std::chrono::steady_clock::now();
+            if (hasDuplicateStatusIds) {
+                // Preserve legacy repair_attempts semantics for duplicate entries targeting the
+                // same document in one batch: each entry counts as one repair attempt.
+                YAMS_TRY_UNWRAP(statusStmtResult, db.prepareCached(R"(
+                    UPDATE documents
+                    SET content_extracted = 1,
+                        extraction_status = 'Success',
+                        extraction_error = NULL,
+                        repair_status = 'completed',
+                        repair_attempted_at = unixepoch(),
+                        repair_attempts = repair_attempts + 1
+                    WHERE id = ?
+                )"));
+                auto& statusStmt = *statusStmtResult;
+                for (const auto documentId : statusUpdateIds) {
+                    YAMS_TRY(statusStmt.reset());
+                    YAMS_TRY(statusStmt.clearBindings());
+                    YAMS_TRY(statusStmt.bind(1, documentId));
+                    YAMS_TRY(statusStmt.execute());
+                }
+            } else {
+                constexpr std::size_t kMaxStatusIdsPerUpdate = 400;
+                for (std::size_t offset = 0; offset < statusUpdateIds.size();
+                     offset += kMaxStatusIdsPerUpdate) {
+                    const auto chunkSize =
+                        std::min(kMaxStatusIdsPerUpdate, statusUpdateIds.size() - offset);
+                    std::string placeholders;
+                    placeholders.reserve(chunkSize * 2);
+                    for (std::size_t i = 0; i < chunkSize; ++i) {
+                        if (i > 0) {
+                            placeholders += ',';
+                        }
+                        placeholders += '?';
+                    }
+                    std::string sql;
+                    sql.reserve(placeholders.size() + 256);
+                    sql += "UPDATE documents SET content_extracted = 1, ";
+                    sql += "extraction_status = 'Success', extraction_error = NULL, ";
+                    sql += "repair_status = 'completed', repair_attempted_at = unixepoch(), ";
+                    sql += "repair_attempts = repair_attempts + 1 WHERE id IN (";
+                    sql += placeholders;
+                    sql += ')';
+
+                    YAMS_TRY_UNWRAP(statusStmtResult, db.prepareCached(sql));
+                    auto& statusStmt = *statusStmtResult;
+                    YAMS_TRY(statusStmt.reset());
+                    YAMS_TRY(statusStmt.clearBindings());
+                    for (std::size_t i = 0; i < chunkSize; ++i) {
+                        YAMS_TRY(
+                            statusStmt.bind(static_cast<int>(i + 1), statusUpdateIds[offset + i]));
+                    }
+                    YAMS_TRY(statusStmt.execute());
+                }
+            }
+            phaseTimings.statusUpdates += statusUpdateIds.size();
+            addElapsedUs(phaseTimings.statusUpdateUs, phaseStart);
+        }
+
+        const auto commitStart = std::chrono::steady_clock::now();
         YAMS_TRY(commitOrRollback(db));
+        addElapsedUs(phaseTimings.commitUs, commitStart);
         committed = true;
         rollback.dismiss();
+        addElapsedUs(phaseTimings.transactionUs, transactionStart);
 
         return delta;
     });
@@ -905,6 +1031,26 @@ MetadataRepository::batchInsertContentAndIndex(const std::vector<BatchContentEnt
                   static_cast<int64_t>(delta.newlyExtracted));
         YAMS_PLOT("metadata_repo::batch_content_newly_indexed",
                   static_cast<int64_t>(delta.newlyIndexed));
+        YAMS_PLOT("metadata_repo::batch_content_prepare_us", phaseTimings.prepareInputUs);
+        YAMS_PLOT("metadata_repo::batch_content_transaction_us", phaseTimings.transactionUs);
+        YAMS_PLOT("metadata_repo::batch_content_precheck_us", phaseTimings.precheckUs);
+        YAMS_PLOT("metadata_repo::batch_content_content_upsert_us", phaseTimings.contentUpsertUs);
+        YAMS_PLOT("metadata_repo::batch_content_fts_upsert_us", phaseTimings.ftsUpsertUs);
+        YAMS_PLOT("metadata_repo::batch_content_status_update_us", phaseTimings.statusUpdateUs);
+        if (traceBatchContent) {
+            spdlog::info("MetadataRepository::batchInsertContentAndIndex phases entries={} "
+                         "prepare_us={} transaction_us={} begin_us={} fts_detect_us={} "
+                         "stmt_prepare_us={} precheck_us={} content_upsert_us={} "
+                         "fts_upsert_us={} status_update_us={} commit_us={} prechecks={} "
+                         "content_upserts={} fts_upserts={} status_updates={} stale_skipped={}",
+                         entries.size(), phaseTimings.prepareInputUs, phaseTimings.transactionUs,
+                         phaseTimings.beginUs, phaseTimings.detectFtsUs,
+                         phaseTimings.prepareStatementsUs, phaseTimings.precheckUs,
+                         phaseTimings.contentUpsertUs, phaseTimings.ftsUpsertUs,
+                         phaseTimings.statusUpdateUs, phaseTimings.commitUs, phaseTimings.prechecks,
+                         phaseTimings.contentUpserts, phaseTimings.ftsUpserts,
+                         phaseTimings.statusUpdates, phaseTimings.staleSkipped);
+        }
 
         const auto cachedIndexed = cachedIndexedCount_.load(std::memory_order_relaxed);
         const auto cachedDocuments = cachedDocumentCount_.load(std::memory_order_relaxed);

--- a/src/metadata/metadata_repository.cpp
+++ b/src/metadata/metadata_repository.cpp
@@ -987,8 +987,7 @@ MetadataRepository::batchInsertContentAndIndex(const std::vector<BatchContentEnt
                     sql += placeholders;
                     sql += ')';
 
-                    YAMS_TRY_UNWRAP(statusStmtResult, db.prepareCached(sql));
-                    auto& statusStmt = *statusStmtResult;
+                    YAMS_TRY_UNWRAP(statusStmt, db.prepare(sql));
                     YAMS_TRY(statusStmt.reset());
                     YAMS_TRY(statusStmt.clearBindings());
                     for (std::size_t i = 0; i < chunkSize; ++i) {
@@ -3255,8 +3254,11 @@ MetadataRepository::tryAddSymSpellTerms(const std::vector<std::pair<std::string,
 
     for (std::size_t offset = 0; offset < filtered.size(); offset += kTermsPerChunk) {
         const std::size_t end = std::min(filtered.size(), offset + kTermsPerChunk);
-        std::vector<std::pair<std::string, int64_t>> chunk(filtered.begin() + offset,
-                                                           filtered.begin() + end);
+        std::vector<std::pair<std::string, int64_t>> chunk;
+        chunk.reserve(end - offset);
+        for (std::size_t i = offset; i < end; ++i) {
+            chunk.push_back(std::move(filtered[i]));
+        }
         auto result = executeWriteQuery<void>([&](Database& db) -> Result<void> {
             sqlite3* rawDb = db.rawHandle();
             if (!rawDb) {

--- a/src/metadata/repository/metadata_kv_ops.cpp
+++ b/src/metadata/repository/metadata_kv_ops.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <span>
 #include <string>
@@ -75,8 +76,8 @@ Result<void> MetadataRepository::setMetadata(int64_t documentId, const std::stri
             }
         });
 
-        YAMS_TRY_UNWRAP(delta, repository::upsertMetadataWritesWithTagDelta(
-                                   db, entries, pendingTagKeysByDoc));
+        YAMS_TRY_UNWRAP(
+            delta, repository::upsertMetadataWritesWithTagDelta(db, entries, pendingTagKeysByDoc));
         YAMS_TRY(commitOrRollback(db));
         committed = true;
         return delta;
@@ -95,14 +96,35 @@ Result<void> MetadataRepository::setMetadata(int64_t documentId, const std::stri
 
 Result<void> MetadataRepository::setMetadataBatch(
     const std::vector<std::tuple<int64_t, std::string, MetadataValue>>& entries) {
+    YAMS_ZONE_SCOPED_N("MetadataRepo::setMetadataBatch");
+    YAMS_PLOT("metadata_repo::set_metadata_batch_entries", static_cast<int64_t>(entries.size()));
     if (entries.empty()) {
         return Result<void>();
     }
 
+    const bool traceMetadataBatch = metadata_trace_enabled();
+    const auto overallStart = std::chrono::steady_clock::now();
+    auto phaseStart = overallStart;
     const auto dedupedEntries = repository::deduplicateMetadataWrites(entries);
+    const auto dedupUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                             std::chrono::steady_clock::now() - phaseStart)
+                             .count();
+    phaseStart = std::chrono::steady_clock::now();
     const auto pendingTagKeysByDoc = repository::collectPendingTagKeysByDoc(dedupedEntries);
+    const auto collectTagsUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                   std::chrono::steady_clock::now() - phaseStart)
+                                   .count();
+
+    int64_t beginUs = 0;
+    int64_t upsertUs = 0;
+    int64_t commitUs = 0;
+    const auto executeStart = std::chrono::steady_clock::now();
     auto result = executeQuery<MetadataTagDelta>([&](Database& db) -> Result<MetadataTagDelta> {
+        auto txnPhaseStart = std::chrono::steady_clock::now();
         YAMS_TRY(repository::beginTransaction(db));
+        beginUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                      std::chrono::steady_clock::now() - txnPhaseStart)
+                      .count();
         bool committed = false;
         auto rollback = scope_exit([&] {
             if (!committed) {
@@ -110,12 +132,23 @@ Result<void> MetadataRepository::setMetadataBatch(
             }
         });
 
-        YAMS_TRY_UNWRAP(delta, repository::upsertMetadataWritesWithTagDelta(
-                                   db, dedupedEntries, pendingTagKeysByDoc));
+        txnPhaseStart = std::chrono::steady_clock::now();
+        YAMS_TRY_UNWRAP(delta, repository::upsertMetadataWritesWithTagDelta(db, dedupedEntries,
+                                                                            pendingTagKeysByDoc));
+        upsertUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                       std::chrono::steady_clock::now() - txnPhaseStart)
+                       .count();
+        txnPhaseStart = std::chrono::steady_clock::now();
         YAMS_TRY(repository::commitOrRollback(db));
+        commitUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                       std::chrono::steady_clock::now() - txnPhaseStart)
+                       .count();
         committed = true;
         return delta;
     });
+    const auto executeUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                               std::chrono::steady_clock::now() - executeStart)
+                               .count();
 
     if (!result) {
         return result.error();
@@ -125,6 +158,16 @@ Result<void> MetadataRepository::setMetadataBatch(
     applyMetadataTagDelta(cachedTagCount_, cachedDocsWithTags_, cachedDocumentCount_,
                           result.value());
     metadataChangeCounter_.fetch_add(dedupedEntries.size(), std::memory_order_release);
+    if (traceMetadataBatch) {
+        const auto totalUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                 std::chrono::steady_clock::now() - overallStart)
+                                 .count();
+        spdlog::info("MetadataRepository::setMetadataBatch phases entries={} deduped={} tags={} "
+                     "dedup_us={} collect_tags_us={} execute_us={} begin_us={} upsert_us={} "
+                     "commit_us={} total_us={}",
+                     entries.size(), dedupedEntries.size(), pendingTagKeysByDoc.size(), dedupUs,
+                     collectTagsUs, executeUs, beginUs, upsertUs, commitUs, totalUs);
+    }
     return {};
 }
 

--- a/src/metadata/versioning_util.cpp
+++ b/src/metadata/versioning_util.cpp
@@ -1,6 +1,7 @@
-#include <spdlog/spdlog.h>
 #include <cstdlib>
 #include <string_view>
+#include <tuple>
+#include <vector>
 #include <yams/metadata/metadata_repository.h>
 #include <yams/metadata/query_helpers.h>
 #include <yams/metadata/versioning_util.h>
@@ -8,11 +9,36 @@
 namespace yams::metadata {
 
 static bool versioningEnabled() {
-    if (const char* env = std::getenv("YAMS_ENABLE_VERSIONING")) {
+    if (const char* env = std::getenv("YAMS_ENABLE_VERSIONING")) { // NOLINT(concurrency-mt-unsafe)
         std::string_view v(env);
         return !(v == "0" || v == "false" || v == "FALSE");
     }
     return true;
+}
+
+static void applyVersioningMetadataWrites(
+    MetadataRepository& repo,
+    const std::vector<std::tuple<int64_t, std::string, MetadataValue>>& entries) {
+    if (entries.empty()) {
+        return;
+    }
+
+    if (entries.size() > 1) {
+        auto batchResult = repo.setMetadataBatch(entries);
+        if (batchResult) {
+            return;
+        }
+        spdlog::debug("Versioning: metadata batch failed: {}; falling back to per-entry writes",
+                      batchResult.error().message);
+    }
+
+    for (const auto& [documentId, key, value] : entries) {
+        auto setResult = repo.setMetadata(documentId, key, value);
+        if (!setResult) {
+            spdlog::debug("Versioning: failed to set metadata doc={} key='{}': {}", documentId, key,
+                          setResult.error().message);
+        }
+    }
 }
 
 int64_t applyPathSeriesVersioning(MetadataRepository& repo, const std::string& filePath,
@@ -32,7 +58,12 @@ int64_t applyPathSeriesVersioning(MetadataRepository& repo, const std::string& f
                     maxVersion = v;
                     prevLatestHint = doc;
                 }
+            } catch (const std::exception& ex) {
+                spdlog::debug("Versioning: ignoring invalid prior version metadata for doc {}: {}",
+                              doc.id, ex.what());
             } catch (...) {
+                spdlog::debug("Versioning: ignoring invalid prior version metadata for doc {}",
+                              doc.id);
             }
         }
     };
@@ -70,8 +101,11 @@ int64_t applyPathSeriesVersioning(MetadataRepository& repo, const std::string& f
         }
 
         int64_t newVersion = 1;
+        std::vector<std::tuple<int64_t, std::string, MetadataValue>> metadataEntries;
+        metadataEntries.reserve(prevLatestHint.has_value() ? 4U : 3U);
+
         if (prevLatestHint.has_value()) {
-            (void)repo.setMetadata(prevLatestHint->id, "is_latest", MetadataValue(false));
+            metadataEntries.emplace_back(prevLatestHint->id, "is_latest", MetadataValue(false));
 
             DocumentRelationship rel;
             rel.parentId = prevLatestHint->id;
@@ -84,9 +118,10 @@ int64_t applyPathSeriesVersioning(MetadataRepository& repo, const std::string& f
             newVersion = (maxVersion > 0 ? maxVersion : 1) + 1;
         }
 
-        (void)repo.setMetadata(newDocumentId, "version", MetadataValue(newVersion));
-        (void)repo.setMetadata(newDocumentId, "is_latest", MetadataValue(true));
-        (void)repo.setMetadata(newDocumentId, "series_key", MetadataValue(seriesKey));
+        metadataEntries.emplace_back(newDocumentId, "version", MetadataValue(newVersion));
+        metadataEntries.emplace_back(newDocumentId, "is_latest", MetadataValue(true));
+        metadataEntries.emplace_back(newDocumentId, "series_key", MetadataValue(seriesKey));
+        applyVersioningMetadataWrites(repo, metadataEntries);
 
         if (auto latestRes = repo.getMetadata(newDocumentId, "is_latest");
             latestRes && latestRes.value().has_value()) {

--- a/src/metadata/versioning_util.cpp
+++ b/src/metadata/versioning_util.cpp
@@ -1,3 +1,4 @@
+#include <spdlog/spdlog.h>
 #include <cstdlib>
 #include <string_view>
 #include <tuple>

--- a/tests/benchmarks/TRACY_PROFILING.md
+++ b/tests/benchmarks/TRACY_PROFILING.md
@@ -38,6 +38,33 @@ meson setup build --buildtype=release
 
 ## Running Benchmarks with Tracy
 
+### Programmatic capture status
+
+YAMS can programmatically emit Tracy zones and plots from benchmark code via `YAMS_*` macros in `include/yams/profiling.h`. Saving a `.tracy` trace file is a separate Tracy-tool concern: it requires either the GUI/profiler or a headless capture tool from the Tracy distribution. This was not standardized earlier because local installs expose different tool names and flags (`Tracy`, `tracy-profiler`, `capture`, `tracy-capture`, etc.).
+
+First, record the local Tracy tooling status:
+
+```bash
+scripts/check_tracy_capture.sh bench_results/tracy_capture_status.json
+```
+
+Use the wrapper below for repeatable benchmark execution. If a headless capture tool is available, pass its exact invocation through environment variables:
+
+```bash
+# Runs the benchmark and, when configured, starts a Tracy capture process first.
+YAMS_TRACY_CAPTURE_CMD=/path/to/tracy/capture \
+YAMS_TRACY_CAPTURE_ARGS='-o bench_results/write_coordinator.tracy' \
+YAMS_BENCH_NUM_FILES=1000 \
+YAMS_BENCH_REPEAT=3 \
+scripts/run_tracy_benchmark.sh write_coordinator_bench
+```
+
+If no capture tool is configured, the status artifact will report `"status": "gui-only"`. Start `tracy-profiler` / Tracy GUI first and run:
+
+```bash
+scripts/run_tracy_benchmark.sh write_coordinator_bench
+```
+
 ### 1. Start Tracy Server First
 
 Launch the Tracy GUI on port 8086 (default):

--- a/tests/benchmarks/metadata_contention_bench.cpp
+++ b/tests/benchmarks/metadata_contention_bench.cpp
@@ -18,7 +18,8 @@
 //   YAMS_BENCH_METADATA_BATCH        - setMetadataBatch entries per write op (default: 8)
 //   YAMS_BENCH_STATUS_BATCH          - repair-status hashes per write op (default: 64)
 //   YAMS_BENCH_READ_BATCH            - getMetadataForDocuments ids per read op (default: 16)
-//   YAMS_BENCH_CHECKPOINT_EVERY_MS   - TRUNCATE checkpoint cadence, 0 disables (default: 500)
+//   YAMS_BENCH_CHECKPOINT_EVERY_MS   - checkpoint cadence, 0 disables (default: 500)
+//   YAMS_BENCH_CHECKPOINT_MODE       - truncate|passive checkpoint type (default: truncate)
 //   YAMS_BENCH_DB_BUSY_TIMEOUT_MS    - SQLite busy timeout (default: 100)
 //   YAMS_BENCH_DUAL_POOL             - 1 => separate read-only pool, 0 => single pool (default: 1)
 //   YAMS_BENCH_EXTERNAL_LOCKER       - 1 => separate writer periodically holds BEGIN IMMEDIATE
@@ -95,6 +96,8 @@ struct BenchConfig {
     int statusBatchSize{64};
     int readBatchSize{16};
     int checkpointEveryMs{500};
+    std::string checkpointModeName{"truncate"};
+    bool checkpointTruncate{true};
     int dbBusyTimeoutMs{100};
     bool dualPool{true};
     bool externalLocker{false};
@@ -143,6 +146,24 @@ using yams::bench::isoTimestamp;
 using yams::bench::readBoolEnv;
 using yams::bench::readIntEnv;
 
+std::pair<bool, std::string> readCheckpointModeEnv() {
+    const char* val = std::getenv("YAMS_BENCH_CHECKPOINT_MODE");
+    if (!val || !*val) {
+        return {true, "truncate"};
+    }
+    std::string s(val);
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    if (s == "passive") {
+        return {false, "passive"};
+    }
+    if (s == "truncate") {
+        return {true, "truncate"};
+    }
+    spdlog::warn("Unknown YAMS_BENCH_CHECKPOINT_MODE='{}'; using truncate", s);
+    return {true, "truncate"};
+}
+
 std::pair<int, std::string> readWriteModeEnv() {
     const char* val = std::getenv("YAMS_BENCH_WRITE_MODE");
     if (!val || !*val) {
@@ -189,6 +210,9 @@ BenchConfig loadConfig() {
     cfg.statusBatchSize = readIntEnv("YAMS_BENCH_STATUS_BATCH", 64, 1, 1024);
     cfg.readBatchSize = readIntEnv("YAMS_BENCH_READ_BATCH", 16, 1, 256);
     cfg.checkpointEveryMs = readIntEnv("YAMS_BENCH_CHECKPOINT_EVERY_MS", 500, 0, 60000);
+    auto [checkpointTruncate, checkpointModeName] = readCheckpointModeEnv();
+    cfg.checkpointTruncate = checkpointTruncate;
+    cfg.checkpointModeName = std::move(checkpointModeName);
     cfg.dbBusyTimeoutMs = readIntEnv("YAMS_BENCH_DB_BUSY_TIMEOUT_MS", 100, 0, 30000);
     cfg.dualPool = readBoolEnv("YAMS_BENCH_DUAL_POOL", true);
     cfg.externalLocker = readBoolEnv("YAMS_BENCH_EXTERNAL_LOCKER", false);
@@ -361,6 +385,7 @@ TEST_CASE("MetadataRepository SQLite contention profile", "[bench][metadata][sql
     spdlog::info("  statusBatchSize:    {}", cfg.statusBatchSize);
     spdlog::info("  readBatchSize:      {}", cfg.readBatchSize);
     spdlog::info("  checkpointEveryMs:  {}", cfg.checkpointEveryMs);
+    spdlog::info("  checkpointMode:     {}", cfg.checkpointModeName);
     spdlog::info("  dbBusyTimeoutMs:    {}", cfg.dbBusyTimeoutMs);
     spdlog::info("  dualPool:           {}", cfg.dualPool);
     spdlog::info("  externalLocker:     {}", cfg.externalLocker);
@@ -964,8 +989,10 @@ TEST_CASE("MetadataRepository SQLite contention profile", "[bench][metadata][sql
                         break;
                     }
                     const auto t0 = std::chrono::steady_clock::now();
-                    MetadataOpScope op("bench_checkpoint_truncate");
-                    auto result = repo.checkpointWalTruncate();
+                    MetadataOpScope op(cfg.checkpointTruncate ? "bench_checkpoint_truncate"
+                                                              : "bench_checkpoint_passive");
+                    auto result = cfg.checkpointTruncate ? repo.checkpointWalTruncate()
+                                                         : repo.checkpointWal();
                     const auto us = std::chrono::duration_cast<std::chrono::microseconds>(
                                         std::chrono::steady_clock::now() - t0)
                                         .count();
@@ -1040,6 +1067,7 @@ TEST_CASE("MetadataRepository SQLite contention profile", "[bench][metadata][sql
                     {"status_batch_size", cfg.statusBatchSize},
                     {"read_batch_size", cfg.readBatchSize},
                     {"checkpoint_every_ms", cfg.checkpointEveryMs},
+                    {"checkpoint_mode", cfg.checkpointModeName},
                     {"db_busy_timeout_ms", cfg.dbBusyTimeoutMs},
                     {"external_locker", cfg.externalLocker},
                     {"external_lock_hold_ms", cfg.externalLockHoldMs},

--- a/tests/benchmarks/metadata_contention_bench.cpp
+++ b/tests/benchmarks/metadata_contention_bench.cpp
@@ -116,6 +116,26 @@ struct OpStats {
     std::vector<int64_t> latenciesUs;
 };
 
+struct CheckpointContextStats {
+    uint64_t samples{0};
+    std::uintmax_t maxWalBytesBefore{0};
+    std::uintmax_t maxWalBytesAfter{0};
+    uint64_t maxWalFramesBefore{0};
+    uint64_t maxWalFramesAfter{0};
+    uint64_t maxWriteSlowHoldersBefore{0};
+    uint64_t maxWriteSlowHoldersAfter{0};
+    uint64_t maxReadSlowHoldersBefore{0};
+    uint64_t maxReadSlowHoldersAfter{0};
+    uint64_t maxWriteHolderMicrosBefore{0};
+    uint64_t maxWriteHolderMicrosAfter{0};
+    uint64_t maxReadHolderMicrosBefore{0};
+    uint64_t maxReadHolderMicrosAfter{0};
+    uint64_t maxWriteWaitingBefore{0};
+    uint64_t maxWriteWaitingAfter{0};
+    uint64_t maxReadWaitingBefore{0};
+    uint64_t maxReadWaitingAfter{0};
+};
+
 struct WorkerStats {
     OpStats writes;
     OpStats insertWrites;
@@ -129,6 +149,7 @@ struct WorkerStats {
     OpStats extractionWrites;
     OpStats reads;
     OpStats checkpoints;
+    CheckpointContextStats checkpointContext;
     OpStats longReads;
     OpStats externalLocks;
 };
@@ -242,6 +263,29 @@ std::uintmax_t walBytes(const fs::path& dbPath) {
     return fs::file_size(walPath, ec);
 }
 
+uint64_t estimateWalFrames(std::uintmax_t bytes, uint64_t pageSize) {
+    constexpr uint64_t kWalHeaderBytes = 32;
+    constexpr uint64_t kWalFrameHeaderBytes = 24;
+    if (pageSize == 0 || bytes <= kWalHeaderBytes) {
+        return 0;
+    }
+    return static_cast<uint64_t>((bytes - kWalHeaderBytes) / (pageSize + kWalFrameHeaderBytes));
+}
+
+uint64_t queryPageSize(Database& db) {
+    auto stmtResult = db.prepare("PRAGMA page_size");
+    if (!stmtResult) {
+        return 4096;
+    }
+    auto& stmt = stmtResult.value();
+    auto step = stmt.step();
+    if (!step || !step.value()) {
+        return 4096;
+    }
+    const auto value = stmt.getInt64(0);
+    return value > 0 ? static_cast<uint64_t>(value) : 4096;
+}
+
 DocumentInfo makeDocument(const fs::path& root, int writerId, uint64_t seq) {
     DocumentInfo doc;
     doc.fileName = "writer_" + std::to_string(writerId) + "_" + std::to_string(seq) + ".txt";
@@ -299,6 +343,34 @@ void mergeOpStats(OpStats& dst, const OpStats& src) {
     }
 }
 
+void mergeCheckpointContext(CheckpointContextStats& dst, const CheckpointContextStats& src) {
+    dst.samples += src.samples;
+    dst.maxWalBytesBefore = std::max(dst.maxWalBytesBefore, src.maxWalBytesBefore);
+    dst.maxWalBytesAfter = std::max(dst.maxWalBytesAfter, src.maxWalBytesAfter);
+    dst.maxWalFramesBefore = std::max(dst.maxWalFramesBefore, src.maxWalFramesBefore);
+    dst.maxWalFramesAfter = std::max(dst.maxWalFramesAfter, src.maxWalFramesAfter);
+    dst.maxWriteSlowHoldersBefore =
+        std::max(dst.maxWriteSlowHoldersBefore, src.maxWriteSlowHoldersBefore);
+    dst.maxWriteSlowHoldersAfter =
+        std::max(dst.maxWriteSlowHoldersAfter, src.maxWriteSlowHoldersAfter);
+    dst.maxReadSlowHoldersBefore =
+        std::max(dst.maxReadSlowHoldersBefore, src.maxReadSlowHoldersBefore);
+    dst.maxReadSlowHoldersAfter =
+        std::max(dst.maxReadSlowHoldersAfter, src.maxReadSlowHoldersAfter);
+    dst.maxWriteHolderMicrosBefore =
+        std::max(dst.maxWriteHolderMicrosBefore, src.maxWriteHolderMicrosBefore);
+    dst.maxWriteHolderMicrosAfter =
+        std::max(dst.maxWriteHolderMicrosAfter, src.maxWriteHolderMicrosAfter);
+    dst.maxReadHolderMicrosBefore =
+        std::max(dst.maxReadHolderMicrosBefore, src.maxReadHolderMicrosBefore);
+    dst.maxReadHolderMicrosAfter =
+        std::max(dst.maxReadHolderMicrosAfter, src.maxReadHolderMicrosAfter);
+    dst.maxWriteWaitingBefore = std::max(dst.maxWriteWaitingBefore, src.maxWriteWaitingBefore);
+    dst.maxWriteWaitingAfter = std::max(dst.maxWriteWaitingAfter, src.maxWriteWaitingAfter);
+    dst.maxReadWaitingBefore = std::max(dst.maxReadWaitingBefore, src.maxReadWaitingBefore);
+    dst.maxReadWaitingAfter = std::max(dst.maxReadWaitingAfter, src.maxReadWaitingAfter);
+}
+
 void mergeWorkerStats(WorkerStats& dst, const WorkerStats& src) {
     mergeOpStats(dst.writes, src.writes);
     mergeOpStats(dst.insertWrites, src.insertWrites);
@@ -312,6 +384,7 @@ void mergeWorkerStats(WorkerStats& dst, const WorkerStats& src) {
     mergeOpStats(dst.extractionWrites, src.extractionWrites);
     mergeOpStats(dst.reads, src.reads);
     mergeOpStats(dst.checkpoints, src.checkpoints);
+    mergeCheckpointContext(dst.checkpointContext, src.checkpointContext);
     mergeOpStats(dst.longReads, src.longReads);
     mergeOpStats(dst.externalLocks, src.externalLocks);
 }
@@ -359,6 +432,26 @@ json poolStatsJson(const ConnectionPool::Stats& stats) {
                 {"failed_acquisitions", stats.failedAcquisitions},
                 {"slow_holder_count", stats.slowHolderCount},
                 {"max_holder_micros", stats.maxHolderMicros}};
+}
+
+json checkpointContextJson(const CheckpointContextStats& stats) {
+    return json{{"samples", stats.samples},
+                {"max_wal_bytes_before", stats.maxWalBytesBefore},
+                {"max_wal_bytes_after", stats.maxWalBytesAfter},
+                {"max_wal_frames_before_est", stats.maxWalFramesBefore},
+                {"max_wal_frames_after_est", stats.maxWalFramesAfter},
+                {"max_write_slow_holder_count_before", stats.maxWriteSlowHoldersBefore},
+                {"max_write_slow_holder_count_after", stats.maxWriteSlowHoldersAfter},
+                {"max_read_slow_holder_count_before", stats.maxReadSlowHoldersBefore},
+                {"max_read_slow_holder_count_after", stats.maxReadSlowHoldersAfter},
+                {"max_write_holder_micros_before", stats.maxWriteHolderMicrosBefore},
+                {"max_write_holder_micros_after", stats.maxWriteHolderMicrosAfter},
+                {"max_read_holder_micros_before", stats.maxReadHolderMicrosBefore},
+                {"max_read_holder_micros_after", stats.maxReadHolderMicrosAfter},
+                {"max_write_waiting_before", stats.maxWriteWaitingBefore},
+                {"max_write_waiting_after", stats.maxWriteWaitingAfter},
+                {"max_read_waiting_before", stats.maxReadWaitingBefore},
+                {"max_read_waiting_after", stats.maxReadWaitingAfter}};
 }
 
 void appendJsonLine(const fs::path& outputPath, const json& record) {
@@ -464,6 +557,9 @@ TEST_CASE("MetadataRepository SQLite contention profile", "[bench][metadata][sql
             paths.push_back(doc.filePath);
         }
 
+        const auto walPageSize = writePool.withConnection(
+            [&](Database& db) -> yams::Result<uint64_t> { return queryPageSize(db); });
+        REQUIRE(walPageSize.has_value());
         const auto walBefore = walBytes(dbPath);
         std::chrono::steady_clock::time_point start;
         std::chrono::steady_clock::time_point deadline;
@@ -988,6 +1084,11 @@ TEST_CASE("MetadataRepository SQLite contention profile", "[bench][metadata][sql
                         std::chrono::steady_clock::now() >= deadline) {
                         break;
                     }
+                    const auto walBytesBefore = walBytes(dbPath);
+                    const auto writeStatsBefore = writePool.getStats();
+                    const auto readStatsBefore =
+                        readPool ? std::optional<ConnectionPool::Stats>(readPool->getStats())
+                                 : std::nullopt;
                     const auto t0 = std::chrono::steady_clock::now();
                     MetadataOpScope op(cfg.checkpointTruncate ? "bench_checkpoint_truncate"
                                                               : "bench_checkpoint_passive");
@@ -996,6 +1097,60 @@ TEST_CASE("MetadataRepository SQLite contention profile", "[bench][metadata][sql
                     const auto us = std::chrono::duration_cast<std::chrono::microseconds>(
                                         std::chrono::steady_clock::now() - t0)
                                         .count();
+                    const auto walBytesAfter = walBytes(dbPath);
+                    const auto writeStatsAfter = writePool.getStats();
+                    const auto readStatsAfter =
+                        readPool ? std::optional<ConnectionPool::Stats>(readPool->getStats())
+                                 : std::nullopt;
+                    local.checkpointContext.samples++;
+                    local.checkpointContext.maxWalBytesBefore =
+                        std::max(local.checkpointContext.maxWalBytesBefore, walBytesBefore);
+                    local.checkpointContext.maxWalBytesAfter =
+                        std::max(local.checkpointContext.maxWalBytesAfter, walBytesAfter);
+                    local.checkpointContext.maxWalFramesBefore =
+                        std::max(local.checkpointContext.maxWalFramesBefore,
+                                 estimateWalFrames(walBytesBefore, walPageSize.value()));
+                    local.checkpointContext.maxWalFramesAfter =
+                        std::max(local.checkpointContext.maxWalFramesAfter,
+                                 estimateWalFrames(walBytesAfter, walPageSize.value()));
+                    local.checkpointContext.maxWriteSlowHoldersBefore =
+                        std::max(local.checkpointContext.maxWriteSlowHoldersBefore,
+                                 writeStatsBefore.slowHolderCount);
+                    local.checkpointContext.maxWriteSlowHoldersAfter =
+                        std::max(local.checkpointContext.maxWriteSlowHoldersAfter,
+                                 writeStatsAfter.slowHolderCount);
+                    local.checkpointContext.maxWriteHolderMicrosBefore =
+                        std::max(local.checkpointContext.maxWriteHolderMicrosBefore,
+                                 writeStatsBefore.maxHolderMicros);
+                    local.checkpointContext.maxWriteHolderMicrosAfter =
+                        std::max(local.checkpointContext.maxWriteHolderMicrosAfter,
+                                 writeStatsAfter.maxHolderMicros);
+                    local.checkpointContext.maxWriteWaitingBefore =
+                        std::max(local.checkpointContext.maxWriteWaitingBefore,
+                                 static_cast<uint64_t>(writeStatsBefore.waitingRequests));
+                    local.checkpointContext.maxWriteWaitingAfter =
+                        std::max(local.checkpointContext.maxWriteWaitingAfter,
+                                 static_cast<uint64_t>(writeStatsAfter.waitingRequests));
+                    if (readStatsBefore && readStatsAfter) {
+                        local.checkpointContext.maxReadSlowHoldersBefore =
+                            std::max(local.checkpointContext.maxReadSlowHoldersBefore,
+                                     readStatsBefore->slowHolderCount);
+                        local.checkpointContext.maxReadSlowHoldersAfter =
+                            std::max(local.checkpointContext.maxReadSlowHoldersAfter,
+                                     readStatsAfter->slowHolderCount);
+                        local.checkpointContext.maxReadHolderMicrosBefore =
+                            std::max(local.checkpointContext.maxReadHolderMicrosBefore,
+                                     readStatsBefore->maxHolderMicros);
+                        local.checkpointContext.maxReadHolderMicrosAfter =
+                            std::max(local.checkpointContext.maxReadHolderMicrosAfter,
+                                     readStatsAfter->maxHolderMicros);
+                        local.checkpointContext.maxReadWaitingBefore =
+                            std::max(local.checkpointContext.maxReadWaitingBefore,
+                                     static_cast<uint64_t>(readStatsBefore->waitingRequests));
+                        local.checkpointContext.maxReadWaitingAfter =
+                            std::max(local.checkpointContext.maxReadWaitingAfter,
+                                     static_cast<uint64_t>(readStatsAfter->waitingRequests));
+                    }
                     noteResult(local.checkpoints, result.has_value(),
                                result ? std::nullopt
                                       : std::optional<std::string_view>(result.error().message),
@@ -1076,6 +1231,7 @@ TEST_CASE("MetadataRepository SQLite contention profile", "[bench][metadata][sql
                     {"write_mode", cfg.writeModeName},
                     {"wal_bytes_before", walBefore},
                     {"wal_bytes_after", walAfter},
+                    {"wal_page_size", walPageSize.value()},
                     {"writes", latencyJson(aggregate.writes)},
                     {"insert_document_writes", latencyJson(aggregate.insertWrites)},
                     {"metadata_single_writes", latencyJson(aggregate.metadataSingleWrites)},
@@ -1088,6 +1244,7 @@ TEST_CASE("MetadataRepository SQLite contention profile", "[bench][metadata][sql
                     {"extraction_status_writes", latencyJson(aggregate.extractionWrites)},
                     {"reads", latencyJson(aggregate.reads)},
                     {"checkpoints", latencyJson(aggregate.checkpoints)},
+                    {"checkpoint_context", checkpointContextJson(aggregate.checkpointContext)},
                     {"long_reads", latencyJson(aggregate.longReads)},
                     {"external_locks", latencyJson(aggregate.externalLocks)},
                     {"write_pool", poolStatsJson(writePoolStats)}};

--- a/tests/benchmarks/write_coordinator_bench.cpp
+++ b/tests/benchmarks/write_coordinator_bench.cpp
@@ -39,6 +39,7 @@
 #include <yams/app/services/document_ingestion_service.h>
 #include <yams/daemon/components/ServiceManager.h>
 #include <yams/daemon/components/WriteCoordinator.h>
+#include <yams/profiling.h>
 
 namespace fs = std::filesystem;
 using json = nlohmann::json;
@@ -203,6 +204,8 @@ void sleepMs(int ms) {
 } // namespace
 
 TEST_CASE("WriteCoordinator throughput and versioning profile", "[bench][write-coordinator]") {
+    YAMS_ZONE_SCOPED_N("Bench::WriteCoordinator");
+    YAMS_SET_THREAD_NAME("bench-write-coordinator");
     const auto cfg = loadConfig();
 
     spdlog::info("=== WriteCoordinator Benchmark ===");
@@ -217,6 +220,9 @@ TEST_CASE("WriteCoordinator throughput and versioning profile", "[bench][write-c
     REQUIRE(outFile.is_open());
 
     for (int rep = 0; rep < cfg.repeat; ++rep) {
+        YAMS_ZONE_SCOPED_N("Bench::WriteCoordinator::repeat");
+        YAMS_FRAME_MARK_NAMED("write_coordinator_repeat");
+        YAMS_PLOT("bench.write_coordinator.repeat", static_cast<int64_t>(rep));
         spdlog::info("--- Repeat {}/{} ---", rep + 1, cfg.repeat);
 
         DaemonHarness::Options harnessOpts;
@@ -270,6 +276,8 @@ TEST_CASE("WriteCoordinator throughput and versioning profile", "[bench][write-c
 
         // ── Phase 1: Cold ingest (first-time, no versioning) ──
         {
+            YAMS_ZONE_SCOPED_N("Bench::WriteCoordinator::cold_ingest");
+            YAMS_PLOT("bench.write_coordinator.files", static_cast<int64_t>(cfg.numFiles));
             spdlog::info("Phase 1: cold ingest {} files", cfg.numFiles);
             auto snapBefore = CoordinatorSnapshot::from(wc->getStats());
 
@@ -311,10 +319,13 @@ TEST_CASE("WriteCoordinator throughput and versioning profile", "[bench][write-c
 
         // ── Phase 2: Version churn (re-ingest same paths) ──
         {
+            YAMS_ZONE_SCOPED_N("Bench::WriteCoordinator::version_churn");
             spdlog::info("Phase 2: version churn ({} iterations of {} files)",
                          cfg.versionIterations, cfg.numFiles);
 
             for (int vi = 0; vi < cfg.versionIterations; ++vi) {
+                YAMS_ZONE_SCOPED_N("Bench::WriteCoordinator::version_iteration");
+                YAMS_PLOT("bench.write_coordinator.version_iter", static_cast<int64_t>(vi));
                 // Write new content to the same files
                 for (int i = 0; i < cfg.numFiles; ++i) {
                     auto content = randomContent(static_cast<std::size_t>(cfg.fileSizeBytes), rng);
@@ -363,6 +374,7 @@ TEST_CASE("WriteCoordinator throughput and versioning profile", "[bench][write-c
 
         // ── Phase 3: Final coordinator summary ──
         {
+            YAMS_ZONE_SCOPED_N("Bench::WriteCoordinator::final_stats");
             sleepMs(500);
             wc->flush(60s);
 

--- a/tests/benchmarks/write_coordinator_bench.cpp
+++ b/tests/benchmarks/write_coordinator_bench.cpp
@@ -89,11 +89,17 @@ struct CoordinatorSnapshot {
     std::uint64_t opsApplied{0};
     std::uint64_t commitErrors{0};
     std::uint64_t documentsInserted{0};
+    std::uint64_t repairStatusesUpdated{0};
     std::uint64_t metadataEntriesSet{0};
+    std::uint64_t extractionStatusesUpdated{0};
+    std::uint64_t embeddingStatusesUpdated{0};
+    std::uint64_t symbolExtractionStatesUpdated{0};
     std::uint64_t relationshipsInserted{0};
+    std::uint64_t symSpellTermsAdded{0};
     std::uint64_t nodesUpserted{0};
     std::uint64_t edgesAdded{0};
     std::uint64_t maxBatchQueueWaitMs{0};
+    std::uint64_t maxBatchExcessQueueWaitMs{0};
     std::uint64_t maxBatchApplyMs{0};
     std::vector<WriteCoordinator::Stats::Hotspot> hotSources;
 
@@ -104,11 +110,17 @@ struct CoordinatorSnapshot {
         snap.opsApplied = s.opsApplied;
         snap.commitErrors = s.commitErrors;
         snap.documentsInserted = s.documentsInserted;
+        snap.repairStatusesUpdated = s.repairStatusesUpdated;
         snap.metadataEntriesSet = s.metadataEntriesSet;
+        snap.extractionStatusesUpdated = s.extractionStatusesUpdated;
+        snap.embeddingStatusesUpdated = s.embeddingStatusesUpdated;
+        snap.symbolExtractionStatesUpdated = s.symbolExtractionStatesUpdated;
         snap.relationshipsInserted = s.relationshipsInserted;
+        snap.symSpellTermsAdded = s.symSpellTermsAdded;
         snap.nodesUpserted = s.nodesUpserted;
         snap.edgesAdded = s.edgesAdded;
         snap.maxBatchQueueWaitMs = s.maxBatchQueueWaitMs;
+        snap.maxBatchExcessQueueWaitMs = s.maxBatchExcessQueueWaitMs;
         snap.maxBatchApplyMs = s.maxBatchApplyMs;
         snap.hotSources = s.hotSources;
         return snap;
@@ -121,11 +133,18 @@ struct CoordinatorSnapshot {
         d.opsApplied = opsApplied - prev.opsApplied;
         d.commitErrors = commitErrors - prev.commitErrors;
         d.documentsInserted = documentsInserted - prev.documentsInserted;
+        d.repairStatusesUpdated = repairStatusesUpdated - prev.repairStatusesUpdated;
         d.metadataEntriesSet = metadataEntriesSet - prev.metadataEntriesSet;
+        d.extractionStatusesUpdated = extractionStatusesUpdated - prev.extractionStatusesUpdated;
+        d.embeddingStatusesUpdated = embeddingStatusesUpdated - prev.embeddingStatusesUpdated;
+        d.symbolExtractionStatesUpdated =
+            symbolExtractionStatesUpdated - prev.symbolExtractionStatesUpdated;
         d.relationshipsInserted = relationshipsInserted - prev.relationshipsInserted;
+        d.symSpellTermsAdded = symSpellTermsAdded - prev.symSpellTermsAdded;
         d.nodesUpserted = nodesUpserted - prev.nodesUpserted;
         d.edgesAdded = edgesAdded - prev.edgesAdded;
         d.maxBatchQueueWaitMs = maxBatchQueueWaitMs;
+        d.maxBatchExcessQueueWaitMs = maxBatchExcessQueueWaitMs;
         d.maxBatchApplyMs = maxBatchApplyMs;
         d.hotSources = hotSources;
         return d;
@@ -138,11 +157,17 @@ struct CoordinatorSnapshot {
             {"ops_applied", opsApplied},
             {"commit_errors", commitErrors},
             {"documents_inserted", documentsInserted},
+            {"repair_statuses_updated", repairStatusesUpdated},
             {"metadata_entries_set", metadataEntriesSet},
+            {"extraction_statuses_updated", extractionStatusesUpdated},
+            {"embedding_statuses_updated", embeddingStatusesUpdated},
+            {"symbol_extraction_states_updated", symbolExtractionStatesUpdated},
             {"relationships_inserted", relationshipsInserted},
+            {"symspell_terms_added", symSpellTermsAdded},
             {"nodes_upserted", nodesUpserted},
             {"edges_added", edgesAdded},
             {"max_batch_queue_wait_ms", maxBatchQueueWaitMs},
+            {"max_batch_excess_queue_wait_ms", maxBatchExcessQueueWaitMs},
             {"max_batch_apply_ms", maxBatchApplyMs},
         };
         if (!hotSources.empty()) {
@@ -155,6 +180,7 @@ struct CoordinatorSnapshot {
                     {"errors", hs.errors},
                     {"total_queue_wait_ms", hs.totalQueueWaitMs},
                     {"max_queue_wait_ms", hs.maxQueueWaitMs},
+                    {"max_excess_queue_wait_ms", hs.maxExcessQueueWaitMs},
                     {"total_apply_ms", hs.totalApplyMs},
                     {"max_apply_ms", hs.maxApplyMs},
                 });
@@ -202,11 +228,11 @@ TEST_CASE("WriteCoordinator throughput and versioning profile", "[bench][write-c
         REQUIRE(harness.start(30s));
 
         auto* daemon = harness.daemon();
-        REQUIRE(daemon != nullptr);
+        REQUIRE((daemon != nullptr));
         auto* sm = daemon->getServiceManager();
-        REQUIRE(sm != nullptr);
+        REQUIRE((sm != nullptr));
         auto* wc = sm->getWriteCoordinator();
-        REQUIRE(wc != nullptr);
+        REQUIRE((wc != nullptr));
 
         // Create temp directory with test files
         fs::path workDir = harness.rootDir() / "work";

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -668,6 +668,15 @@ if catch2_dep.found()
     install: false,
   )
 
+  catch2_write_coordinator_exe = executable('catch2_write_coordinator',
+    files('unit/daemon/write_coordinator_catch2_test.cpp'),
+    include_directories: incs,
+    dependencies: [catch2_dep, catch2_main_dep] + test_deps,
+    cpp_args: test_cpp_noerror_args + ['-DYAMS_TESTING=1'],
+    build_rpath: ':'.join(_test_rpaths),
+    install: false,
+  )
+
   catch2_service_manager_exe = executable('catch2_service_manager',
     files('unit/daemon/service_manager_catch2_test.cpp'),
     include_directories: incs,
@@ -2600,6 +2609,13 @@ if catch2_dep.found()
 
   test('embedding_lifecycle', catch2_embedding_lifecycle_exe,
     suite: ['catch2', 'unit', 'daemon', 'embedding-lifecycle'],
+    env: { 'LD_LIBRARY_PATH': _test_env_ld_library_path },
+    timeout: 60,
+    is_parallel: false
+  )
+
+  test('write_coordinator', catch2_write_coordinator_exe,
+    suite: ['catch2', 'unit', 'daemon', 'write-coordinator'],
     env: { 'LD_LIBRARY_PATH': _test_env_ld_library_path },
     timeout: 60,
     is_parallel: false

--- a/tests/unit/app/services/document_service_update_metadata_catch2_test.cpp
+++ b/tests/unit/app/services/document_service_update_metadata_catch2_test.cpp
@@ -136,3 +136,49 @@ TEST_CASE("DocumentService atomic metadata updates preserve request-level counts
     REQUIRE((tags));
     CHECK((std::find(tags.value().begin(), tags.value().end(), "fresh") != tags.value().end()));
 }
+
+TEST_CASE("DocumentService non-atomic metadata updates use batch-compatible semantics",
+          "[document][service][update]") {
+    UpdateMetadataFixture fixture;
+
+    UpdateMetadataRequest request;
+    request.hash = fixture.storedHash;
+    request.atomic = false;
+    request.keyValues = {{"author", "alice"}, {"category", "docs"}};
+    request.pairs = {"topic=systems", "topic=storage", "invalidpair"};
+    request.addTags = {"fresh", "fresh"};
+    request.removeTags = {"test", "missing"};
+
+    auto result = fixture.documentService->updateMetadata(request);
+    REQUIRE((result));
+    REQUIRE((result.value().success));
+    REQUIRE((result.value().documentId.has_value()));
+    CHECK((result.value().updatesApplied == 4));
+    CHECK((result.value().tagsAdded == 2));
+    CHECK((result.value().tagsRemoved == 1));
+
+    const auto documentId = *result.value().documentId;
+    auto author = fixture.metadataRepo->getMetadata(documentId, "author");
+    REQUIRE((author));
+    REQUIRE((author.value().has_value()));
+    CHECK((author.value()->asString() == "alice"));
+
+    auto category = fixture.metadataRepo->getMetadata(documentId, "category");
+    REQUIRE((category));
+    REQUIRE((category.value().has_value()));
+    CHECK((category.value()->asString() == "docs"));
+
+    auto topic = fixture.metadataRepo->getMetadata(documentId, "topic");
+    REQUIRE((topic));
+    REQUIRE((topic.value().has_value()));
+    CHECK((topic.value()->asString() == "storage"));
+
+    auto tags = fixture.metadataRepo->getDocumentTags(documentId);
+    REQUIRE((tags));
+    CHECK((std::find(tags.value().begin(), tags.value().end(), "fresh") != tags.value().end()));
+
+    auto removedTag = fixture.metadataRepo->getMetadata(documentId, "tag:test");
+    REQUIRE((removedTag));
+    REQUIRE((removedTag.value().has_value()));
+    CHECK((removedTag.value()->asString().empty()));
+}

--- a/tests/unit/cli/update_command_catch2_test.cpp
+++ b/tests/unit/cli/update_command_catch2_test.cpp
@@ -152,6 +152,23 @@ TEST_CASE("UpdateCommand - parseArguments captures key and value pairs", "[cli][
     CHECK((metadata.value()->asString() == "notes"));
 }
 
+TEST_CASE("UpdateCommand - parseArguments ignores missing value after key",
+          "[cli][update][catch2]") {
+    UpdateCommandFixture fixture;
+    fixture.insertTestDocument("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                               "missing-value.txt");
+
+    UpdateCommand command(fixture.repo, nullptr);
+    command.parseArguments({"--hash",
+                            "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                            "--key", "category", "--value"});
+
+    CaptureStdout capture;
+    const auto result = command.execute();
+    REQUIRE(result.has_value());
+    CHECK((capture.str().find("Metadata updated: 0") != std::string::npos));
+}
+
 TEST_CASE("UpdateCommand - local path batches multiple metadata and tag updates",
           "[cli][update][catch2]") {
     UpdateCommandFixture fixture;

--- a/tests/unit/cli/update_command_catch2_test.cpp
+++ b/tests/unit/cli/update_command_catch2_test.cpp
@@ -120,12 +120,12 @@ TEST_CASE("UpdateCommand - execute updates metadata by hash", "[cli][update][cat
     const auto result = command.execute();
 
     REQUIRE(result.has_value());
-    CHECK(capture.str().find("Document metadata updated successfully!") != std::string::npos);
+    CHECK((capture.str().find("Document metadata updated successfully!") != std::string::npos));
 
     auto metadata = fixture.repo->getMetadata(docId, "author");
     REQUIRE(metadata.has_value());
     REQUIRE(metadata.value().has_value());
-    CHECK(metadata.value()->asString() == "Alice");
+    CHECK((metadata.value()->asString() == "Alice"));
 }
 
 TEST_CASE("UpdateCommand - parseArguments captures key and value pairs", "[cli][update][catch2]") {
@@ -149,5 +149,44 @@ TEST_CASE("UpdateCommand - parseArguments captures key and value pairs", "[cli][
     auto metadata = fixture.repo->getMetadata(doc.value()->id, "category");
     REQUIRE(metadata.has_value());
     REQUIRE(metadata.value().has_value());
-    CHECK(metadata.value()->asString() == "notes");
+    CHECK((metadata.value()->asString() == "notes"));
+}
+
+TEST_CASE("UpdateCommand - local path batches multiple metadata and tag updates",
+          "[cli][update][catch2]") {
+    UpdateCommandFixture fixture;
+    const auto docId = fixture.insertTestDocument(
+        "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface", "batch-test.txt");
+
+    UpdateCommand command(fixture.repo, nullptr);
+    command.parseArguments(
+        {"--hash", "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface", "--metadata",
+         "author=Alice", "--metadata", "category=notes", "--metadata", "topic=systems",
+         "--metadata", "invalidpair", "--tags", "fresh,cli", "--remove-tags", "old"});
+
+    CaptureStdout capture;
+    const auto result = command.execute();
+    REQUIRE(result.has_value());
+    CHECK((capture.str().find("Metadata updated: 4") != std::string::npos));
+    CHECK((capture.str().find("Metadata failed: 1") != std::string::npos));
+
+    auto author = fixture.repo->getMetadata(docId, "author");
+    REQUIRE(author.has_value());
+    REQUIRE(author.value().has_value());
+    CHECK((author.value()->asString() == "Alice"));
+
+    auto category = fixture.repo->getMetadata(docId, "category");
+    REQUIRE(category.has_value());
+    REQUIRE(category.value().has_value());
+    CHECK((category.value()->asString() == "notes"));
+
+    auto topic = fixture.repo->getMetadata(docId, "topic");
+    REQUIRE(topic.has_value());
+    REQUIRE(topic.value().has_value());
+    CHECK((topic.value()->asString() == "systems"));
+
+    auto tags = fixture.repo->getMetadata(docId, "tags");
+    REQUIRE(tags.has_value());
+    REQUIRE(tags.value().has_value());
+    CHECK((tags.value()->asString() == "fresh,cli,-old"));
 }

--- a/tests/unit/daemon/components/checkpoint_manager_test.cpp
+++ b/tests/unit/daemon/components/checkpoint_manager_test.cpp
@@ -8,18 +8,49 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <yams/daemon/components/CheckpointManager.h>
+#include <yams/metadata/connection_pool.h>
+#include <yams/metadata/metadata_repository.h>
 
 #include <boost/asio/io_context.hpp>
 
 #include <atomic>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
 #include <thread>
 
 using namespace yams::daemon;
 using namespace std::chrono_literals;
 
 namespace {
+
+class CountingMetadataRepository : public yams::metadata::MetadataRepository {
+public:
+    explicit CountingMetadataRepository(yams::metadata::ConnectionPool& pool)
+        : yams::metadata::MetadataRepository(pool) {}
+
+    yams::Result<void> checkpointWal() override {
+        ++passiveCalls;
+        return {};
+    }
+
+    yams::Result<void> checkpointWalTruncate() override {
+        ++truncateCalls;
+        return {};
+    }
+
+    int passiveCalls{0};
+    int truncateCalls{0};
+};
+
+void createSparseFile(const std::filesystem::path& path, std::uint64_t sizeBytes) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    REQUIRE(out.good());
+    out.seekp(static_cast<std::streamoff>(sizeBytes - 1));
+    const char byte = '\0';
+    out.write(&byte, 1);
+    REQUIRE(out.good());
+}
 
 struct CheckpointManagerFixture {
     std::shared_ptr<boost::asio::io_context> io;
@@ -88,14 +119,14 @@ TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager construction and s
     }
 
     SECTION("initial counters are zero") {
-        CHECK(mgr.vectorCheckpointCount() == 0);
-        CHECK(mgr.hotzoneCheckpointCount() == 0);
-        CHECK(mgr.checkpointErrorCount() == 0);
+        CHECK((mgr.vectorCheckpointCount() == 0));
+        CHECK((mgr.hotzoneCheckpointCount() == 0));
+        CHECK((mgr.checkpointErrorCount() == 0));
     }
 
     SECTION("stats are initially zero") {
-        CHECK(mgr.lastVectorCheckpointEpoch() == 0);
-        CHECK(mgr.lastHotzoneCheckpointEpoch() == 0);
+        CHECK((mgr.lastVectorCheckpointEpoch() == 0));
+        CHECK((mgr.lastHotzoneCheckpointEpoch() == 0));
     }
 }
 
@@ -149,9 +180,9 @@ TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager manual checkpoint"
 
         bool result = mgr.checkpointNow();
         CHECK(result);
-        CHECK(mgr.vectorCheckpointCount() == 0);
-        CHECK(mgr.hotzoneCheckpointCount() == 0);
-        CHECK(mgr.checkpointErrorCount() == 0);
+        CHECK((mgr.vectorCheckpointCount() == 0));
+        CHECK((mgr.hotzoneCheckpointCount() == 0));
+        CHECK((mgr.checkpointErrorCount() == 0));
     }
 
     SECTION("checkpoint with hotzone enabled succeeds") {
@@ -172,14 +203,80 @@ TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager manual checkpoint"
         for (int i = 0; i < 5; ++i) {
             CHECK(mgr.checkpointNow());
         }
-        CHECK(mgr.checkpointErrorCount() == 0);
+        CHECK((mgr.checkpointErrorCount() == 0));
     }
+}
+
+TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager routine checkpoint is passive",
+                 "[daemon][components][checkpoint][catch2]") {
+    yams::metadata::ConnectionPoolConfig poolConfig;
+    poolConfig.minConnections = 1;
+    poolConfig.maxConnections = 1;
+    poolConfig.enableWAL = true;
+    yams::metadata::ConnectionPool pool((tempDir / "metadata.db").string(), poolConfig);
+    REQUIRE(pool.initialize().has_value());
+    CountingMetadataRepository repository(pool);
+
+    auto cfg = makeConfig();
+    auto deps = makeDeps();
+    deps.metadataRepository = &repository;
+    CheckpointManager mgr(cfg, deps);
+
+    CHECK(mgr.checkpointNow());
+
+    CHECK((repository.passiveCalls == 1));
+    CHECK((repository.truncateCalls == 0));
+}
+
+TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager watermark checkpoint truncates WAL",
+                 "[daemon][components][checkpoint][catch2]") {
+    yams::metadata::ConnectionPoolConfig poolConfig;
+    poolConfig.minConnections = 1;
+    poolConfig.maxConnections = 1;
+    poolConfig.enableWAL = true;
+    yams::metadata::ConnectionPool pool((tempDir / "metadata.db").string(), poolConfig);
+    REQUIRE(pool.initialize().has_value());
+    CountingMetadataRepository repository(pool);
+
+    constexpr std::uint64_t kWatermarkBytes = 256ULL * 1024ULL * 1024ULL;
+    createSparseFile(tempDir / "yams.db-wal", kWatermarkBytes + 1);
+    auto cfg = makeConfig();
+    auto deps = makeDeps();
+    deps.metadataRepository = &repository;
+    CheckpointManager mgr(cfg, deps);
+
+    CHECK(mgr.checkpointNow());
+
+    CHECK((repository.passiveCalls == 0));
+    CHECK((repository.truncateCalls == 1));
+}
+
+TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager shutdown truncates WAL",
+                 "[daemon][components][checkpoint][catch2]") {
+    yams::metadata::ConnectionPoolConfig poolConfig;
+    poolConfig.minConnections = 1;
+    poolConfig.maxConnections = 1;
+    poolConfig.enableWAL = true;
+    yams::metadata::ConnectionPool pool((tempDir / "metadata.db").string(), poolConfig);
+    REQUIRE(pool.initialize().has_value());
+    CountingMetadataRepository repository(pool);
+
+    auto cfg = makeConfig();
+    auto deps = makeDeps();
+    deps.metadataRepository = &repository;
+    CheckpointManager mgr(cfg, deps);
+    mgr.start();
+    std::this_thread::sleep_for(50ms);
+
+    mgr.stop();
+
+    CHECK((repository.truncateCalls == 1));
 }
 
 TEST_CASE("CheckpointManager config defaults", "[daemon][components][checkpoint][catch2]") {
     CheckpointManager::Config cfg;
 
-    CHECK(cfg.checkpoint_interval.count() == 300);
-    CHECK(cfg.vector_index_insert_threshold == 1000);
+    CHECK((cfg.checkpoint_interval.count() == 300));
+    CHECK((cfg.vector_index_insert_threshold == 1000));
     CHECK_FALSE(cfg.enable_hotzone_persistence);
 }

--- a/tests/unit/daemon/write_coordinator_catch2_test.cpp
+++ b/tests/unit/daemon/write_coordinator_catch2_test.cpp
@@ -1,0 +1,98 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <yams/daemon/components/WriteCoordinator.h>
+
+#include <boost/asio/io_context.hpp>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+
+using yams::daemon::AddSymSpellTermsOp;
+using yams::daemon::WriteBatch;
+using yams::daemon::WriteCoordinator;
+
+namespace {
+
+std::unique_ptr<WriteBatch> makeTermBatch(const std::string& term) {
+    auto batch = std::make_unique<WriteBatch>();
+    batch->source = "test/write_coordinator_capacity";
+    batch->ops.emplace_back(AddSymSpellTermsOp{{term}});
+    return batch;
+}
+
+} // namespace
+
+TEST_CASE("WriteCoordinator: tryEnqueue rejects batches at channel capacity",
+          "[unit][daemon][write-coordinator]") {
+    boost::asio::io_context io;
+    WriteCoordinator::Config config;
+    config.maxBatchSize = 8;
+    config.maxBatchDelayMs = std::chrono::milliseconds{1};
+    config.channelCapacity = 2;
+    WriteCoordinator coordinator(io, {}, {}, config);
+
+    coordinator.enqueue(makeTermBatch("alpha"));
+    coordinator.enqueue(makeTermBatch("beta"));
+    REQUIRE((coordinator.queuedBatches() == 2));
+
+    auto rejected = makeTermBatch("gamma");
+    CHECK_FALSE(coordinator.tryEnqueue(rejected));
+    REQUIRE((rejected != nullptr));
+    CHECK((coordinator.queuedBatches() == 2));
+
+    coordinator.start();
+    std::thread writerLoop([&io] { io.run(); });
+
+    auto flushResult = coordinator.flush(std::chrono::seconds{10});
+    REQUIRE((flushResult.has_value()));
+
+    CHECK(coordinator.tryEnqueue(rejected));
+    CHECK((rejected == nullptr));
+
+    auto secondFlush = coordinator.flush(std::chrono::seconds{10});
+    REQUIRE((secondFlush.has_value()));
+
+    auto stats = coordinator.getStats();
+    CHECK((stats.batchesEnqueued == 3));
+    CHECK((stats.batchesCommitted == 3));
+
+    coordinator.shutdown();
+    io.stop();
+    if (writerLoop.joinable()) {
+        writerLoop.join();
+    }
+}
+
+TEST_CASE("WriteCoordinator: shutdown drains queued batches and rejects new enqueue",
+          "[unit][daemon][write-coordinator]") {
+    boost::asio::io_context io;
+    WriteCoordinator::Config config;
+    config.maxBatchSize = 1;
+    config.maxBatchDelayMs = std::chrono::milliseconds{1};
+    config.channelCapacity = 8;
+    WriteCoordinator coordinator(io, {}, {}, config);
+
+    coordinator.enqueue(makeTermBatch("alpha"));
+    coordinator.enqueue(makeTermBatch("beta"));
+    REQUIRE((coordinator.queuedBatches() == 2));
+
+    coordinator.start();
+    std::thread writerLoop([&io] { io.run(); });
+
+    coordinator.shutdown();
+    io.stop();
+    if (writerLoop.joinable()) {
+        writerLoop.join();
+    }
+
+    CHECK((coordinator.queuedBatches() == 0));
+    auto stats = coordinator.getStats();
+    CHECK((stats.batchesEnqueued == 2));
+    CHECK((stats.batchesCommitted == 2));
+
+    auto lateBatch = makeTermBatch("gamma");
+    CHECK_FALSE(coordinator.tryEnqueue(lateBatch));
+    CHECK((lateBatch != nullptr));
+    CHECK((coordinator.queuedBatches() == 0));
+}

--- a/tests/unit/daemon/write_coordinator_catch2_test.cpp
+++ b/tests/unit/daemon/write_coordinator_catch2_test.cpp
@@ -72,6 +72,7 @@ TEST_CASE("WriteCoordinator: shutdown drains queued batches and rejects new enqu
     config.maxBatchDelayMs = std::chrono::milliseconds{1};
     config.channelCapacity = 8;
     WriteCoordinator coordinator(io, {}, {}, config);
+    CHECK_FALSE(coordinator.isShuttingDown());
 
     coordinator.enqueue(makeTermBatch("alpha"));
     coordinator.enqueue(makeTermBatch("beta"));
@@ -87,6 +88,7 @@ TEST_CASE("WriteCoordinator: shutdown drains queued batches and rejects new enqu
     }
 
     CHECK((coordinator.queuedBatches() == 0));
+    CHECK(coordinator.isShuttingDown());
     auto stats = coordinator.getStats();
     CHECK((stats.batchesEnqueued == 2));
     CHECK((stats.batchesCommitted == 2));

--- a/tests/unit/metadata/metadata_repository_catch2_test.cpp
+++ b/tests/unit/metadata/metadata_repository_catch2_test.cpp
@@ -2537,6 +2537,110 @@ TEST_CASE(
     CHECK((fuzzyResult.value().results.front().document.id == docId));
 }
 
+TEST_CASE("MetadataRepository: coordinator coalesces duplicate SymSpell terms preserving "
+          "frequency",
+          "[unit][metadata][repository][symspell]") {
+    MetadataRepositoryFixture fix;
+
+    auto doc = makeDocumentWithPath(
+        "/notes/symspell_coalesce.txt",
+        "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE70");
+    auto insertResult = fix.repository_->insertDocument(doc);
+    REQUIRE((insertResult.has_value()));
+    const auto docId = insertResult.value();
+
+    const std::string indexedTerm = "coalescestormtarget";
+    const std::string contentText = std::string("The ") + indexedTerm;
+    REQUIRE((fix.repository_->indexDocumentContent(docId, doc.fileName, contentText, "text/plain")
+                 .has_value()));
+
+    boost::asio::io_context io;
+    yams::daemon::WriteCoordinator::Config config;
+    config.maxBatchSize = 8;
+    config.maxBatchDelayMs = std::chrono::milliseconds{1};
+    config.channelCapacity = 512;
+    auto repoRef =
+        std::shared_ptr<MetadataRepository>(fix.repository_.get(), [](MetadataRepository*) {});
+    yams::daemon::WriteCoordinator coordinator(io, {}, repoRef, config);
+    coordinator.start();
+    std::thread writerLoop([&io] { io.run(); });
+
+    constexpr std::uint64_t kDuplicateBatches = 300;
+    for (std::uint64_t i = 0; i < kDuplicateBatches; ++i) {
+        auto batch = std::make_unique<yams::daemon::WriteBatch>();
+        batch->source = "test/symspell_coalesce";
+        batch->ops.emplace_back(yams::daemon::AddSymSpellTermsOp{{indexedTerm}});
+        coordinator.enqueue(std::move(batch));
+    }
+
+    auto flushResult = coordinator.flush(std::chrono::seconds{10});
+    coordinator.shutdown();
+    io.stop();
+    if (writerLoop.joinable()) {
+        writerLoop.join();
+    }
+
+    REQUIRE((flushResult.has_value()));
+    CHECK((coordinator.getStats().symSpellTermsAdded == kDuplicateBatches));
+
+    auto fuzzyResult = fix.repository_->fuzzySearch("coalescestormtargat", 0.6f, 10);
+    REQUIRE((fuzzyResult.has_value()));
+    REQUIRE((fuzzyResult.value().results.size() == 1));
+    CHECK((fuzzyResult.value().results.front().document.id == docId));
+}
+
+TEST_CASE("MetadataRepository: SymSpell terms spanning write chunk boundaries are all indexed",
+          "[unit][metadata][repository][symspell]") {
+    MetadataRepositoryFixture fix;
+
+    struct Target {
+        std::string term;
+        std::string typo;
+        std::string path;
+        std::string hashSuffix;
+        int64_t docId = 0;
+    };
+    std::vector<Target> targets = {
+        {"alphachunkzero", "alphachunkzera", "/notes/chunk_alpha.txt", "71", 0},
+        {"betachunkmiddle", "betachunkmiddel", "/notes/chunk_beta.txt", "72", 0},
+        {"gammachunklast", "gammachunklasd", "/notes/chunk_gamma.txt", "73", 0},
+    };
+
+    for (auto& target : targets) {
+        auto doc = makeDocumentWithPath(
+            target.path,
+            std::string("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE") +
+                target.hashSuffix);
+        auto insertResult = fix.repository_->insertDocument(doc);
+        REQUIRE((insertResult.has_value()));
+        target.docId = insertResult.value();
+        const std::string contentText = std::string("The ") + target.term;
+        REQUIRE((fix.repository_
+                     ->indexDocumentContent(target.docId, doc.fileName, contentText, "text/plain")
+                     .has_value()));
+    }
+
+    constexpr std::size_t kTotalTerms = 520;
+    std::vector<std::pair<std::string, int64_t>> termPairs;
+    termPairs.reserve(kTotalTerms);
+    for (std::size_t i = 0; i < kTotalTerms; ++i) {
+        termPairs.emplace_back("fillerchunkterm" + std::to_string(i), 1);
+    }
+    termPairs[0] = {targets[0].term, 1};
+    termPairs[511] = {targets[1].term, 1};
+    termPairs[519] = {targets[2].term, 1};
+
+    auto addTermsResult = fix.repository_->tryAddSymSpellTerms(termPairs);
+    REQUIRE((addTermsResult.has_value()));
+
+    for (const auto& target : targets) {
+        auto fuzzyResult = fix.repository_->fuzzySearch(target.typo, 0.6f, 10);
+        REQUIRE((fuzzyResult.has_value()));
+        REQUIRE((fuzzyResult.value().results.size() == 1));
+        CHECK((fuzzyResult.value().results.front().document.id == target.docId));
+    }
+}
+
 TEST_CASE("MetadataRepository: search sanitizes snippet UTF-8", "[unit][metadata][repository]") {
     MetadataRepositoryFixture fix;
 

--- a/tests/unit/metadata/metadata_repository_catch2_test.cpp
+++ b/tests/unit/metadata/metadata_repository_catch2_test.cpp
@@ -3384,6 +3384,40 @@ TEST_CASE("batchInsertContentAndIndex: fresh documents increment extracted and i
     }
 }
 
+TEST_CASE(
+    "batchInsertContentAndIndex: duplicate document entries preserve per-entry repair attempts",
+    "[unit][metadata-repo][batch-content][status-update][duplicates]") {
+    MetadataRepositoryFixture fix;
+
+    DocumentInfo doc;
+    doc.sha256Hash = "counter_hash_duplicate_status";
+    doc.fileName = "duplicate_status.txt";
+    doc.fileSize = 100;
+    doc.mimeType = "text/plain";
+    doc.createdTime = std::chrono::floor<std::chrono::seconds>(std::chrono::system_clock::now());
+    doc.modifiedTime = doc.createdTime;
+    auto insertResult = fix.repository_->insertDocument(doc);
+    REQUIRE((insertResult.has_value()));
+    const auto docId = insertResult.value();
+
+    BatchContentEntry first = makeBatchContentEntry(docId, "First title", "First content");
+    BatchContentEntry second = makeBatchContentEntry(docId, "Second title", "Second content");
+
+    auto batchResult = fix.repository_->batchInsertContentAndIndex({first, second});
+    REQUIRE((batchResult.has_value()));
+
+    auto docResult = fix.repository_->getDocument(docId);
+    REQUIRE((docResult.has_value()));
+    REQUIRE((docResult.value().has_value()));
+    CHECK((docResult.value()->repairStatus == RepairStatus::Completed));
+    CHECK((docResult.value()->repairAttempts == 2));
+
+    auto contentResult = fix.repository_->getContent(docId);
+    REQUIRE((contentResult.has_value()));
+    REQUIRE((contentResult.value().has_value()));
+    CHECK((contentResult.value()->contentText == "Second content"));
+}
+
 TEST_CASE("batchInsertContentAndIndex: skips stale missing document ids",
           "[unit][metadata-repo][batch-content][counters][stale]") {
     MetadataRepositoryFixture fix;

--- a/tests/unit/metadata/versioning_util_catch2_test.cpp
+++ b/tests/unit/metadata/versioning_util_catch2_test.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <fstream>
 #include <random>
+#include <tuple>
 
 #include <yams/compat/unistd.h>
 #include <yams/metadata/connection_pool.h>
@@ -60,6 +61,26 @@ DocumentInfo makeDocInfo(const std::string& filePath, const std::string& hash,
     return info;
 }
 
+class BatchFailingMetadataRepository : public MetadataRepository {
+public:
+    explicit BatchFailingMetadataRepository(ConnectionPool& pool) : MetadataRepository(pool) {}
+
+    Result<void> setMetadataBatch(
+        const std::vector<std::tuple<int64_t, std::string, MetadataValue>>& entries) override {
+        ++batchAttempts;
+        lastBatchSize = entries.size();
+        if (failNextBatch) {
+            failNextBatch = false;
+            return Error{ErrorCode::DatabaseError, "injected metadata batch failure"};
+        }
+        return MetadataRepository::setMetadataBatch(entries);
+    }
+
+    bool failNextBatch{true};
+    std::size_t batchAttempts{0};
+    std::size_t lastBatchSize{0};
+};
+
 struct VersioningFixture {
     VersioningFixture() { testDir = make_temp_dir(); }
 
@@ -76,6 +97,15 @@ struct VersioningFixture {
         REQUIRE(pool_->initialize());
         repo_ = std::make_shared<MetadataRepository>(*pool_);
         return repo_;
+    }
+
+    std::shared_ptr<BatchFailingMetadataRepository> makeBatchFailingRepo() {
+        auto dbPath = (testDir / "meta.db").string();
+        pool_ = std::make_shared<ConnectionPool>(dbPath);
+        REQUIRE(pool_->initialize());
+        auto repo = std::make_shared<BatchFailingMetadataRepository>(*pool_);
+        repo_ = repo;
+        return repo;
     }
 
     std::filesystem::path testDir;
@@ -100,22 +130,22 @@ TEST_CASE_METHOD(VersioningFixture, "Versioning: first document gets version 1 a
     auto docId = ins.value();
 
     int64_t version = applyPathSeriesVersioning(*repo, docInfo.filePath, docId, std::nullopt);
-    CHECK(version == 1);
+    CHECK((version == 1));
 
     auto verMeta = repo->getMetadata(docId, "version");
     REQUIRE(verMeta);
     REQUIRE(verMeta.value().has_value());
-    CHECK(verMeta.value()->asInteger() == 1);
+    CHECK((verMeta.value()->asInteger() == 1));
 
     auto latestMeta = repo->getMetadata(docId, "is_latest");
     REQUIRE(latestMeta);
     REQUIRE(latestMeta.value().has_value());
-    CHECK(latestMeta.value()->asBoolean() == true);
+    CHECK((latestMeta.value()->asBoolean() == true));
 
     auto seriesMeta = repo->getMetadata(docId, "series_key");
     REQUIRE(seriesMeta);
     REQUIRE(seriesMeta.value().has_value());
-    CHECK(seriesMeta.value()->asString() == docInfo.filePath);
+    CHECK((seriesMeta.value()->asString() == docInfo.filePath));
 }
 
 TEST_CASE_METHOD(VersioningFixture, "Versioning: re-index with different hash creates version edge",
@@ -134,37 +164,37 @@ TEST_CASE_METHOD(VersioningFixture, "Versioning: re-index with different hash cr
     REQUIRE(ins1);
     auto id1 = ins1.value();
     int64_t ver1 = applyPathSeriesVersioning(*repo, path, id1, std::nullopt);
-    CHECK(ver1 == 1);
+    CHECK((ver1 == 1));
 
     auto v2 = makeDocInfo(path, "hash_v2", "evolving.txt");
     auto ins2 = repo->insertDocument(v2);
     REQUIRE(ins2);
     auto id2 = ins2.value();
-    REQUIRE(id1 != id2);
+    REQUIRE((id1 != id2));
 
     auto priorDocResult = repo->findDocumentByExactPath(path);
     REQUIRE(priorDocResult);
     auto priorDoc = priorDocResult.value();
     REQUIRE(priorDoc.has_value());
     int64_t ver2 = applyPathSeriesVersioning(*repo, path, id2, priorDoc);
-    CHECK(ver2 == 2);
+    CHECK((ver2 == 2));
 
     // v1 is no longer latest
     auto latest1 = repo->getMetadata(id1, "is_latest");
     REQUIRE(latest1);
     REQUIRE(latest1.value().has_value());
-    CHECK(latest1.value()->asBoolean() == false);
+    CHECK((latest1.value()->asBoolean() == false));
 
     // v2 is latest
     auto latest2 = repo->getMetadata(id2, "is_latest");
     REQUIRE(latest2);
     REQUIRE(latest2.value().has_value());
-    CHECK(latest2.value()->asBoolean() == true);
+    CHECK((latest2.value()->asBoolean() == true));
 
     auto verMeta2 = repo->getMetadata(id2, "version");
     REQUIRE(verMeta2);
     REQUIRE(verMeta2.value().has_value());
-    CHECK(verMeta2.value()->asInteger() == 2);
+    CHECK((verMeta2.value()->asInteger() == 2));
 
     // VersionOf relationship exists
     auto relResult = repo->getRelationships(id2);
@@ -202,7 +232,74 @@ TEST_CASE_METHOD(VersioningFixture, "Versioning: same hash re-index does not cre
     auto priorDoc = repo->findDocumentByExactPath(path);
     REQUIRE(priorDoc);
     REQUIRE(priorDoc.value().has_value());
-    CHECK(priorDoc.value()->sha256Hash == "hash_same");
+    CHECK((priorDoc.value()->sha256Hash == "hash_same"));
+}
+
+TEST_CASE_METHOD(VersioningFixture,
+                 "Versioning: metadata batch failure falls back to best-effort individual writes",
+                 "[versioning][metadata][catch2]") {
+#ifdef _WIN32
+    _putenv_s("YAMS_ENABLE_VERSIONING", "1");
+#else
+    setenv("YAMS_ENABLE_VERSIONING", "1", 1);
+#endif
+
+    auto repo = makeBatchFailingRepo();
+    const std::string path = "/path/fallback.txt";
+
+    auto v1 = makeDocInfo(path, "hash_v1_fallback", "fallback.txt");
+    auto ins1 = repo->insertDocument(v1);
+    REQUIRE(ins1);
+    const auto id1 = ins1.value();
+    REQUIRE((applyPathSeriesVersioning(*repo, path, id1, std::nullopt) == 1));
+    REQUIRE((repo->batchAttempts == 1));
+    REQUIRE((repo->lastBatchSize == 3));
+
+    repo->failNextBatch = true;
+    auto v2 = makeDocInfo(path, "hash_v2_fallback", "fallback.txt");
+    auto ins2 = repo->insertDocument(v2);
+    REQUIRE(ins2);
+    const auto id2 = ins2.value();
+
+    auto priorDoc = repo->findDocumentByExactPath(path);
+    REQUIRE(priorDoc);
+    REQUIRE(priorDoc.value().has_value());
+
+    const auto version = applyPathSeriesVersioning(*repo, path, id2, priorDoc.value());
+    CHECK((version == 2));
+    CHECK((repo->batchAttempts == 2));
+    CHECK((repo->lastBatchSize == 4));
+
+    auto latest1 = repo->getMetadata(id1, "is_latest");
+    REQUIRE(latest1);
+    REQUIRE(latest1.value().has_value());
+    CHECK((latest1.value()->asBoolean() == false));
+
+    auto version2 = repo->getMetadata(id2, "version");
+    REQUIRE(version2);
+    REQUIRE(version2.value().has_value());
+    CHECK((version2.value()->asInteger() == 2));
+
+    auto latest2 = repo->getMetadata(id2, "is_latest");
+    REQUIRE(latest2);
+    REQUIRE(latest2.value().has_value());
+    CHECK((latest2.value()->asBoolean() == true));
+
+    auto series2 = repo->getMetadata(id2, "series_key");
+    REQUIRE(series2);
+    REQUIRE(series2.value().has_value());
+    CHECK((series2.value()->asString() == path));
+
+    auto relResult = repo->getRelationships(id2);
+    REQUIRE(relResult);
+    bool foundVersionOf = false;
+    for (const auto& rel : relResult.value()) {
+        if (rel.relationshipType == RelationshipType::VersionOf && rel.parentId == id1) {
+            foundVersionOf = true;
+            break;
+        }
+    }
+    CHECK(foundVersionOf);
 }
 
 TEST_CASE_METHOD(VersioningFixture, "Versioning respects YAMS_ENABLE_VERSIONING=0",
@@ -220,7 +317,7 @@ TEST_CASE_METHOD(VersioningFixture, "Versioning respects YAMS_ENABLE_VERSIONING=
     auto docId = ins.value();
 
     int64_t version = applyPathSeriesVersioning(*repo, docInfo.filePath, docId, std::nullopt);
-    CHECK(version == 0);
+    CHECK((version == 0));
 
     auto verMeta = repo->getMetadata(docId, "version");
     REQUIRE(verMeta);


### PR DESCRIPTION
## Problem

Metadata and daemon write paths needed release-prep hardening: prior profiling showed avoidable write-path latency, unclear benchmark plumbing, and weak evidence around checkpoint policy / SQLite contention.

Recent release signal checked before opening:
- Latest scheduled `Release` on `main` failed in Linux package jobs (`linux-x86_64`, `linux-arm64`) while linking `src/daemon/yams-daemon`.
- Failure is unresolved `std::stacktrace` symbols from libstdc++/GCC 14 stacktrace support:
  - `std::stacktrace_entry::_Info::_M_populate(unsigned long)`
  - `std::__stacktrace_impl::_S_current(...)`
- macOS and Windows release package jobs passed in that run.
- Current `experimental` Tests run is in progress: https://github.com/trvon/yams/actions/runs/27431919046

## Solution

- Batch and profile metadata/write-path updates:
  - batch content/index status updates for unique-doc batches
  - preserve duplicate-doc repair-attempt semantics
  - add trace-only phase timing for batch content and metadata batch writes
  - add benchmark runners for Tracy detection, benchmark smoke suite, stable metadata baselines, and complexity analysis
- Confirm checkpoint policy with tests:
  - routine checkpoints use PASSIVE
  - watermark checkpoints use TRUNCATE
  - shutdown uses TRUNCATE
- Add/extend benchmark coverage and focused Catch2 tests for metadata repository behavior.

## Release Note
- [ ] Internal only (no user-facing release note)
- User-facing summary (1-2 bullets, outcome-focused):
  - Improves metadata/write-path batching and profiling coverage, reducing measured batch-content status-update tails in benchmark workloads.
- Migration or operator note (if needed): None.
