### PR TITLE
perf(search): bound topology routing and harden runtime paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
             arch_container: true
     runs-on: ${{ matrix.runs_on }}
     env:
+      BUILD_DIR: build/release
       STAGE_DIR: stage
     steps:
       - name: Checkout
@@ -833,6 +834,21 @@ jobs:
               linux-arm64) ARCH="armv8" ;;
               linux-x86_64) ARCH="x86_64" ;;
             esac
+          fi
+
+          # Hosted runners already provide CMake. Model it as a Conan platform
+          # tool so cold ARM64 caches do not download another CMake from cmake.org.
+          if [ "${{ matrix.hosted }}" = "true" ]; then
+            SYSTEM_CMAKE_VERSION="$(cmake --version | sed -n -E '1s/^cmake version ([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p')"
+            if [ -z "$SYSTEM_CMAKE_VERSION" ]; then
+              echo "Unable to detect the hosted CMake version" >&2
+              exit 1
+            fi
+            CI_HOST_PROFILE="${RUNNER_TEMP}/yams-conan-host-${{ matrix.suffix }}"
+            cp "$HOST_PROFILE" "$CI_HOST_PROFILE"
+            printf '\n[platform_tool_requires]\ncmake/%s\n' "$SYSTEM_CMAKE_VERSION" >> "$CI_HOST_PROFILE"
+            HOST_PROFILE="$CI_HOST_PROFILE"
+            echo "Using platform CMake ${SYSTEM_CMAKE_VERSION} via ${HOST_PROFILE}"
           fi
 
           # Use setup.sh with CI environment variables for consistent configuration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ---
 description: YAMS repo supplement — conventions, structure, and repo-scoped rules
-argument-hint: [TASK=<description>] [MODE=<engineering|bug-bounty>] [PHASE=<start|checkpoint|complete>]
+argument-hint: "[TASK=<description>] [MODE=<engineering|bug-bounty>] [PHASE=<start|checkpoint|complete>]"
 ---
 
 # AGENTS.md (Repo Supplement)

--- a/docs/PROMPT-eng.md
+++ b/docs/PROMPT-eng.md
@@ -1,6 +1,6 @@
 ---
 description: YAMS-first agent with blackboard coordination and persistent memory
-argument-hint: [TASK=<description>] [PHASE=<start|checkpoint|complete>]
+argument-hint: "[TASK=<description>] [PHASE=<start|checkpoint|complete>]"
 ---
 
 # Agent Workflow (YAMS + Blackboard)
@@ -100,11 +100,22 @@ bb_update_task({ task_id: "<task-id>", status: "working" })
 yams grep "<pattern>" --cwd .
 
 # Semantic/concept search
-yams search "$TASK" --limit 20
+yams search "$TASK" --limit 10
 
-# Structured metadata lookups
-yams search "task=$TASK" --type keyword --limit 20
+# Exact task-memory lookup
+yams list --format json --show-metadata \
+  --metadata "owner=opencode" --metadata "task=$TASK" \
+  --metadata "source=note" --limit 10
+
+# Search/list results are candidates, not recovered memory. Hydrate the
+# relevant note, decision, research, or evidence artifact by its exact hash.
+yams cat --hash <hash-from-result>
 ```
+
+Do not rely on a search snippet as task context. Hydrate the most relevant
+saved-memory artifacts before acting. For code hits, use the graph and then a
+targeted local read; use `yams get --hash <hash> -o <path>` only when a
+filesystem copy is needed.
 
 ### 1a) Use the Graph for Codebase Navigation
 
@@ -148,28 +159,28 @@ For C++ / systems implementation, do not jump straight from discovery to edits:
 - refactor only while tests stay green
 - profile before optimizing: define workload/KPI, baseline, change one thing, re-measure
 
-### 2) Start Work (Index Baseline + Claim)
+### 2) Start Work (Check Index + Claim)
 
 ```bash
-# Index baseline
+# Check first. Only rebuild a missing/stale repo index; do not attach the
+# current task to every source file in an already healthy index.
+yams status
 yams add . --recursive \
   --include "*.cpp,*.hpp,*.h,*.py,*.ts,*.js,*.md" \
-  --label "Working on: $TASK" \
-  --metadata "task=$TASK,phase=start,owner=opencode,source=code,agent_id=opencode-$TASK"
+  --label "Repository baseline" \
+  --metadata "task=repo-index,phase=checkpoint,owner=opencode,source=code"
 ```
 
-If blackboard is available, claim or create a task there. If not, "claim" files via YAMS metadata:
+Store the claim in YAMS even when blackboard coordination is available, so
+session recovery has one concise task artifact:
 
 ```bash
 yams add - --name "claim-$TASK.md" \
-  --metadata "task=$TASK,phase=start,owner=opencode,source=note,agent_id=opencode-$TASK" \
-  <<'EOF'
-## Claim
-Agent: opencode-$TASK
-Scope: <paths or subsystems>
-Goal: <one sentence>
-EOF
+  --metadata "task=$TASK,phase=start,owner=opencode,source=note,agent_id=opencode-$TASK"
 ```
+
+Send `TASK`, `SCOPE`, `GOAL`, and `NEXT` directly on stdin. Also claim or
+create the task on the blackboard when available.
 
 ### 3) Checkpoint (Index What Changed)
 
@@ -179,14 +190,10 @@ yams add <changed-files> \
   --metadata "task=$TASK,phase=checkpoint,owner=opencode,source=code,agent_id=opencode-$TASK"
 ```
 
-### 4) Complete (Index + Close Loop)
+### 4) Complete (Handoff + Close Loop)
 
-```bash
-yams add . --recursive \
-  --include "*.cpp,*.hpp,*.h,*.py,*.ts,*.js,*.md" \
-  --label "Completed: $TASK" \
-  --metadata "task=$TASK,phase=complete,owner=opencode,source=code,agent_id=opencode-$TASK"
-```
+Store the completed Response Template as a `source=note`, `phase=complete`
+artifact, then index only changed files with `phase=complete` metadata.
 
 ## Response Template
 
@@ -225,7 +232,19 @@ NEXT:
 
 ## Context Recovery
 
-If the chat context is compacted or lost, rebuild it from YAMS using `yams list` filtered by `owner=opencode`, `task`, and recent time.
+If the chat context is compacted or lost, rebuild it from YAMS with exact
+metadata filters, then hydrate the relevant artifacts. A list result alone is
+not recovered context.
+
+```bash
+yams list --format json --show-metadata \
+  --metadata "owner=opencode" --metadata "task=<task>" \
+  --metadata "source=note" --limit 10
+yams cat --hash <selected-note-or-decision-hash>
+```
+
+Change the `source` filter to `decision`, `research`, or `evidence` when that
+artifact type carries the needed context.
 
 ## References (Skills)
 

--- a/docs/prompts/PROMPT-eng-codex.md
+++ b/docs/prompts/PROMPT-eng-codex.md
@@ -1,6 +1,6 @@
 ---
 description: Codex engineering/bug-bounty prompt with YAMS-first distributed memory
-argument-hint: [TASK=<description>] [MODE=<engineering|bug-bounty>] [PHASE=<start|checkpoint|complete>]
+argument-hint: "[TASK=<description>] [MODE=<engineering|bug-bounty>] [PHASE=<start|checkpoint|complete>]"
 ---
 
 # Codex Prompt (YAMS-First)
@@ -26,22 +26,31 @@ Agent identity: `opencode-<task-slug>` (lowercase ASCII, dashes).
 
 ## Retrieval Contract (mandatory, token-economy)
 
-YAMS retrieval returns scoped snippets; local exploration re-reads whole files
-the index already knows. Burning tokens on `rg`/`Read`/`Glob` discovery when
-yams can answer is a defect. Pick by question type:
+YAMS search/list/grep returns scoped snippets and candidate identifiers; those
+results are discovery, not recovered memory. Hydrate the selected saved-memory
+artifacts before relying on them. Local exploration re-reads whole files the
+index already knows. Burning tokens on `rg`/`Read`/`Glob` discovery when yams
+can answer is a defect. Pick by question type:
 
 | Question | Tool (first hop) |
 |---|---|
 | Exact symbol / string / pattern | `yams grep "<pat>" --cwd .` |
 | Callers / callees / includes / blast radius / related tests | `yams graph --explore "<symbol-or-file>" --max-files 8` |
-| Concept / prior decision / task history | `yams search "<query>" --limit 20` |
-| Artifact content after retrieval | `yams get` |
+| Concept / prior decision / task history | `yams search "<query>" --limit 10` |
+| Inspect a selected saved-memory artifact | run the emitted `yams cat --hash <hash>` hint |
+| Export a selected artifact | `yams get --hash <hash> -o <path>` |
 | Exact implementation detail in a file yams already named | local `Read` |
 | Unfamiliar subsystem entry point | `yams graph --topology-clusters`, then `--cluster <id>` |
 | Precise edges | `yams graph --name <file> --depth 1 --limit 50`, `--node-key <key> -r <relation>` |
 
 Rules:
 
+- Search, list, and grep only select candidates. Before using a prior note,
+  decision, research item, or evidence item, hydrate the most relevant one to
+  three hits with `yams cat --hash <hash>`. Do not claim recovered context from
+  snippets alone.
+- Do not `cat` every code hit. Use `graph --explore` to narrow code context,
+  then locally read only the exact implementation detail that remains needed.
 - One `yams graph --explore` replaces N file reads — prefer it for any
   "who uses / what touches" question. Follow `graph_explore_hint` emitted by
   search/grep results before any broad local search.
@@ -56,17 +65,29 @@ Rules:
 
 0. **Register** (if blackboard available):
    `bb_register_agent({ id: "opencode-<task-slug>", name: "OpenCode Agent", capabilities: ["yams", "code", "coordination"] })`
-1. **Retrieve** per the contract above before any local exploration.
-2. **Start**: index baseline + claim.
+1. **Retrieve + hydrate** per the contract above before any local exploration.
+2. **Start**: check index health and store a concise claim.
    ```bash
+   yams status
+
+   # Only if the repo index is missing/stale; do not task-tag a healthy repo.
    yams add . --recursive --include "*.cpp,*.hpp,*.h,*.py,*.ts,*.js,*.md" \
-     --label "Working on: $TASK" \
-     --metadata "mode=$MODE,task=$TASK,phase=start,owner=opencode,source=code,agent_id=opencode-$TASK"
+     --label "Repository baseline" \
+     --metadata "mode=$MODE,task=repo-index,phase=checkpoint,owner=opencode,source=code"
+
+   yams add - --name "claim-$TASK.md" \
+     --metadata "mode=$MODE,task=$TASK,phase=start,owner=opencode,source=note,agent_id=opencode-$TASK"
    ```
+   Send `TASK`, `SCOPE`, `GOAL`, and `NEXT` directly on stdin. In restricted
+   shells, invoke `yams` directly and use the executor's stdin channel; a
+   `printf | yams` wrapper can change command-prefix sandbox authorization.
 3. **Act**: implement/test/verify in scope; keep notes concise and indexable.
    For C++/systems work follow the design-first TDD loop in `AGENTS.md`.
-4. **Checkpoint**: `yams add <changed-files> --label "$TASK: checkpoint" --metadata "...,phase=checkpoint,..."`
-5. **Complete**: re-index as in step 2 with `phase=complete`.
+4. **Checkpoint**: index changed files and a concise `source=note` record of
+   decisions, open questions, and the next action.
+5. **Complete**: store the completed Handoff Template as a `source=note`,
+   `phase=complete` artifact, then re-index changed files with
+   `phase=complete` metadata.
 
 ## Metadata (every `yams add`)
 
@@ -83,10 +104,21 @@ potentially destructive verification steps.
 ## Session Recovery
 
 ```bash
-yams search "owner=opencode task=<task>" --type keyword --limit 50
-yams search "agent_id=opencode-<task-slug>" --type keyword --limit 50
+# Select exact task memories, then hydrate the relevant artifacts.
+yams list --format json --show-metadata \
+  --metadata "owner=opencode" --metadata "task=<task>" \
+  --metadata "source=note" --limit 10
+yams cat --hash <selected-note-decision-research-or-evidence-hash>
+
+# Fall back to concept/pattern discovery, then execute the emitted cat/graph hint.
+yams search "<task concept or prior decision>" --limit 10
 yams grep "<pattern>" --cwd .
 ```
+
+Recovery is incomplete until selected saved-memory artifacts have been
+hydrated. Record their hashes in `USED_CONTEXT` so the handoff is reproducible.
+Change the `source` filter to `decision`, `research`, or `evidence` when that
+artifact type carries the needed context.
 
 ## Handoff Template
 

--- a/docs/prompts/PROMPT-research-assistant.md
+++ b/docs/prompts/PROMPT-research-assistant.md
@@ -17,7 +17,8 @@ Before responding to any non-trivial request, follow this sequence:
 2. **YAMS second** — Search your persistent memory for prior work:
    - Call `query` with a search step: `{"steps": [{"op": "search", "params": {"query": "<keywords>", "limit": 10}}]}`
    - If results are thin, try grep: `{"steps": [{"op": "grep", "params": {"pattern": "<regex>"}}]}`
-   - If something exists, retrieve it: `{"steps": [{"op": "get", "params": {"name": "<name>"}}]}`
+   - Search/grep snippets only select candidates. If something exists, hydrate
+     the relevant artifact before using it: `{"steps": [{"op": "get", "params": {"hash": "<hash>", "include_content": true}}]}`
 
 3. **Web / browser third** — Only reach out externally if YAMS and Sage have no answer:
    - Use Exa for AI-powered semantic search
@@ -90,7 +91,7 @@ Runs a pipeline of read-only steps. Each step's result is available as `$prev` i
 {
   "steps": [
     {"op": "search", "params": {"query": "RLHF training", "limit": 5}},
-    {"op": "get", "params": {"hash": "$prev.results[0].hash"}}
+    {"op": "get", "params": {"hash": "$prev.results[0].hash", "include_content": true}}
   ]
 }
 ```

--- a/docs/prompts/PROMPT-research-cli.md
+++ b/docs/prompts/PROMPT-research-cli.md
@@ -49,8 +49,8 @@ YAMS-first Knowledge Workflow (mandatory)
   - printf "%s" "<snippet>" | yams add - --name "snippet-<desc>.txt" --metadata "lang=<lang>,label=Snippet:<desc>"
 - Retrieval:
   - Discover: yams search "<query>" --limit 20 [--fuzzy --similarity <v>]
-  - Inspect: yams cat --name "<name>" or yams cat <hash>
-  - Export: yams get <hash> -o <path> (or by name)
+  - Hydrate: execute the result's `yams cat --hash <hash>` hint; snippets alone are not recovered knowledge
+  - Export: yams get --hash <hash> -o <path> (or use `--name`)
 - Download-first with YAMS:
   - Prefer yams download "<URL>" to fetch PDFs/datasets/models directly into CAS (store-only). Use --export only when a filesystem copy is needed.
   - Use checksums, resume, and TLS verification; keep provenance in metadata where appropriate.

--- a/docs/prompts/PROMPT-research-mcp.md
+++ b/docs/prompts/PROMPT-research-mcp.md
@@ -53,7 +53,7 @@ Runs one or more read steps sequentially. Each step's result is available as `$p
 // Pipeline: search then retrieve first result
 {"steps": [
   {"op": "search", "params": {"query": "LLM reasoning"}},
-  {"op": "get", "params": {"hash": "$prev.results[0].hash"}}
+  {"op": "get", "params": {"hash": "$prev.results[0].hash", "include_content": true}}
 ]}
 
 // Discover search parameters
@@ -105,6 +105,10 @@ No tool needed when:
   - Call `query` with: `{"steps": [{"op": "search", "params": {"query": "<keywords>", "limit": 20}}]}`
   - For broader recall: add `"fuzzy": true, "similarity": 0.7` to search params
   - If terms are unclear: `{"steps": [{"op": "list", "params": {"pattern": "<glob>", "recent": 10}}]}`
+- Search/list/grep snippets only select candidates. Hydrate each saved-memory
+  artifact you rely on with a `get` step and `"include_content": true`; when
+  the top search hit is the intended artifact, chain search and get in one
+  `query` pipeline.
 - Prefer grep for pattern-based search:
   - `{"steps": [{"op": "grep", "params": {"pattern": "<regex>", "ignore_case": true}}]}`
 - Persist new external findings immediately:

--- a/docs/prompts/PROMPT-yams-cpp-workflow.md
+++ b/docs/prompts/PROMPT-yams-cpp-workflow.md
@@ -1,6 +1,6 @@
 ---
 description: Repo-specific C++ workflow for YAMS using YAMS-first context, design-first TDD, assertions, profiling, and Meson validation.
-argument-hint: [TASK=<description>] [MODE=engineering] [PHASE=<start|checkpoint|complete>]
+argument-hint: "[TASK=<description>] [MODE=engineering] [PHASE=<start|checkpoint|complete>]"
 ---
 
 # YAMS C++ Workflow
@@ -21,9 +21,13 @@ You are a senior C++ engineer working in the YAMS repository.
 
 <workflow>
 1. Discover context
-   - Check prior context with YAMS first: `search` / `grep` / `get`.
+   - Check prior context with YAMS first: `search` / `grep` / `list` select
+     candidates; they do not recover full saved memories.
+   - Hydrate the relevant prior notes, decisions, research, or evidence by
+     running the emitted `yams cat --hash <hash>` hint before relying on them.
    - Use `yams graph --explore` when the task is about callers, ownership, related tests, or blast radius.
-   - Then read only the files needed for implementation.
+   - Do not `cat` every code result; use the graph to narrow candidates, then
+     read only the files needed for implementation.
 
 2. Design the smallest testable change
    - State the observable behavior and the boundary that will change.

--- a/docs/skills/yams/SKILL.md
+++ b/docs/skills/yams/SKILL.md
@@ -30,6 +30,10 @@ yams grep -g "*.cpp" "TODO"   # rg-style glob filtering
 yams grep --minimal "TODO"     # Compact grep-style output
 yams search "query"            # Semantic/hybrid search
 
+# Hydrate/export a selected search result
+yams cat --hash <hash>          # Inspect saved content on stdout
+yams get --hash <hash> -o <path> # Export only when a file copy is needed
+
 # Graph
 yams graph --explore <query>   # Agent context: symbols, relationships, snippets
 yams graph --name <file>       # Raw file relationships
@@ -93,6 +97,12 @@ yams list --limit 10           # Recent indexed files
 3. **Codebase shape / blast radius** → `yams graph --explore` from a search/grep hit
 4. **Path/tree/topology inspection** → use `yams graph`, not retired top-level `tree`
 5. **No results from grep** → Try `yams search`, then follow `graph_explore_hint` when present
+6. **Saved memory content** → search/list discovers candidates; `yams cat --hash <hash>` hydrates the selected artifact
+
+Search, list, and grep snippets are routing context, not the complete saved
+memory. Hydrate the most relevant one to three note/decision/research/evidence
+hits before using them. For code hits, prefer graph narrowing plus a targeted
+local read instead of reading every result in full.
 
 ### grep (Code Search)
 
@@ -196,17 +206,28 @@ Stateless, scalable, industry standard.
 ### Retrieve Knowledge
 
 ```bash
-# Find related decisions
-yams search "authentication decision"
+# Discover related decisions; results emit an exact cat command.
+yams search "authentication decision" --limit 10
 
-# Find by metadata (JSON list is the source of truth)
+# Hydrate a selected saved-memory artifact before relying on it.
+yams cat --hash <hash-from-result>
+
+# Export only when a filesystem copy is needed.
+yams get --hash <hash-from-result> -o <path>
+
+# Find by exact metadata.
 yams list --format json --show-metadata \
-  | jq '.documents[] | select(.metadata.task=="example-task")'
+  --metadata "owner=codex" --metadata "task=example-task" \
+  --metadata "source=decision" --limit 10
 
 # Metadata + tags are separate in JSON output
 yams list --format json --show-metadata \
   | jq '.documents[] | {name,metadata,tags}'
 ```
+
+For CLI workflows, `cat` is the inspection/hydration hop and `get -o` is the
+export hop. For MCP workflows, chain `search` to `get` with
+`include_content: true`, as shown below.
 
 ## Session Management
 

--- a/include/yams/cli/daemon_helpers.h
+++ b/include/yams/cli/daemon_helpers.h
@@ -821,15 +821,21 @@ inline bool is_socket_mode_forced_by_env() {
            mode == "daemon";
 }
 
-inline bool explicit_socket_without_autostart() {
+inline std::filesystem::path explicit_socket_path() {
     const char* socketPath = std::getenv("YAMS_DAEMON_SOCKET_PATH");
     if (socketPath == nullptr || *socketPath == '\0') {
         socketPath = std::getenv("YAMS_DAEMON_SOCKET");
     }
     if (socketPath == nullptr || *socketPath == '\0') {
+        return {};
+    }
+    return socketPath;
+}
+
+inline bool explicit_socket_without_autostart() {
+    if (explicit_socket_path().empty()) {
         return false;
     }
-
     const char* disableAutoStart = std::getenv("YAMS_CLI_DISABLE_DAEMON_AUTOSTART");
     if (disableAutoStart == nullptr || *disableAutoStart == '\0') {
         return false;
@@ -1010,19 +1016,26 @@ inline Result<CliDaemonClientPlan> prepare_cli_daemon_client_plan(
     plan.config = requestedCfg;
 
     const bool socketForcedByEnv = detail::is_socket_mode_forced_by_env();
+    const bool pinnedSocket = detail::explicit_socket_without_autostart();
     const bool requireSocket =
-        socketForcedByEnv || (policy == CliDaemonAccessPolicy::RequireSocket);
+        socketForcedByEnv || pinnedSocket || (policy == CliDaemonAccessPolicy::RequireSocket);
     plan.requireSocket = requireSocket;
     plan.allowInProcessFallback = !requireSocket;
     plan.allowLocalServiceFallback = false;
-    plan.allowSocketAutoStart = requireSocket;
+    plan.allowSocketAutoStart = requireSocket && !pinnedSocket;
 
     // Respect explicit CLI no-autostart intent even on socket-required paths.
     // This is especially important for test and pinned-socket flows where the caller
     // provides a concrete daemon endpoint and wants request execution to surface
     // connectivity errors directly, without a separate readiness/autostart phase.
-    if (detail::explicit_socket_without_autostart()) {
+    if (pinnedSocket) {
         plan.config.autoStart = false;
+        if (plan.config.socketPath.empty()) {
+            plan.config.socketPath = detail::explicit_socket_path();
+        }
+        if (plan.config.transportMode == yams::daemon::ClientTransportMode::Auto) {
+            plan.config.transportMode = yams::daemon::ClientTransportMode::Socket;
+        }
     }
 
     if (!requireSocket) {

--- a/include/yams/daemon/components/ConfigResolver.h
+++ b/include/yams/daemon/components/ConfigResolver.h
@@ -83,6 +83,7 @@ public:
         std::optional<std::size_t> maxClusters;
         std::optional<std::size_t> maxSeedDocuments;
         std::optional<std::size_t> representativeLimit;
+        std::optional<std::size_t> annCandidateLimit;
         std::optional<float> adaptiveProbeScoreGap;
         std::optional<float> narrowMinBoundaryMargin;
         std::optional<std::size_t> maxDocs;
@@ -443,6 +444,7 @@ public:
      * - search.topology.max_clusters = int
      * - search.topology.max_seed_documents = int
      * - search.topology.representative_limit = int
+     * - search.topology.ann_candidate_limit = int
      * - search.topology.adaptive_probe_score_gap = float
      * - search.topology.narrow_min_boundary_margin = float
      * - search.topology.max_docs = int

--- a/include/yams/daemon/components/WorkCoordinator.h
+++ b/include/yams/daemon/components/WorkCoordinator.h
@@ -84,6 +84,10 @@ namespace yams::daemon {
 class WorkCoordinator {
 private:
     struct DetachedCancellationState;
+    struct DetachedCancellationRequest {
+        std::shared_ptr<boost::asio::cancellation_signal> signal;
+        boost::asio::any_io_executor executor;
+    };
 
 public:
     enum class Priority {
@@ -126,10 +130,10 @@ public:
     void start(std::optional<std::size_t> numThreads = std::nullopt);
 
     /**
-     * @brief Stop accepting new work and drain io_context.
+     * @brief Stop accepting new work and interrupt the io_context.
      *
-     * Resets work guard, allowing io_context to exit when all posted work completes.
-     * Does NOT block - call join() to wait for threads.
+     * Serializes detached-coroutine cancellation on their executors, then stops the
+     * io_context. Does NOT block - call join() to wait for threads.
      *
      * Safe to call multiple times (idempotent).
      */
@@ -244,12 +248,14 @@ public:
 
     template <typename Executor, typename Awaitable>
     void spawnDetached(Executor&& executor, Awaitable&& awaitable) {
+        boost::asio::any_io_executor serializedExecutor = boost::asio::make_strand(
+            boost::asio::any_io_executor(std::forward<Executor>(executor)));
         auto signal = std::make_shared<boost::asio::cancellation_signal>();
-        registerDetachedCancellationSignal(signal);
+        registerDetachedCancellationSignal(signal, serializedExecutor);
         std::weak_ptr<DetachedCancellationState> state = detachedCancellationState_;
         const auto* completedSignal = signal.get();
         boost::asio::co_spawn(
-            std::forward<Executor>(executor), std::forward<Awaitable>(awaitable),
+            serializedExecutor, std::forward<Awaitable>(awaitable),
             boost::asio::bind_cancellation_slot(
                 signal->slot(),
                 [state, completedSignal, signal = std::move(signal)](std::exception_ptr) mutable {
@@ -259,9 +265,10 @@ public:
 
 private:
     void registerDetachedCancellationSignal(
-        const std::shared_ptr<boost::asio::cancellation_signal>& signal);
-    [[nodiscard]] std::vector<std::shared_ptr<boost::asio::cancellation_signal>>
-    snapshotDetachedCancellationSignals() const;
+        const std::shared_ptr<boost::asio::cancellation_signal>& signal,
+        boost::asio::any_io_executor executor);
+    [[nodiscard]] std::vector<DetachedCancellationRequest>
+    snapshotDetachedCancellationRequests() const;
     static void
     cleanupDetachedCancellationState(const std::weak_ptr<DetachedCancellationState>& state,
                                      const boost::asio::cancellation_signal* completedSignal);
@@ -313,7 +320,7 @@ private:
     boost::asio::strand<boost::asio::io_context::executor_type> normalPriorityStrand_;
     boost::asio::strand<boost::asio::io_context::executor_type> backgroundPriorityStrand_;
 
-    /// Registry of per-coroutine cancellation signals used by spawnDetached().
+    /// Registry of serialized per-coroutine cancellation requests used by spawnDetached().
     std::shared_ptr<DetachedCancellationState> detachedCancellationState_;
 };
 

--- a/include/yams/metadata/metadata_repository.h
+++ b/include/yams/metadata/metadata_repository.h
@@ -207,6 +207,8 @@ struct DocumentQueryOptions {
     std::optional<std::string> likePattern;
     // Generic metadata filtering (replaces findDocumentsByCollection)
     std::vector<std::pair<std::string, std::string>> metadataFilters;
+    // Optional OR group, combined with metadataFilters and all other filters using AND.
+    std::vector<std::pair<std::string, std::string>> metadataAnyFilters;
 
     // --- Repair / health-check filters (added for targeted stuck-doc detection) ---
     /// Filter by extraction status (e.g., Failed, Pending). Multiple values → OR.

--- a/include/yams/search/search_engine_config.h
+++ b/include/yams/search/search_engine_config.h
@@ -198,6 +198,9 @@ struct SearchEngineConfig {
     /// Maximum total dense representatives evaluated per cluster, including the centroid.
     /// Zero evaluates the complete representative cover stored in the topology snapshot.
     size_t topologyRoutingRepresentativeLimit = 0;
+    /// Exact-score this many cached centroid-ANN candidates when the topology exceeds the limit.
+    /// Sparse-vote clusters are always retained. Zero forces exhaustive centroid scoring.
+    size_t topologyRoutingAnnCandidateLimit = 64;
     /// Include another cluster while its score remains this close to the best route.
     float topologyAdaptiveProbeScoreGap = 0.0f;
     /// Abstain from hard narrowing when the selected/excluded boundary is closer
@@ -459,6 +462,7 @@ struct SearchEngineConfig {
         topologyMaxClusters = source.topologyMaxClusters;
         topologyMaxSeedDocuments = source.topologyMaxSeedDocuments;
         topologyRoutingRepresentativeLimit = source.topologyRoutingRepresentativeLimit;
+        topologyRoutingAnnCandidateLimit = source.topologyRoutingAnnCandidateLimit;
         topologyAdaptiveProbeScoreGap = source.topologyAdaptiveProbeScoreGap;
         topologyNarrowMinBoundaryMargin = source.topologyNarrowMinBoundaryMargin;
         topologyMaxDocs = source.topologyMaxDocs;

--- a/include/yams/search/search_metric_keys.h
+++ b/include/yams/search/search_metric_keys.h
@@ -50,6 +50,12 @@ constexpr std::string_view kTopologyRouteRepresentativeDistanceEvaluations =
     "topology_route_representative_distance_evaluations";
 constexpr std::string_view kTopologyRouteRepresentativeCountMax =
     "topology_route_representative_count_max";
+constexpr std::string_view kTopologyRouteAnnUsed = "topology_route_ann_used";
+constexpr std::string_view kTopologyRouteAnnCandidates = "topology_route_ann_candidates";
+constexpr std::string_view kTopologyRouteAnnDistanceEvaluations =
+    "topology_route_ann_distance_evaluations";
+constexpr std::string_view kTopologyRouteExactRepresentativeDistanceEvaluations =
+    "topology_route_exact_representative_distance_evaluations";
 constexpr std::string_view kTopologyWeakQueryRoutedDocs = "topology_weak_query_routed_docs";
 constexpr std::string_view kTopologyWeakQueryAddedCandidates =
     "topology_weak_query_added_candidates";
@@ -88,6 +94,22 @@ constexpr std::string_view kVectorSearchExactDistanceEvaluationsActual =
     "vector_search_exact_distance_evaluations_actual";
 constexpr std::string_view kVectorSearchAnnCandidateBudgetActual =
     "vector_search_ann_candidate_budget_actual";
+constexpr std::string_view kVectorSearchCandidateLookupCount =
+    "vector_search_candidate_lookup_count";
+constexpr std::string_view kVectorSearchCandidateIndexCacheUsed =
+    "vector_search_candidate_index_cache_used";
+constexpr std::string_view kVectorSearchCandidateIndexPayloadBytes =
+    "vector_search_candidate_index_payload_bytes";
+constexpr std::string_view kVectorSearchMaterializedRows = "vector_search_materialized_rows";
+constexpr std::string_view kVectorSearchCandidateLookupNs = "vector_search_candidate_lookup_ns";
+constexpr std::string_view kVectorSearchCandidateProjectionNs =
+    "vector_search_candidate_projection_ns";
+constexpr std::string_view kVectorSearchPqLutNs = "vector_search_pq_lut_ns";
+constexpr std::string_view kVectorSearchAdcScoringNs = "vector_search_adc_scoring_ns";
+constexpr std::string_view kVectorSearchTopKSelectionNs = "vector_search_topk_selection_ns";
+constexpr std::string_view kVectorSearchResultMaterializationNs =
+    "vector_search_result_materialization_ns";
+constexpr std::string_view kVectorSearchExactRerankNs = "vector_search_exact_rerank_ns";
 constexpr std::string_view kTopologyVectorFilterApplied = "topology_vector_filter_applied";
 constexpr std::string_view kTopologyVectorFilterFallback = "topology_vector_filter_fallback";
 constexpr std::string_view kTopologyVectorFilterMatched = "topology_vector_filter_matched";
@@ -96,6 +118,7 @@ constexpr std::string_view kTopologyVectorAllowedSetAnnApplied =
     "topology_vector_allowed_set_ann_applied";
 constexpr std::string_view kTopologyVectorAllowedSetAnnFallback =
     "topology_vector_allowed_set_ann_fallback";
+constexpr std::string_view kTopologyVectorGlobalFillCount = "topology_vector_global_fill_count";
 constexpr std::string_view kTopologyShadowEvaluated = "topology_shadow_evaluated";
 constexpr std::string_view kTopologyShadowProposedAction = "topology_shadow_proposed_action";
 constexpr std::string_view kTopologyShadowRetainedCandidates =

--- a/include/yams/search/topology_routing_session.h
+++ b/include/yams/search/topology_routing_session.h
@@ -87,6 +87,7 @@ struct TopologyRoutingOptions {
     std::size_t minClusters = 1;
     std::size_t maxClusters = 0;
     std::size_t representativeLimit = 0;
+    std::size_t denseAnnCandidateLimit = 0;
     float adaptiveProbeScoreGap = 0.0F;
     float narrowMinBoundaryMargin = 0.0F;
     /// Maximum documents in a materialized route allowed set or expansion result.
@@ -146,9 +147,16 @@ struct TopologyRoutingSessionResult {
     std::size_t staleCandidates = 0;
     std::size_t routeRepresentativeDistanceEvaluations = 0;
     std::size_t routeRepresentativeCountMax = 0;
+    bool routeAnnUsed = false;
+    std::size_t routeAnnCandidates = 0;
+    std::size_t routeAnnDistanceEvaluations = 0;
+    std::size_t routeExactRepresentativeDistanceEvaluations = 0;
     std::vector<std::string> addedCandidateHashes;
     std::unordered_set<std::string> routedCandidateHashes;
     std::unordered_set<std::string> routeAllowedDocumentHashes;
+    /// Full selected membership by accepted route, in route-score order. The union above remains
+    /// the backend filter; these groups let callers allocate balanced result quotas.
+    std::vector<std::unordered_set<std::string>> routeAllowedDocumentHashGroups;
     std::unordered_set<std::string> medoidHashes;
     std::unordered_map<std::string, TopologyCandidateStructureEvidence> candidateStructureEvidence;
     TopologyRoutingTimings timings;

--- a/include/yams/topology/topology_artifacts.h
+++ b/include/yams/topology/topology_artifacts.h
@@ -209,6 +209,9 @@ struct TopologyRouteRequest {
     /// Maximum total dense representatives evaluated per cluster, including the centroid.
     /// Zero evaluates the complete prebuilt cover.
     std::size_t maxRoutingRepresentatives{0};
+    /// Maximum centroid candidates exact-scored after cached ANN routing. Zero preserves the
+    /// exhaustive centroid scan. Sparse-vote clusters are always unioned into the shortlist.
+    std::size_t denseAnnCandidateLimit{0};
 };
 
 struct ClusterRoute {

--- a/include/yams/topology/topology_baseline.h
+++ b/include/yams/topology/topology_baseline.h
@@ -2,6 +2,12 @@
 
 #include <yams/topology/topology_engine.h>
 
+#include <memory>
+
+namespace yams::vector {
+class StaticCosineAnnIndex;
+}
+
 namespace yams::topology {
 
 /// Immutable query-time index derived from a validated topology artifact batch.
@@ -10,6 +16,7 @@ struct SparseRouteIndex {
     std::unordered_map<std::string, std::vector<std::size_t>> clustersByDocumentHash;
     std::vector<float> centroidNorms;
     std::vector<std::vector<float>> routingRepresentativeNorms;
+    std::shared_ptr<const yams::vector::StaticCosineAnnIndex> centroidAnnIndex;
 };
 
 struct SparseRouteWork {
@@ -17,6 +24,10 @@ struct SparseRouteWork {
     std::size_t clusterMemberHashesScanned{0};
     std::size_t queryNormEvaluations{0};
     std::size_t representativeDistanceEvaluations{0};
+    std::size_t exactRepresentativeDistanceEvaluations{0};
+    std::size_t denseAnnDistanceEvaluations{0};
+    std::size_t denseAnnCandidates{0};
+    bool denseAnnUsed{false};
 };
 
 class ConnectedComponentTopologyEngine final : public ITopologyEngine {

--- a/include/yams/vector/static_cosine_ann_index.h
+++ b/include/yams/vector/static_cosine_ann_index.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <yams/core/types.h>
+
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <vector>
+
+namespace yams::vector {
+
+struct StaticCosineAnnHit {
+    std::size_t id{0};
+    float distance{0.0F};
+};
+
+struct StaticCosineAnnSearchResult {
+    std::vector<StaticCosineAnnHit> hits;
+    std::size_t distanceEvaluations{0};
+};
+
+/// Immutable, in-memory cosine ANN index for small routing/vector-codebook surfaces.
+/// IDs are caller-owned and need not be dense. Construction normalizes vectors once;
+/// each query reports the graph traversal's actual distance evaluations.
+class StaticCosineAnnIndex final {
+public:
+    static Result<std::shared_ptr<const StaticCosineAnnIndex>>
+    build(std::span<const std::size_t> ids, std::span<const std::vector<float>> vectors);
+
+    ~StaticCosineAnnIndex();
+    StaticCosineAnnIndex(const StaticCosineAnnIndex&) = delete;
+    StaticCosineAnnIndex& operator=(const StaticCosineAnnIndex&) = delete;
+
+    [[nodiscard]] Result<StaticCosineAnnSearchResult>
+    search(std::span<const float> query, std::size_t candidates, std::size_t efSearch = 0) const;
+
+    [[nodiscard]] std::size_t size() const noexcept;
+    [[nodiscard]] std::size_t dimension() const noexcept;
+
+private:
+    class Impl;
+    explicit StaticCosineAnnIndex(std::unique_ptr<Impl> impl);
+
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace yams::vector

--- a/include/yams/vector/vector_types.h
+++ b/include/yams/vector/vector_types.h
@@ -202,10 +202,21 @@ struct EntitySearchParams {
 struct VectorSearchDiagnostics {
     bool usedAnn = false;
     bool usedExactScan = false;
+    bool usedCandidateIndexCache = false;
     size_t rowsVisited = 0;
     size_t exactDistanceEvaluations = 0;
     size_t annCandidateBudget = 0;
+    size_t candidateLookupCount = 0;
+    size_t candidateIndexPayloadBytes = 0;
+    size_t materializedRows = 0;
     size_t returnedRows = 0;
+    std::uint64_t candidateLookupNanoseconds = 0;
+    std::uint64_t candidateProjectionNanoseconds = 0;
+    std::uint64_t pqLutNanoseconds = 0;
+    std::uint64_t adcScoringNanoseconds = 0;
+    std::uint64_t topKSelectionNanoseconds = 0;
+    std::uint64_t resultMaterializationNanoseconds = 0;
+    std::uint64_t exactRerankNanoseconds = 0;
 };
 
 /// Controls how an explicit candidate-document set is evaluated. BackendDefault lets the selected

--- a/src/app/services/document_service.cpp
+++ b/src/app/services/document_service.cpp
@@ -2491,6 +2491,11 @@ public:
             queryOpts.metadataFilters.emplace_back("session_id", req.sessionId);
         }
 
+        auto& requestMetadataFilters =
+            req.matchAllMetadata ? queryOpts.metadataFilters : queryOpts.metadataAnyFilters;
+        requestMetadataFilters.insert(requestMetadataFilters.end(), req.metadataFilters.begin(),
+                                      req.metadataFilters.end());
+
         if (req.sortBy == "name") {
             queryOpts.orderByNameAsc = (req.sortOrder != "desc");
         } else {

--- a/src/app/services/graph_context_service.cpp
+++ b/src/app/services/graph_context_service.cpp
@@ -1108,6 +1108,14 @@ private:
             if (startLine == std::numeric_limits<std::size_t>::max() || startLine == 0) {
                 startLine = 1;
             }
+            if (startLine > lines.size()) {
+                snippet.mode = GraphContextSnippetMode::Omitted;
+                snippet.truncated = true;
+                truncated = true;
+                warnings.push_back("Omitted snippet for stale source location: " + file);
+                outFiles.push_back(std::move(snippet));
+                continue;
+            }
             YAMS_DCHECK(
                 startLine >= 1,
                 "graph explore snippet start line must be normalized to one-based indexing");

--- a/src/daemon/client/asio_connection.cpp
+++ b/src/daemon/client/asio_connection.cpp
@@ -244,10 +244,10 @@ boost::asio::awaitable<Result<void>> AsioConnection::async_write_frame(std::vect
             writing = false;
             alive = false;
             boost::system::error_code close_ec;
-            const auto closeResult = socket->close(close_ec);
-            if (closeResult) {
+            socket->close(close_ec);
+            if (close_ec) {
                 spdlog::debug("AsioConnection::async_write_frame: close after timeout failed: {}",
-                              closeResult.message());
+                              close_ec.message());
             }
             co_return Error{ErrorCode::Timeout, "Write timeout"};
         }

--- a/src/daemon/components/ConfigResolver.cpp
+++ b/src/daemon/components/ConfigResolver.cpp
@@ -827,6 +827,9 @@ ConfigResolver::TopologyRoutingPolicy ConfigResolver::resolveTopologyRoutingPoli
             if (auto it = kv.find("search.topology.representative_limit"); it != kv.end()) {
                 policy.representativeLimit = parseSize(it->second);
             }
+            if (auto it = kv.find("search.topology.ann_candidate_limit"); it != kv.end()) {
+                policy.annCandidateLimit = parseSize(it->second);
+            }
             if (auto it = kv.find("search.topology.adaptive_probe_score_gap"); it != kv.end()) {
                 policy.adaptiveProbeScoreGap = parseFloat(it->second);
             }

--- a/src/daemon/components/SearchEngineManager.cpp
+++ b/src/daemon/components/SearchEngineManager.cpp
@@ -426,6 +426,9 @@ SearchEngineManager::buildEngine(std::shared_ptr<yams::metadata::MetadataReposit
         if (tp.representativeLimit) {
             opts.config.topologyRoutingRepresentativeLimit = *tp.representativeLimit;
         }
+        if (tp.annCandidateLimit) {
+            opts.config.topologyRoutingAnnCandidateLimit = *tp.annCandidateLimit;
+        }
         if (tp.adaptiveProbeScoreGap) {
             opts.config.topologyAdaptiveProbeScoreGap = std::max(0.0F, *tp.adaptiveProbeScoreGap);
         }

--- a/src/daemon/components/WorkCoordinator.cpp
+++ b/src/daemon/components/WorkCoordinator.cpp
@@ -28,7 +28,7 @@ namespace yams::daemon {
 
 struct WorkCoordinator::DetachedCancellationState {
     mutable std::mutex mutex;
-    std::vector<std::shared_ptr<boost::asio::cancellation_signal>> signals;
+    std::vector<DetachedCancellationRequest> requests;
 };
 
 WorkCoordinator::WorkCoordinator()
@@ -204,14 +204,26 @@ void WorkCoordinator::stop() {
         stopRequestedAt_ = std::chrono::steady_clock::now();
         stopRequestedSet_ = true;
     }
-    workGuard_.reset();
-    auto detachedSignals = snapshotDetachedCancellationSignals();
-    for (const auto& signal : detachedSignals) {
-        signal->emit(boost::asio::cancellation_type::all);
+    auto detachedCancellationRequests = snapshotDetachedCancellationRequests();
+    if (detachedCancellationRequests.empty()) {
+        ioContext_->stop();
+    } else {
+        auto remaining =
+            std::make_shared<std::atomic<std::size_t>>(detachedCancellationRequests.size());
+        auto ioContext = ioContext_;
+        for (auto& request : detachedCancellationRequests) {
+            boost::asio::post(request.executor,
+                              [signal = std::move(request.signal), remaining, ioContext]() {
+                                  signal->emit(boost::asio::cancellation_type::all);
+                                  if (remaining->fetch_sub(1, std::memory_order_acq_rel) == 1) {
+                                      ioContext->stop();
+                                  }
+                              });
+        }
     }
-    ioContext_->stop();
+    workGuard_.reset();
     try {
-        spdlog::info("[WorkCoordinator] Work guard reset and io_context stopped");
+        spdlog::info("[WorkCoordinator] Cancellation requested and work guard reset");
     } catch (...) {
         // Intentional best-effort path; keep the primary operation unaffected.
     }
@@ -417,36 +429,27 @@ bool WorkCoordinator::joinWithTimeout(std::chrono::milliseconds timeout) {
 }
 
 void WorkCoordinator::registerDetachedCancellationSignal(
-    const std::shared_ptr<boost::asio::cancellation_signal>& signal) {
+    const std::shared_ptr<boost::asio::cancellation_signal>& signal,
+    boost::asio::any_io_executor executor) {
     if (!signal || !detachedCancellationState_) {
         return;
     }
 
     std::lock_guard<std::mutex> lock(detachedCancellationState_->mutex);
-    auto& signals = detachedCancellationState_->signals;
-    signals.erase(std::remove_if(signals.begin(), signals.end(),
-                                 [](const auto& entry) { return entry == nullptr; }),
-                  signals.end());
-    signals.push_back(signal);
+    detachedCancellationState_->requests.push_back(
+        DetachedCancellationRequest{.signal = signal, .executor = std::move(executor)});
 }
 
-std::vector<std::shared_ptr<boost::asio::cancellation_signal>>
-WorkCoordinator::snapshotDetachedCancellationSignals() const {
-    std::vector<std::shared_ptr<boost::asio::cancellation_signal>> activeSignals;
+std::vector<WorkCoordinator::DetachedCancellationRequest>
+WorkCoordinator::snapshotDetachedCancellationRequests() const {
+    std::vector<DetachedCancellationRequest> requests;
     if (!detachedCancellationState_) {
-        return activeSignals;
+        return requests;
     }
 
     std::lock_guard<std::mutex> lock(detachedCancellationState_->mutex);
-    auto& signals = detachedCancellationState_->signals;
-    signals.erase(std::remove_if(signals.begin(), signals.end(),
-                                 [](const auto& entry) { return entry == nullptr; }),
-                  signals.end());
-    activeSignals.reserve(signals.size());
-    for (const auto& entry : signals) {
-        activeSignals.push_back(entry);
-    }
-    return activeSignals;
+    requests = detachedCancellationState_->requests;
+    return requests;
 }
 
 void WorkCoordinator::cleanupDetachedCancellationState(
@@ -454,12 +457,12 @@ void WorkCoordinator::cleanupDetachedCancellationState(
     const boost::asio::cancellation_signal* completedSignal) {
     if (auto locked = state.lock()) {
         std::lock_guard<std::mutex> lock(locked->mutex);
-        auto& signals = locked->signals;
-        signals.erase(std::remove_if(signals.begin(), signals.end(),
-                                     [completedSignal](const auto& entry) {
-                                         return !entry || entry.get() == completedSignal;
-                                     }),
-                      signals.end());
+        auto& requests = locked->requests;
+        requests.erase(std::remove_if(requests.begin(), requests.end(),
+                                      [completedSignal](const auto& request) {
+                                          return request.signal.get() == completedSignal;
+                                      }),
+                       requests.end());
     }
 }
 

--- a/src/metadata/repository/document_query_filters.cpp
+++ b/src/metadata/repository/document_query_filters.cpp
@@ -287,6 +287,21 @@ void appendDocumentQueryFilters(const DocumentQueryOptions& options, bool joinFt
         addTextParam(params, value);
     }
 
+    if (!options.metadataAnyFilters.empty()) {
+        std::string condition = "(";
+        for (std::size_t i = 0; i < options.metadataAnyFilters.size(); ++i) {
+            if (i > 0) {
+                condition += " OR ";
+            }
+            condition += "EXISTS (SELECT 1 FROM metadata m WHERE m.document_id = documents.id "
+                         "AND m.key = ? AND m.value = ?)";
+            addTextParam(params, options.metadataAnyFilters[i].first);
+            addTextParam(params, options.metadataAnyFilters[i].second);
+        }
+        condition += ')';
+        conditions.push_back(std::move(condition));
+    }
+
     if (!options.extractionStatuses.empty()) {
         if (options.extractionStatuses.size() == 1) {
             conditions.emplace_back("extraction_status = ?");

--- a/src/search/search_engine.cpp
+++ b/src/search/search_engine.cpp
@@ -97,6 +97,28 @@ using json = nlohmann::json;
 
 using detail::postWork;
 
+std::vector<std::size_t>
+allocateBalancedRouteQuotas(const std::vector<std::unordered_set<std::string>>& routeGroups,
+                            std::size_t limit) {
+    std::vector<std::size_t> quotas(routeGroups.size(), 0);
+    std::size_t remaining = limit;
+    while (remaining > 0) {
+        bool allocated = false;
+        for (std::size_t route = 0; route < routeGroups.size() && remaining > 0; ++route) {
+            if (quotas[route] >= routeGroups[route].size()) {
+                continue;
+            }
+            ++quotas[route];
+            --remaining;
+            allocated = true;
+        }
+        if (!allocated) {
+            break;
+        }
+    }
+    return quotas;
+}
+
 std::optional<std::int64_t>
 resolveGraphCandidateDocumentId(const std::shared_ptr<yams::metadata::KnowledgeGraphStore>& kgStore,
                                 std::string_view candidateId) {
@@ -1395,10 +1417,23 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
                                          const vector::VectorSearchDiagnostics& sample) {
             total.usedAnn = total.usedAnn || sample.usedAnn;
             total.usedExactScan = total.usedExactScan || sample.usedExactScan;
+            total.usedCandidateIndexCache =
+                total.usedCandidateIndexCache || sample.usedCandidateIndexCache;
             total.rowsVisited += sample.rowsVisited;
             total.exactDistanceEvaluations += sample.exactDistanceEvaluations;
             total.annCandidateBudget += sample.annCandidateBudget;
+            total.candidateLookupCount += sample.candidateLookupCount;
+            total.candidateIndexPayloadBytes =
+                std::max(total.candidateIndexPayloadBytes, sample.candidateIndexPayloadBytes);
+            total.materializedRows += sample.materializedRows;
             total.returnedRows += sample.returnedRows;
+            total.candidateLookupNanoseconds += sample.candidateLookupNanoseconds;
+            total.candidateProjectionNanoseconds += sample.candidateProjectionNanoseconds;
+            total.pqLutNanoseconds += sample.pqLutNanoseconds;
+            total.adcScoringNanoseconds += sample.adcScoringNanoseconds;
+            total.topKSelectionNanoseconds += sample.topKSelectionNanoseconds;
+            total.resultMaterializationNanoseconds += sample.resultMaterializationNanoseconds;
+            total.exactRerankNanoseconds += sample.exactRerankNanoseconds;
         };
         const auto runVectorQuery = [&](const SearchEngineConfig& config) {
             vector::VectorSearchDiagnostics sample;
@@ -1974,6 +2009,17 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
             for (const auto& seed : topologySeedEvidence) {
                 topologyAssistReq.tier1SeedHashes.push_back(seed.documentHash);
             }
+            const bool vectorBackendSupportsAllowedSetAnn =
+                vectorDb_ &&
+                (vectorDb_->getConfig().search_engine == vector::VectorSearchEngine::Vec0L2 ||
+                 vectorDb_->getConfig().search_engine == vector::VectorSearchEngine::SimeonPqAdc);
+            const bool deferTopologyMemberLimitToVectorRanker =
+                vectorBackendSupportsAllowedSetAnn &&
+                workingConfig.topologyVectorPolicy ==
+                    SearchEngineConfig::TopologyVectorPolicy::Narrow;
+            if (deferTopologyMemberLimitToVectorRanker) {
+                topologyAssistReq.config.topologyMaxDocs = 0;
+            }
             topologyAssistReq.existingCandidateHashes = tier2Candidates;
             topologyAssistReq.queryEmbedding = queryEmbedding;
             topologyAssistReq.metadataRepo = metadataRepo_;
@@ -2003,8 +2049,14 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
                     SearchEngineConfig::TopologyVectorPolicy::Narrow &&
                 !topologySession.routeAllowedDocumentHashes.empty();
             const bool topologyVectorAllowedSetAnnEligible =
-                topologyVectorFilterEligible && vectorDb_ &&
-                vectorDb_->getConfig().search_engine == vector::VectorSearchEngine::Vec0L2;
+                topologyVectorFilterEligible && vectorBackendSupportsAllowedSetAnn;
+            const bool topologyVectorGlobalFillAllowed =
+                !vectorDb_ ||
+                vectorDb_->getConfig().search_engine != vector::VectorSearchEngine::SimeonPqAdc;
+            const std::size_t topologyVectorResultLimit =
+                deferTopologyMemberLimitToVectorRanker && workingConfig.topologyMaxDocs > 0
+                    ? std::min(effectiveVectorMaxResults, workingConfig.topologyMaxDocs)
+                    : effectiveVectorMaxResults;
             topologyWeakQueryNarrowApplied = false;
             topologyWeakQueryRoutingApplied = topologySession.applied && !topologyVectorShadow;
             setDebug(response.debugStats, metrics::kTopologyVectorPolicy,
@@ -2024,6 +2076,11 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
             auto topologyRouteAllowedDocuments =
                 std::make_shared<const std::unordered_set<std::string>>(
                     topologySession.routeAllowedDocumentHashes);
+            auto topologyRouteAllowedDocumentGroups =
+                std::make_shared<const std::vector<std::unordered_set<std::string>>>(
+                    topologySession.routeAllowedDocumentHashGroups);
+            const auto topologyRouteQuotas = allocateBalancedRouteQuotas(
+                *topologyRouteAllowedDocumentGroups, topologyVectorResultLimit);
 
             // Decide whether to narrow vector search to Tier 1 candidates
             // Narrow if: config enabled AND Tier 1 has enough candidates
@@ -2099,6 +2156,7 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
             std::size_t topologyVectorFilterRemoved = 0;
             bool topologyVectorAllowedSetAnnApplied = false;
             bool topologyVectorAllowedSetAnnFallback = false;
+            std::size_t topologyVectorGlobalFillCount = 0;
             std::size_t topologyShadowRetainedCandidates = 0;
             std::size_t topologyShadowRemovedCandidates = 0;
             std::vector<std::string> topologyShadowRetainedDocIds;
@@ -2110,24 +2168,95 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
                     [&queryEmbedding, &baselineTier2Candidates, shouldNarrow,
                      effectiveVectorMaxResults, &queryVectorWithRelaxedRetry,
                      &vectorSearchDiagnostics, topologyRouteAllowedDocuments,
+                     topologyRouteAllowedDocumentGroups, topologyRouteQuotas,
                      topologyVectorFilterEligible, topologyVectorAllowedSetAnnEligible,
+                     topologyVectorGlobalFillAllowed, topologyVectorResultLimit,
                      topologyVectorShadow, &topologyVectorFilterApplied,
                      &topologyVectorFilterFallback, &topologyVectorFilterMatched,
                      &topologyVectorFilterRemoved, &topologyVectorAllowedSetAnnApplied,
-                     &topologyVectorAllowedSetAnnFallback, stageTraceEnabled,
-                     &topologyShadowRetainedCandidates, &topologyShadowRemovedCandidates,
-                     &topologyShadowRetainedDocIds, &topologyShadowRemovedDocIds]() {
+                     &topologyVectorAllowedSetAnnFallback, &topologyVectorGlobalFillCount,
+                     stageTraceEnabled, &topologyShadowRetainedCandidates,
+                     &topologyShadowRemovedCandidates, &topologyShadowRetainedDocIds,
+                     &topologyShadowRemovedDocIds]() {
                         YAMS_ZONE_SCOPED_N("component::vector");
                         Result<std::vector<ComponentResult>> results = [&]() {
                             if (topologyVectorAllowedSetAnnEligible) {
-                                auto routed = queryVectorWithRelaxedRetry(
-                                    queryEmbedding.value(), effectiveVectorMaxResults,
-                                    topologyRouteAllowedDocuments.get(), &vectorSearchDiagnostics);
-                                if (routed && !routed.value().empty()) {
+                                std::vector<ComponentResult> routedResults;
+                                routedResults.reserve(topologyVectorResultLimit);
+                                std::unordered_set<std::string> seenDocuments;
+                                seenDocuments.reserve(topologyVectorResultLimit * 2);
+                                const auto appendUnique = [&](std::vector<ComponentResult> incoming,
+                                                              std::size_t limit) {
+                                    const auto before = routedResults.size();
+                                    for (auto& candidate : incoming) {
+                                        if (routedResults.size() >= limit) {
+                                            break;
+                                        }
+                                        if (candidate.documentHash.empty() ||
+                                            !seenDocuments.insert(candidate.documentHash).second) {
+                                            continue;
+                                        }
+                                        routedResults.push_back(std::move(candidate));
+                                    }
+                                    return routedResults.size() - before;
+                                };
+
+                                if (!topologyRouteAllowedDocumentGroups->empty()) {
+                                    for (std::size_t route = 0;
+                                         route < topologyRouteAllowedDocumentGroups->size();
+                                         ++route) {
+                                        const auto quota = topologyRouteQuotas[route];
+                                        if (quota == 0) {
+                                            continue;
+                                        }
+                                        auto routed = queryVectorWithRelaxedRetry(
+                                            queryEmbedding.value(), quota,
+                                            &(*topologyRouteAllowedDocumentGroups)[route],
+                                            &vectorSearchDiagnostics);
+                                        if (routed) {
+                                            appendUnique(std::move(routed.value()),
+                                                         topologyVectorResultLimit);
+                                        }
+                                    }
+                                } else {
+                                    auto routed = queryVectorWithRelaxedRetry(
+                                        queryEmbedding.value(), topologyVectorResultLimit,
+                                        topologyRouteAllowedDocuments.get(),
+                                        &vectorSearchDiagnostics);
+                                    if (routed) {
+                                        appendUnique(std::move(routed.value()),
+                                                     topologyVectorResultLimit);
+                                    }
+                                }
+
+                                if (!routedResults.empty()) {
                                     topologyVectorAllowedSetAnnApplied = true;
                                     topologyVectorFilterApplied = true;
-                                    topologyVectorFilterMatched = routed.value().size();
-                                    return routed;
+                                    topologyVectorFilterMatched = routedResults.size();
+                                    if (topologyVectorGlobalFillAllowed &&
+                                        routedResults.size() < topologyVectorResultLimit) {
+                                        auto global = queryVectorWithRelaxedRetry(
+                                            queryEmbedding.value(), topologyVectorResultLimit,
+                                            nullptr, &vectorSearchDiagnostics);
+                                        if (global) {
+                                            topologyVectorGlobalFillCount =
+                                                appendUnique(std::move(global.value()),
+                                                             topologyVectorResultLimit);
+                                        }
+                                    }
+                                    std::ranges::sort(
+                                        routedResults, [](const auto& lhs, const auto& rhs) {
+                                            if (lhs.score != rhs.score) {
+                                                return lhs.score > rhs.score;
+                                            }
+                                            return lhs.documentHash < rhs.documentHash;
+                                        });
+                                    for (std::size_t rank = 0; rank < routedResults.size();
+                                         ++rank) {
+                                        routedResults[rank].rank = rank;
+                                    }
+                                    return Result<std::vector<ComponentResult>>{
+                                        std::move(routedResults)};
                                 }
                                 topologyVectorAllowedSetAnnFallback = true;
                                 topologyVectorFilterFallback = true;
@@ -2218,6 +2347,8 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
                          topologyVectorAllowedSetAnnApplied);
             setDebugBool(response.debugStats, metrics::kTopologyVectorAllowedSetAnnFallback,
                          topologyVectorAllowedSetAnnFallback);
+            setDebug(response.debugStats, metrics::kTopologyVectorGlobalFillCount,
+                     std::to_string(topologyVectorGlobalFillCount));
             setDebug(response.debugStats, metrics::kTopologyShadowRetainedCandidates,
                      std::to_string(topologyShadowRetainedCandidates));
             setDebug(response.debugStats, metrics::kTopologyShadowRemovedCandidates,
@@ -2239,6 +2370,9 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
                                               topologyVectorAllowedSetAnnApplied ? 1 : 0);
             traceCollector.recordStageCounter("vector", "topology_allowed_set_ann_fallback",
                                               topologyVectorAllowedSetAnnFallback ? 1 : 0);
+            traceCollector.recordStageCounter(
+                "vector", "topology_global_fill_count",
+                static_cast<std::int64_t>(topologyVectorGlobalFillCount));
         }
     } else {
         auto runSequential = [&](auto queryFn, const char* name, float weight,
@@ -3782,6 +3916,28 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
              std::to_string(vectorSearchDiagnostics.exactDistanceEvaluations));
     setDebug(response.debugStats, metrics::kVectorSearchAnnCandidateBudgetActual,
              std::to_string(vectorSearchDiagnostics.annCandidateBudget));
+    setDebug(response.debugStats, metrics::kVectorSearchCandidateLookupCount,
+             std::to_string(vectorSearchDiagnostics.candidateLookupCount));
+    setDebugBool(response.debugStats, metrics::kVectorSearchCandidateIndexCacheUsed,
+                 vectorSearchDiagnostics.usedCandidateIndexCache);
+    setDebug(response.debugStats, metrics::kVectorSearchCandidateIndexPayloadBytes,
+             std::to_string(vectorSearchDiagnostics.candidateIndexPayloadBytes));
+    setDebug(response.debugStats, metrics::kVectorSearchMaterializedRows,
+             std::to_string(vectorSearchDiagnostics.materializedRows));
+    setDebug(response.debugStats, metrics::kVectorSearchCandidateLookupNs,
+             std::to_string(vectorSearchDiagnostics.candidateLookupNanoseconds));
+    setDebug(response.debugStats, metrics::kVectorSearchCandidateProjectionNs,
+             std::to_string(vectorSearchDiagnostics.candidateProjectionNanoseconds));
+    setDebug(response.debugStats, metrics::kVectorSearchPqLutNs,
+             std::to_string(vectorSearchDiagnostics.pqLutNanoseconds));
+    setDebug(response.debugStats, metrics::kVectorSearchAdcScoringNs,
+             std::to_string(vectorSearchDiagnostics.adcScoringNanoseconds));
+    setDebug(response.debugStats, metrics::kVectorSearchTopKSelectionNs,
+             std::to_string(vectorSearchDiagnostics.topKSelectionNanoseconds));
+    setDebug(response.debugStats, metrics::kVectorSearchResultMaterializationNs,
+             std::to_string(vectorSearchDiagnostics.resultMaterializationNanoseconds));
+    setDebug(response.debugStats, metrics::kVectorSearchExactRerankNs,
+             std::to_string(vectorSearchDiagnostics.exactRerankNanoseconds));
     traceCollector.recordStageCounter(
         "vector", "rows_visited_actual",
         static_cast<std::int64_t>(vectorSearchDiagnostics.rowsVisited));
@@ -3791,6 +3947,26 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
     traceCollector.recordStageCounter(
         "vector", "ann_candidate_budget_actual",
         static_cast<std::int64_t>(vectorSearchDiagnostics.annCandidateBudget));
+    traceCollector.recordStageCounter(
+        "vector", "candidate_lookup_ns",
+        static_cast<std::int64_t>(vectorSearchDiagnostics.candidateLookupNanoseconds));
+    traceCollector.recordStageCounter(
+        "vector", "candidate_projection_ns",
+        static_cast<std::int64_t>(vectorSearchDiagnostics.candidateProjectionNanoseconds));
+    traceCollector.recordStageCounter(
+        "vector", "pq_lut_ns", static_cast<std::int64_t>(vectorSearchDiagnostics.pqLutNanoseconds));
+    traceCollector.recordStageCounter(
+        "vector", "adc_scoring_ns",
+        static_cast<std::int64_t>(vectorSearchDiagnostics.adcScoringNanoseconds));
+    traceCollector.recordStageCounter(
+        "vector", "topk_selection_ns",
+        static_cast<std::int64_t>(vectorSearchDiagnostics.topKSelectionNanoseconds));
+    traceCollector.recordStageCounter(
+        "vector", "result_materialization_ns",
+        static_cast<std::int64_t>(vectorSearchDiagnostics.resultMaterializationNanoseconds));
+    traceCollector.recordStageCounter(
+        "vector", "exact_rerank_ns",
+        static_cast<std::int64_t>(vectorSearchDiagnostics.exactRerankNanoseconds));
     traceCollector.recordStageCounter("vector", "relaxed_retry_enabled",
                                       relaxedVectorRetryEnabled ? 1 : 0);
     traceCollector.recordStageCounter("vector", "relaxed_retry_attempted",

--- a/src/search/search_tracing.cpp
+++ b/src/search/search_tracing.cpp
@@ -167,6 +167,13 @@ void recordTopologyRoutingDebug(SearchResponse& response, const SearchEngineConf
              std::to_string(session.routeRepresentativeDistanceEvaluations));
     setDebug(debug, metrics::kTopologyRouteRepresentativeCountMax,
              std::to_string(session.routeRepresentativeCountMax));
+    setDebugBool(debug, metrics::kTopologyRouteAnnUsed, session.routeAnnUsed);
+    setDebug(debug, metrics::kTopologyRouteAnnCandidates,
+             std::to_string(session.routeAnnCandidates));
+    setDebug(debug, metrics::kTopologyRouteAnnDistanceEvaluations,
+             std::to_string(session.routeAnnDistanceEvaluations));
+    setDebug(debug, metrics::kTopologyRouteExactRepresentativeDistanceEvaluations,
+             std::to_string(session.routeExactRepresentativeDistanceEvaluations));
     setDebug(debug, metrics::kTopologyWeakQueryRoutedDocs, std::to_string(session.routedDocs));
     setDebug(debug, metrics::kTopologyWeakQueryAddedCandidates,
              std::to_string(shadowEvaluation ? 0 : session.addedCandidates));

--- a/src/search/topology_routing_session.cpp
+++ b/src/search/topology_routing_session.cpp
@@ -122,6 +122,16 @@ std::int64_t microsSince(std::chrono::steady_clock::time_point start) {
         .count();
 }
 
+void accumulateRouteWork(TopologyRoutingSessionResult& result,
+                         const yams::topology::SparseRouteWork& work) {
+    result.routeRepresentativeDistanceEvaluations += work.representativeDistanceEvaluations;
+    result.routeAnnUsed = result.routeAnnUsed || work.denseAnnUsed;
+    result.routeAnnCandidates += work.denseAnnCandidates;
+    result.routeAnnDistanceEvaluations += work.denseAnnDistanceEvaluations;
+    result.routeExactRepresentativeDistanceEvaluations +=
+        work.exactRepresentativeDistanceEvaluations;
+}
+
 /// Collect bidirectional semantic_neighbor edges for one document hash.
 /// Returns nullopt when the node is missing or edge lookup fails hard.
 std::optional<std::vector<NeighborTriple>>
@@ -295,6 +305,7 @@ tryMedoidGraphExpansion(const TopologyRoutingSessionRequest& request,
     routeRequest.scoringMode = topologyRouteScoringMode(request.options.routeScoringMode);
     routeRequest.sparseDenseAlpha = std::clamp(request.options.sparseDenseAlpha, 0.0F, 1.0F);
     routeRequest.maxRoutingRepresentatives = request.options.representativeLimit;
+    routeRequest.denseAnnCandidateLimit = request.options.denseAnnCandidateLimit;
     if (request.queryEmbedding.has_value()) {
         routeRequest.queryEmbedding = request.queryEmbedding.value();
     }
@@ -302,7 +313,7 @@ tryMedoidGraphExpansion(const TopologyRoutingSessionRequest& request,
     yams::topology::SparseGuidedClusterRouter router;
     yams::topology::SparseRouteWork routeWork;
     auto routes = router.route(routeRequest, topology, snapshot->sparseRouteIndex, &routeWork);
-    result.routeRepresentativeDistanceEvaluations += routeWork.representativeDistanceEvaluations;
+    accumulateRouteWork(result, routeWork);
     if (!routes) {
         return out;
     }
@@ -589,6 +600,11 @@ void materializeAllowedRouteMembers(
             entry->first,
             finalizeCandidateStructure(entry->second.structure, selectedScaleMask, acceptedRoutes));
     }
+    for (auto& routeGroup : result.routeAllowedDocumentHashGroups) {
+        std::erase_if(routeGroup, [&](const auto& hash) {
+            return !result.routeAllowedDocumentHashes.contains(hash);
+        });
+    }
     result.routedDocs = take;
 }
 
@@ -618,6 +634,7 @@ runClusterArtifactExpansion(const TopologyRoutingSessionRequest& request,
     routeRequest.scoringMode = topologyRouteScoringMode(request.options.routeScoringMode);
     routeRequest.sparseDenseAlpha = std::clamp(request.options.sparseDenseAlpha, 0.0F, 1.0F);
     routeRequest.maxRoutingRepresentatives = request.options.representativeLimit;
+    routeRequest.denseAnnCandidateLimit = request.options.denseAnnCandidateLimit;
     if (request.queryEmbedding.has_value()) {
         routeRequest.queryEmbedding = request.queryEmbedding.value();
     }
@@ -627,7 +644,7 @@ runClusterArtifactExpansion(const TopologyRoutingSessionRequest& request,
     const auto sparseRouteStart = std::chrono::steady_clock::now();
     yams::topology::SparseRouteWork routeWork;
     auto routes = router.route(routeRequest, topology, snapshot->sparseRouteIndex, &routeWork);
-    result.routeRepresentativeDistanceEvaluations += routeWork.representativeDistanceEvaluations;
+    accumulateRouteWork(result, routeWork);
     result.timings.routeMicros = microsSince(sparseRouteStart);
     if (!routes) {
         result.skipReason = std::string{"route_failed:"} + routes.error().message;
@@ -701,6 +718,10 @@ runClusterArtifactExpansion(const TopologyRoutingSessionRequest& request,
         if (route.medoidDocumentHash.has_value()) {
             result.medoidHashes.insert(*route.medoidDocumentHash);
         }
+        std::unordered_set<std::string>* routeMemberGroup = nullptr;
+        if (request.options.collectRouteMembership && mayExpand) {
+            routeMemberGroup = &result.routeAllowedDocumentHashGroups.emplace_back();
+        }
 
         const auto clusterLookupStart = std::chrono::steady_clock::now();
         const auto clusterIt = snapshot->clustersById.find(route.clusterId);
@@ -714,6 +735,7 @@ runClusterArtifactExpansion(const TopologyRoutingSessionRequest& request,
                 if (hash.empty()) {
                     continue;
                 }
+                routeMemberGroup->insert(hash);
                 auto& candidate = routedMembers[hash];
                 candidate.seed = candidate.seed || seedSet.contains(hash);
                 if (candidate.seed) {
@@ -860,6 +882,7 @@ makeTopologyRoutingOptions(const SearchEngineConfig& config,
         .minClusters = config.topologyMinClusters,
         .maxClusters = config.topologyMaxClusters,
         .representativeLimit = config.topologyRoutingRepresentativeLimit,
+        .denseAnnCandidateLimit = config.topologyRoutingAnnCandidateLimit,
         .adaptiveProbeScoreGap = config.topologyAdaptiveProbeScoreGap,
         .narrowMinBoundaryMargin = config.topologyNarrowMinBoundaryMargin,
         .maxDocs = config.topologyMaxDocs,

--- a/src/storage/storage_engine.cpp
+++ b/src/storage/storage_engine.cpp
@@ -26,6 +26,7 @@ namespace yamsfmt = fmt;
 #include <optional>
 #include <random>
 #include <shared_mutex>
+#include <span>
 #include <system_error>
 #include <yams/compat/unistd.h>
 #ifdef _WIN32
@@ -551,7 +552,7 @@ std::vector<Result<void>> StorageEngine::storeBatch(
                 return;
             }
             const auto& [hash, data] = items[index];
-            results[index] = store(hash, data);
+            results[index] = store(hash, std::span<const std::byte>(data.data(), data.size()));
         }
     };
 

--- a/src/topology/topology_baseline.cpp
+++ b/src/topology/topology_baseline.cpp
@@ -1,5 +1,6 @@
 #include <yams/topology/topology_baseline.h>
 #include <yams/topology/topology_representatives.h>
+#include <yams/vector/static_cosine_ann_index.h>
 
 #include <algorithm>
 #include <chrono>
@@ -712,6 +713,27 @@ SparseGuidedClusterRouter::buildRouteIndex(const TopologyArtifactBatch& artifact
         }
     }
 
+    std::vector<std::size_t> centroidIds;
+    std::vector<std::vector<float>> centroids;
+    centroidIds.reserve(artifacts.clusters.size());
+    centroids.reserve(artifacts.clusters.size());
+    for (std::size_t clusterIndex = 0; clusterIndex < artifacts.clusters.size(); ++clusterIndex) {
+        const auto& centroid = artifacts.clusters[clusterIndex].centroidEmbedding;
+        if (centroid.empty() || index.centroidNorms[clusterIndex] <= 0.0F) {
+            centroidIds.clear();
+            centroids.clear();
+            break;
+        }
+        centroidIds.push_back(clusterIndex);
+        centroids.push_back(centroid);
+    }
+    if (!centroids.empty()) {
+        auto annIndex = yams::vector::StaticCosineAnnIndex::build(centroidIds, centroids);
+        if (annIndex) {
+            index.centroidAnnIndex = std::move(annIndex).value();
+        }
+    }
+
     auto addMembership = [&](const std::string& hash, const std::string& clusterId) {
         const auto clusterIt = clusterIndexById.find(clusterId);
         if (hash.empty() || clusterIt == clusterIndexById.end()) {
@@ -807,11 +829,45 @@ SparseGuidedClusterRouter::route(const TopologyRouteRequest& request,
         maxSparseMass = std::max(maxSparseMass, signal.sparseMass);
     }
 
+    const float alpha = std::clamp(request.sparseDenseAlpha, 0.0F, 1.0F);
     const float queryNorm = vectorNorm(request.queryEmbedding);
     if (!request.queryEmbedding.empty() && work != nullptr) {
         ++work->queryNormEvaluations;
     }
+
+    std::vector<bool> routeCandidates(artifacts.clusters.size(), true);
+    const bool denseAnnEligible = alpha < 1.0F && queryNorm > 0.0F && request.limit > 0 &&
+                                  request.denseAnnCandidateLimit > 0 && index.centroidAnnIndex &&
+                                  artifacts.clusters.size() > request.denseAnnCandidateLimit;
+    if (denseAnnEligible) {
+        const auto candidateLimit = std::min(
+            artifacts.clusters.size(), std::max(request.denseAnnCandidateLimit, request.limit));
+        auto annResult = index.centroidAnnIndex->search(request.queryEmbedding, candidateLimit);
+        if (annResult) {
+            std::fill(routeCandidates.begin(), routeCandidates.end(), false);
+            for (const auto& hit : annResult.value().hits) {
+                if (hit.id < routeCandidates.size()) {
+                    routeCandidates[hit.id] = true;
+                }
+            }
+            for (std::size_t clusterIndex = 0; clusterIndex < signals.size(); ++clusterIndex) {
+                if (signals[clusterIndex].sparseMass > 0.0) {
+                    routeCandidates[clusterIndex] = true;
+                }
+            }
+            if (work != nullptr) {
+                work->denseAnnUsed = true;
+                work->denseAnnCandidates = annResult.value().hits.size();
+                work->denseAnnDistanceEvaluations = annResult.value().distanceEvaluations;
+                work->representativeDistanceEvaluations += annResult.value().distanceEvaluations;
+            }
+        }
+    }
+
     for (std::size_t clusterIndex = 0; clusterIndex < artifacts.clusters.size(); ++clusterIndex) {
+        if (!routeCandidates[clusterIndex] || alpha >= 1.0F) {
+            continue;
+        }
         const auto& cluster = artifacts.clusters[clusterIndex];
         const float centroidNorm = index.centroidNorms[clusterIndex];
         if (queryNorm > 0.0F && centroidNorm > 0.0F && !cluster.centroidEmbedding.empty()) {
@@ -821,6 +877,7 @@ SparseGuidedClusterRouter::route(const TopologyRouteRequest& request,
             signals[clusterIndex].dense = std::clamp((dense + 1.0F) * 0.5F, 0.0F, 1.0F);
             if (work != nullptr) {
                 ++work->representativeDistanceEvaluations;
+                ++work->exactRepresentativeDistanceEvaluations;
             }
         }
         const auto& representativeNorms = index.routingRepresentativeNorms[clusterIndex];
@@ -849,14 +906,17 @@ SparseGuidedClusterRouter::route(const TopologyRouteRequest& request,
             signals[clusterIndex].dense = std::max(signals[clusterIndex].dense, dense);
             if (work != nullptr) {
                 ++work->representativeDistanceEvaluations;
+                ++work->exactRepresentativeDistanceEvaluations;
             }
         }
     }
 
-    const float alpha = std::clamp(request.sparseDenseAlpha, 0.0F, 1.0F);
     std::vector<ClusterRoute> routes;
     routes.reserve(artifacts.clusters.size());
     for (std::size_t clusterIndex = 0; clusterIndex < artifacts.clusters.size(); ++clusterIndex) {
+        if (!routeCandidates[clusterIndex]) {
+            continue;
+        }
         const auto& cluster = artifacts.clusters[clusterIndex];
         const auto& clusterSignals = signals[clusterIndex];
         const float dense = clusterSignals.dense;

--- a/src/vector/meson.build
+++ b/src/vector/meson.build
@@ -153,6 +153,7 @@ srcs = [
   'batch_metrics.cpp',
   'document_chunker.cpp',
   'vector_utils.cpp',
+  'static_cosine_ann_index.cpp',
   'model_registry.cpp',
   'model_cache.cpp',
   'model_loader.cpp',

--- a/src/vector/sqlite_vec_backend.cpp
+++ b/src/vector/sqlite_vec_backend.cpp
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -48,13 +49,48 @@ namespace yams::vector {
 struct SimeonPqIndexState {
     simeon::ProductQuantizer pq;
     std::vector<std::size_t> rowids;
+    std::vector<std::uint64_t> tie_break_keys;
+    std::unordered_map<std::string, std::vector<std::size_t>> document_indices;
     std::vector<std::uint8_t> codes;
     std::size_t rerank_factor = 2;
+    std::size_t document_index_payload_bytes = 0;
 
     explicit SimeonPqIndexState(simeon::PQConfig cfg) : pq(cfg) {}
+
+    void updateDocumentIndexPayloadBytes() noexcept {
+        document_index_payload_bytes = document_indices.bucket_count() * sizeof(void*);
+        for (const auto& [documentHash, indices] : document_indices) {
+            document_index_payload_bytes += sizeof(decltype(document_indices)::value_type) +
+                                            documentHash.size() +
+                                            indices.capacity() * sizeof(std::size_t);
+        }
+    }
 };
 
 namespace {
+
+std::uint64_t stableEmbeddingSampleKey(std::span<const float> embedding) noexcept {
+    std::uint64_t hash = 1469598103934665603ULL;
+    for (const float value : embedding) {
+        std::uint32_t bits = 0;
+        static_assert(sizeof(bits) == sizeof(value));
+        std::memcpy(&bits, &value, sizeof(bits));
+        for (std::size_t byte = 0; byte < sizeof(bits); ++byte) {
+            hash ^= static_cast<std::uint8_t>((bits >> (byte * 8U)) & 0xFFU);
+            hash *= 1099511628211ULL;
+        }
+    }
+    return hash;
+}
+
+std::uint64_t stableStringKey(std::string_view value) noexcept {
+    std::uint64_t hash = 1469598103934665603ULL;
+    for (const unsigned char byte : value) {
+        hash ^= byte;
+        hash *= 1099511628211ULL;
+    }
+    return hash;
+}
 
 std::optional<std::string> getenvCopy(const char* name) {
     static std::mutex envMutex;
@@ -1261,7 +1297,15 @@ public:
 
             std::vector<int64_t> candidateRowids;
             if (!candidate_hashes.empty()) {
+                const auto lookupStart = std::chrono::steady_clock::now();
                 auto rowids = lookupCandidateRowidsUnlocked(query_dim, candidate_hashes);
+                if (diagnostics != nullptr) {
+                    ++diagnostics->candidateLookupCount;
+                    diagnostics->candidateLookupNanoseconds += static_cast<std::uint64_t>(
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            std::chrono::steady_clock::now() - lookupStart)
+                            .count());
+                }
                 if (!rowids) {
                     return rowids.error();
                 }
@@ -1283,7 +1327,7 @@ public:
         if (usesSimeonPqSearchEngine()) {
             const size_t query_dim = query_embedding.size();
 
-            if (document_hash || !candidate_hashes.empty() || !metadata_filters.empty()) {
+            if (document_hash || !metadata_filters.empty()) {
                 spdlog::debug("[SPQ] filtered search falling back to exact cosine scan");
                 return bruteForceSearchUnlocked(query_embedding, k, similarity_threshold,
                                                 document_hash, candidate_hashes, metadata_filters,
@@ -1307,13 +1351,9 @@ public:
                 }
             }
 
-            auto result = simeonPqSearchUnlocked(query_embedding, k, similarity_threshold);
-            if (diagnostics && result) {
-                diagnostics->usedAnn = true;
-                diagnostics->annCandidateBudget = query_dim_counts_[query_dim];
-                diagnostics->returnedRows = result.value().size();
-            }
-            return result;
+            return simeonPqSearchUnlocked(query_embedding, k, similarity_threshold,
+                                          candidate_hashes.empty() ? nullptr : &candidate_hashes,
+                                          diagnostics);
         }
 
         return Error{ErrorCode::InvalidOperation, "no search engine configured"};
@@ -2860,6 +2900,52 @@ private:
         return rows;
     }
 
+    bool loadSimeonRowMetadataUnlocked(
+        size_t dim, std::span<const std::size_t> rowids, std::vector<std::uint64_t>& keys,
+        std::unordered_map<std::string, std::vector<std::size_t>>& documentIndices) const {
+        keys.clear();
+        keys.reserve(rowids.size());
+        documentIndices.clear();
+        sqlite3_stmt* stmt = nullptr;
+        constexpr const char* sql = "SELECT rowid, chunk_id, document_hash FROM vectors "
+                                    "WHERE embedding_dim = ? ORDER BY rowid";
+        if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+            return false;
+        }
+        sqlite3_bind_int64(stmt, 1, static_cast<sqlite3_int64>(dim));
+        std::size_t expected = 0;
+        while (expected < rowids.size() && sqlite3_step(stmt) == SQLITE_ROW) {
+            const auto rowid = static_cast<std::size_t>(sqlite3_column_int64(stmt, 0));
+            if (rowid < rowids[expected]) {
+                continue;
+            }
+            if (rowid != rowids[expected]) {
+                sqlite3_finalize(stmt);
+                keys.clear();
+                documentIndices.clear();
+                return false;
+            }
+            const auto* chunkId = sqlite3_column_text(stmt, 1);
+            const auto* documentHash = sqlite3_column_text(stmt, 2);
+            if (chunkId == nullptr || documentHash == nullptr) {
+                sqlite3_finalize(stmt);
+                keys.clear();
+                documentIndices.clear();
+                return false;
+            }
+            keys.push_back(stableStringKey(reinterpret_cast<const char*>(chunkId)));
+            documentIndices[reinterpret_cast<const char*>(documentHash)].push_back(expected);
+            ++expected;
+        }
+        sqlite3_finalize(stmt);
+        if (expected != rowids.size()) {
+            keys.clear();
+            documentIndices.clear();
+            return false;
+        }
+        return true;
+    }
+
     Result<void> rebuildVec0DimUnlocked(size_t dim) {
         auto table_result = ensureVec0TableUnlocked(dim);
         if (!table_result) {
@@ -3075,23 +3161,21 @@ private:
         const std::size_t trainCap = std::min(rows.size(), config_.simeon_pq_train_limit);
         state->rowids.reserve(rows.size());
 
-        // Pass 1: normalize in place, collect rowids, copy a bounded prefix
-        // into the training buffer. Normalized embeddings stay in `rows` so
-        // pass 2 can encode without re-reading SQLite.
-        std::vector<float> training;
-        training.reserve(trainCap * dim);
-        std::size_t trainSamples = 0;
-        for (auto& [rowid, embedding] : rows) {
+        // Pass 1: normalize in place and collect rowids. SQLite rowids reflect
+        // ingestion order, so they must not choose or order the PQ training set:
+        // two identical corpora inserted in different orders must build the same
+        // codebook and return the same neighbors.
+        std::vector<std::size_t> trainingOrder;
+        trainingOrder.reserve(rows.size());
+        for (std::size_t index = 0; index < rows.size(); ++index) {
+            auto& [rowid, embedding] = rows[index];
             if (!normalizeEmbeddingInPlace(embedding)) {
                 embedding.clear();
                 embedding.shrink_to_fit();
                 continue;
             }
-            if (trainSamples < trainCap) {
-                training.insert(training.end(), embedding.begin(), embedding.end());
-                ++trainSamples;
-            }
             state->rowids.push_back(rowid);
+            trainingOrder.push_back(index);
         }
 
         if (state->rowids.empty()) {
@@ -3099,6 +3183,33 @@ private:
             simeon_pq_ready_dims_.insert(dim);
             return Result<void>{};
         }
+
+        std::vector<std::uint64_t> trainingKeys(rows.size(), 0);
+        for (const auto index : trainingOrder) {
+            trainingKeys[index] = stableEmbeddingSampleKey(rows[index].second);
+        }
+        std::ranges::sort(trainingOrder, [&](std::size_t lhs, std::size_t rhs) {
+            if (trainingKeys[lhs] != trainingKeys[rhs]) {
+                return trainingKeys[lhs] < trainingKeys[rhs];
+            }
+            const auto& left = rows[lhs].second;
+            const auto& right = rows[rhs].second;
+            return std::lexicographical_compare(left.begin(), left.end(), right.begin(),
+                                                right.end());
+        });
+        if (trainingOrder.size() > trainCap) {
+            trainingOrder.resize(trainCap);
+        }
+
+        std::vector<float> training;
+        training.reserve(trainingOrder.size() * dim);
+        for (const auto index : trainingOrder) {
+            const auto& embedding = rows[index].second;
+            training.insert(training.end(), embedding.begin(), embedding.end());
+        }
+        const auto trainSamples = trainingOrder.size();
+        std::vector<std::uint64_t>().swap(trainingKeys);
+        std::vector<std::size_t>().swap(trainingOrder);
 
         try {
             if (trainSamples >= k) {
@@ -3129,6 +3240,12 @@ private:
             std::vector<float>().swap(embedding);
         }
         std::vector<std::pair<size_t, std::vector<float>>>().swap(rows);
+        if (!loadSimeonRowMetadataUnlocked(dim, state->rowids, state->tie_break_keys,
+                                           state->document_indices)) {
+            return Error{ErrorCode::DatabaseError,
+                         "Failed to load Simeon PQ row metadata for dim " + std::to_string(dim)};
+        }
+        state->updateDocumentIndexPayloadBytes();
         state->rerank_factor = std::max<std::size_t>(1, config_.simeon_pq_rerank_factor);
         simeon_pq_indices_[dim] = std::move(state);
         simeon_pq_dirty_dims_.erase(dim);
@@ -3197,6 +3314,11 @@ private:
             state->rowids.size() != vectorCount) {
             return false;
         }
+        if (!loadSimeonRowMetadataUnlocked(dim, state->rowids, state->tie_break_keys,
+                                           state->document_indices)) {
+            return false;
+        }
+        state->updateDocumentIndexPayloadBytes();
         simeon_pq_indices_[dim] = std::move(state);
         simeon_pq_dirty_dims_.erase(dim);
         simeon_pq_ready_dims_.insert(dim);
@@ -3248,7 +3370,9 @@ private:
 
     Result<std::vector<VectorRecord>>
     simeonPqSearchUnlocked(const std::vector<float>& query_embedding, size_t k,
-                           float similarity_threshold) {
+                           float similarity_threshold,
+                           const std::unordered_set<std::string>* candidateHashes = nullptr,
+                           VectorSearchDiagnostics* diagnostics = nullptr) {
         if (!db_ || query_embedding.empty() || k == 0) {
             return std::vector<VectorRecord>{};
         }
@@ -3263,36 +3387,135 @@ private:
             return std::vector<VectorRecord>{};
         }
 
-        simeon::PQQuery pqQuery(it->second->pq, normalized_query.data());
+        const auto lutStart = std::chrono::steady_clock::now();
+        simeon::PQInnerProductQuery pqQuery(it->second->pq, normalized_query.data());
+        if (diagnostics != nullptr) {
+            diagnostics->pqLutNanoseconds +=
+                static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                               std::chrono::steady_clock::now() - lutStart)
+                                               .count());
+        }
         const size_t m = it->second->pq.m();
-        const size_t approxK = std::min(it->second->rowids.size(),
-                                        std::max<std::size_t>(k, k * it->second->rerank_factor));
+
+        std::vector<std::size_t> candidateIndices;
+        if (candidateHashes != nullptr) {
+            const auto lookupStart = std::chrono::steady_clock::now();
+            for (const auto& documentHash : *candidateHashes) {
+                const auto found = it->second->document_indices.find(documentHash);
+                if (found != it->second->document_indices.end()) {
+                    candidateIndices.insert(candidateIndices.end(), found->second.begin(),
+                                            found->second.end());
+                }
+            }
+            if (diagnostics != nullptr) {
+                diagnostics->usedCandidateIndexCache = true;
+                ++diagnostics->candidateLookupCount;
+                diagnostics->candidateIndexPayloadBytes = it->second->document_index_payload_bytes;
+                diagnostics->candidateLookupNanoseconds +=
+                    static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                                   std::chrono::steady_clock::now() - lookupStart)
+                                                   .count());
+            }
+            const auto projectionStart = std::chrono::steady_clock::now();
+            std::ranges::sort(candidateIndices);
+            if (diagnostics != nullptr) {
+                diagnostics->candidateProjectionNanoseconds += static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        std::chrono::steady_clock::now() - projectionStart)
+                        .count());
+            }
+        }
+
+        const size_t candidateCount =
+            candidateHashes == nullptr ? it->second->rowids.size() : candidateIndices.size();
+        if (diagnostics != nullptr) {
+            diagnostics->usedAnn = true;
+            diagnostics->annCandidateBudget = candidateCount;
+            diagnostics->rowsVisited = candidateCount;
+        }
+        if (candidateCount == 0) {
+            return std::vector<VectorRecord>{};
+        }
+
+        const auto rerankFactor = it->second->rerank_factor;
+        const size_t rerankBudget = k > std::numeric_limits<size_t>::max() / rerankFactor
+                                        ? std::numeric_limits<size_t>::max()
+                                        : k * rerankFactor;
+        const size_t approxK = std::min(candidateCount, std::max(k, rerankBudget));
+        YAMS_ASSERT(it->second->tie_break_keys.size() == it->second->rowids.size(),
+                    "Simeon PQ tie-break keys must align with indexed rowids");
 
         std::vector<std::pair<float, std::size_t>> scores;
-        scores.reserve(it->second->rowids.size());
-        for (std::size_t i = 0; i < it->second->rowids.size(); ++i) {
-            const float approxScore = pqQuery.inner_product(it->second->codes.data() + (i * m));
-            scores.emplace_back(approxScore, i);
+        scores.reserve(candidateCount);
+        const auto scoringStart = std::chrono::steady_clock::now();
+        const auto scoreIndex = [&](std::size_t index) {
+            const float approxScore = pqQuery.inner_product(it->second->codes.data() + (index * m));
+            scores.emplace_back(approxScore, index);
+        };
+        if (candidateHashes == nullptr) {
+            for (std::size_t index = 0; index < it->second->rowids.size(); ++index) {
+                scoreIndex(index);
+            }
+        } else {
+            for (const auto index : candidateIndices) {
+                scoreIndex(index);
+            }
         }
-        const auto cmp = [](const auto& a, const auto& b) { return a.first > b.first; };
+        if (diagnostics != nullptr) {
+            diagnostics->adcScoringNanoseconds +=
+                static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                               std::chrono::steady_clock::now() - scoringStart)
+                                               .count());
+        }
+        const auto cmp = [&](const auto& a, const auto& b) {
+            if (a.first != b.first) {
+                return a.first > b.first;
+            }
+            return it->second->tie_break_keys[a.second] < it->second->tie_break_keys[b.second];
+        };
+        const auto selectionStart = std::chrono::steady_clock::now();
         if (scores.size() > approxK) {
             std::nth_element(scores.begin(), scores.begin() + approxK, scores.end(), cmp);
             scores.resize(approxK);
         }
         std::sort(scores.begin(), scores.end(), cmp);
+        if (diagnostics != nullptr) {
+            diagnostics->topKSelectionNanoseconds +=
+                static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                               std::chrono::steady_clock::now() - selectionStart)
+                                               .count());
+        }
 
         std::vector<VectorRecord> records;
         records.reserve(scores.size());
         for (const auto& [approxScore, idx] : scores) {
+            const auto materializationStart = std::chrono::steady_clock::now();
             auto record_opt =
                 getVectorByRowidUnlocked(static_cast<int64_t>(it->second->rowids[idx]));
+            if (diagnostics != nullptr) {
+                diagnostics->resultMaterializationNanoseconds += static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        std::chrono::steady_clock::now() - materializationStart)
+                        .count());
+            }
             if (!record_opt) {
                 continue;
             }
+            if (diagnostics != nullptr) {
+                ++diagnostics->materializedRows;
+            }
             float similarity = approxScore;
             if (!record_opt->embedding.empty()) {
+                const auto rerankStart = std::chrono::steady_clock::now();
                 similarity = static_cast<float>(VectorDatabase::computeCosineSimilarity(
                     query_embedding, record_opt->embedding));
+                if (diagnostics != nullptr) {
+                    ++diagnostics->exactDistanceEvaluations;
+                    diagnostics->exactRerankNanoseconds += static_cast<std::uint64_t>(
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            std::chrono::steady_clock::now() - rerankStart)
+                            .count());
+                }
             }
             if (similarity < similarity_threshold) {
                 continue;
@@ -3301,10 +3524,16 @@ private:
             records.push_back(std::move(*record_opt));
         }
         std::sort(records.begin(), records.end(), [](const auto& a, const auto& b) {
-            return a.relevance_score > b.relevance_score;
+            if (a.relevance_score != b.relevance_score) {
+                return a.relevance_score > b.relevance_score;
+            }
+            return a.chunk_id < b.chunk_id;
         });
         if (records.size() > k) {
             records.resize(k);
+        }
+        if (diagnostics != nullptr) {
+            diagnostics->returnedRows = records.size();
         }
         return records;
     }

--- a/src/vector/static_cosine_ann_index.cpp
+++ b/src/vector/static_cosine_ann_index.cpp
@@ -1,0 +1,173 @@
+#include <yams/vector/static_cosine_ann_index.h>
+
+#include <sqlite-vec-cpp/distances/inner_product.hpp>
+#include <sqlite-vec-cpp/index/hnsw.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <exception>
+#include <unordered_set>
+#include <utility>
+
+namespace yams::vector {
+
+namespace {
+
+thread_local std::size_t* activeDistanceEvaluationCounter = nullptr;
+
+struct CountingNormalizedCosineDistance {
+    [[nodiscard]] float operator()(std::span<const float> lhs, std::span<const float> rhs) const {
+        if (activeDistanceEvaluationCounter != nullptr) {
+            ++*activeDistanceEvaluationCounter;
+        }
+        return sqlite_vec_cpp::distances::inner_product_distance(lhs, rhs);
+    }
+};
+
+class DistanceEvaluationScope final {
+public:
+    explicit DistanceEvaluationScope(std::size_t& counter) noexcept
+        : previous_(std::exchange(activeDistanceEvaluationCounter, &counter)) {}
+
+    ~DistanceEvaluationScope() { activeDistanceEvaluationCounter = previous_; }
+
+private:
+    std::size_t* previous_;
+};
+
+Result<std::vector<float>> normalized(std::span<const float> values) {
+    double squaredNorm = 0.0;
+    for (const auto value : values) {
+        if (!std::isfinite(value)) {
+            return Error{ErrorCode::InvalidArgument, "ANN vectors must contain finite values"};
+        }
+        squaredNorm += static_cast<double>(value) * static_cast<double>(value);
+    }
+    if (squaredNorm <= 1e-16) {
+        return Error{ErrorCode::InvalidArgument, "ANN vectors must have non-zero norm"};
+    }
+
+    const auto inverseNorm = static_cast<float>(1.0 / std::sqrt(squaredNorm));
+    std::vector<float> result(values.begin(), values.end());
+    for (auto& value : result) {
+        value *= inverseNorm;
+    }
+    return result;
+}
+
+} // namespace
+
+class StaticCosineAnnIndex::Impl final {
+public:
+    using Index = sqlite_vec_cpp::index::HNSWIndex<float, CountingNormalizedCosineDistance>;
+
+    Impl(std::size_t dimension, std::size_t size)
+        : dimension_(dimension), index_(makeConfig(size, dimension)) {
+        externalIds_.reserve(size);
+        index_.reserve(size);
+    }
+
+    static Index::Config makeConfig(std::size_t size, std::size_t dimension) {
+        auto config = Index::Config::for_corpus(size, dimension);
+        config.random_seed = 42;
+        return config;
+    }
+
+    std::size_t dimension_{0};
+    std::vector<std::size_t> externalIds_;
+    Index index_;
+};
+
+StaticCosineAnnIndex::StaticCosineAnnIndex(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+
+StaticCosineAnnIndex::~StaticCosineAnnIndex() = default;
+
+Result<std::shared_ptr<const StaticCosineAnnIndex>>
+StaticCosineAnnIndex::build(std::span<const std::size_t> ids,
+                            std::span<const std::vector<float>> vectors) {
+    if (ids.empty() || ids.size() != vectors.size()) {
+        return Error{ErrorCode::InvalidArgument,
+                     "ANN IDs and vectors must be non-empty and have equal sizes"};
+    }
+    const auto dimension = vectors.front().size();
+    if (dimension == 0) {
+        return Error{ErrorCode::InvalidArgument, "ANN vector dimension must be non-zero"};
+    }
+
+    std::unordered_set<std::size_t> uniqueIds;
+    uniqueIds.reserve(ids.size());
+    std::vector<std::vector<float>> normalizedVectors;
+    normalizedVectors.reserve(vectors.size());
+    for (std::size_t index = 0; index < vectors.size(); ++index) {
+        if (vectors[index].size() != dimension) {
+            return Error{ErrorCode::InvalidArgument, "ANN vector dimensions must match"};
+        }
+        if (!uniqueIds.insert(ids[index]).second) {
+            return Error{ErrorCode::InvalidArgument, "ANN IDs must be unique"};
+        }
+        auto normalizedVector = normalized(vectors[index]);
+        if (!normalizedVector) {
+            return normalizedVector.error();
+        }
+        normalizedVectors.push_back(std::move(normalizedVector).value());
+    }
+
+    try {
+        auto impl = std::make_unique<Impl>(dimension, vectors.size());
+        impl->externalIds_.assign(ids.begin(), ids.end());
+        for (std::size_t index = 0; index < normalizedVectors.size(); ++index) {
+            impl->index_.insert_single_threaded(index, normalizedVectors[index]);
+        }
+        auto mutableIndex =
+            std::shared_ptr<StaticCosineAnnIndex>(new StaticCosineAnnIndex(std::move(impl)));
+        return std::static_pointer_cast<const StaticCosineAnnIndex>(std::move(mutableIndex));
+    } catch (const std::exception& error) {
+        return Error{ErrorCode::InternalError,
+                     std::string{"failed to build static ANN index: "} + error.what()};
+    }
+}
+
+Result<StaticCosineAnnSearchResult> StaticCosineAnnIndex::search(std::span<const float> query,
+                                                                 std::size_t candidates,
+                                                                 std::size_t efSearch) const {
+    if (query.size() != dimension()) {
+        return Error{ErrorCode::InvalidArgument, "ANN query dimension does not match index"};
+    }
+    if (candidates == 0 || size() == 0) {
+        return StaticCosineAnnSearchResult{};
+    }
+    auto normalizedQuery = normalized(query);
+    if (!normalizedQuery) {
+        return normalizedQuery.error();
+    }
+
+    const auto take = std::min(candidates, size());
+    const auto effectiveEf = std::min(size(), std::max({take, efSearch, std::size_t{32}}));
+    StaticCosineAnnSearchResult result;
+    try {
+        DistanceEvaluationScope countDistances(result.distanceEvaluations);
+        const auto hits =
+            impl_->index_.search_read_mostly(normalizedQuery.value(), take, effectiveEf);
+        result.hits.reserve(hits.size());
+        for (const auto& [internalId, distance] : hits) {
+            if (internalId < impl_->externalIds_.size()) {
+                result.hits.push_back(StaticCosineAnnHit{.id = impl_->externalIds_[internalId],
+                                                         .distance = distance});
+            }
+        }
+    } catch (const std::exception& error) {
+        return Error{ErrorCode::InternalError,
+                     std::string{"static ANN search failed: "} + error.what()};
+    }
+    return result;
+}
+
+std::size_t StaticCosineAnnIndex::size() const noexcept {
+    return impl_->externalIds_.size();
+}
+
+std::size_t StaticCosineAnnIndex::dimension() const noexcept {
+    return impl_->dimension_;
+}
+
+} // namespace yams::vector

--- a/tests/benchmarks/search/retrieval_quality_bench.cpp
+++ b/tests/benchmarks/search/retrieval_quality_bench.cpp
@@ -6085,6 +6085,8 @@ struct BenchFixture {
                 std::getenv("YAMS_BENCH_TOPOLOGY_BOUNDARY_SPILL");
             const char* topologyRepresentativeLimitEnv =
                 std::getenv("YAMS_BENCH_TOPOLOGY_ROUTE_REPRESENTATIVE_LIMIT");
+            const char* topologyAnnCandidateLimitEnv =
+                std::getenv("YAMS_BENCH_TOPOLOGY_ROUTE_ANN_CANDIDATE_LIMIT");
             const bool writeTopologyEngineConfig =
                 (topologyEngineEnv && *topologyEngineEnv) ||
                 (topologyRepresentativesEnv && *topologyRepresentativesEnv) ||
@@ -6097,6 +6099,7 @@ struct BenchFixture {
                 (std::getenv("YAMS_BENCH_TOPOLOGY_MIN_CLUSTERS") != nullptr) ||
                 (std::getenv("YAMS_BENCH_TOPOLOGY_MAX_SEED_DOCUMENTS") != nullptr) ||
                 (topologyRepresentativeLimitEnv && *topologyRepresentativeLimitEnv) ||
+                (topologyAnnCandidateLimitEnv && *topologyAnnCandidateLimitEnv) ||
                 (std::getenv("YAMS_BENCH_TOPOLOGY_ADAPTIVE_PROBE_SCORE_GAP") != nullptr) ||
                 (std::getenv("YAMS_BENCH_TOPOLOGY_NARROW_MIN_BOUNDARY_MARGIN") != nullptr) ||
                 (std::getenv("YAMS_BENCH_TOPOLOGY_EXPANSION") != nullptr) ||
@@ -6370,6 +6373,12 @@ struct BenchFixture {
                             configOut << "representative_limit = "
                                       << parseSizeEnvOrDefault(
                                              "YAMS_BENCH_TOPOLOGY_ROUTE_REPRESENTATIVE_LIMIT", 0)
+                                      << "\n";
+                        }
+                        if (topologyAnnCandidateLimitEnv && *topologyAnnCandidateLimitEnv) {
+                            configOut << "ann_candidate_limit = "
+                                      << parseSizeEnvOrDefault(
+                                             "YAMS_BENCH_TOPOLOGY_ROUTE_ANN_CANDIDATE_LIMIT", 64)
                                       << "\n";
                         }
                         configOut << "adaptive_probe_score_gap = "

--- a/tests/benchmarks/vector_backend_engine_compare.cpp
+++ b/tests/benchmarks/vector_backend_engine_compare.cpp
@@ -256,8 +256,8 @@ int main(int argc, char* argv[]) {
                     "comparable\n\n");
 
         if (cfg.filter_cell) {
-            std::printf("filtered-search cell: exact-scan fallback latency by candidate "
-                        "fraction\n");
+            std::printf("filtered-search cell: routed Simeon PQ/ADC versus exact allowed-set "
+                        "control\n");
             SqliteVecBackend::Config backend_cfg;
             backend_cfg.embedding_dim = cfg.dim;
             backend_cfg.search_engine = VectorSearchEngine::SimeonPqAdc;
@@ -273,7 +273,7 @@ int main(int argc, char* argv[]) {
             for (size_t i = 0; i < corpus.size(); ++i) {
                 VectorRecord rec;
                 rec.chunk_id = "chunk_" + std::to_string(i);
-                rec.document_hash = "doc_" + std::to_string(i);
+                rec.document_hash = "doc_" + std::to_string(i / 4);
                 rec.embedding = corpus[i];
                 rec.content = "benchmark content " + std::to_string(i);
                 records.push_back(std::move(rec));
@@ -281,31 +281,107 @@ int main(int argc, char* argv[]) {
             if (!backend.insertVectorsBatch(records)) {
                 throw std::runtime_error("insert failed");
             }
+            const auto buildStart = std::chrono::steady_clock::now();
+            if (!backend.buildIndex()) {
+                throw std::runtime_error("buildIndex failed");
+            }
+            const auto buildEnd = std::chrono::steady_clock::now();
+            std::printf("index_build_ms=%.1f vectors=%zu documents=%zu chunks_per_document=4\n",
+                        std::chrono::duration<double, std::milli>(buildEnd - buildStart).count(),
+                        cfg.corpus, (cfg.corpus + 3) / 4);
 
-            for (double fraction : {0.01, 0.10, 0.50}) {
-                const size_t n_candidates =
-                    std::max<size_t>(1, static_cast<size_t>(fraction * cfg.corpus));
+            const size_t documentCount = (cfg.corpus + 3) / 4;
+            const std::vector<size_t> candidateCounts = {2UL, 7UL, 16UL, 64UL, documentCount};
+            for (const size_t nCandidates : candidateCounts) {
+                const size_t candidateCount = std::min(nCandidates, documentCount);
                 std::unordered_set<std::string> candidates;
-                for (size_t i = 0; i < n_candidates; ++i) {
+                for (size_t i = 0; i < candidateCount; ++i) {
                     candidates.insert("doc_" + std::to_string(i));
                 }
 
-                std::vector<double> latencies;
-                latencies.reserve(queries.size());
-                for (const auto& q : queries) {
-                    const auto start = std::chrono::steady_clock::now();
-                    auto result = backend.searchSimilar(q, cfg.k, 0.0f, std::nullopt, candidates);
-                    const auto end = std::chrono::steady_clock::now();
-                    if (!result) {
-                        throw std::runtime_error(result.error().message);
-                    }
-                    latencies.push_back(
-                        std::chrono::duration<double, std::micro>(end - start).count());
+                VectorSearchDiagnostics warmupDiagnostics;
+                auto warmup = backend.searchSimilarWithDiagnostics(
+                    queries.front(), cfg.k, -1.0F, std::nullopt, candidates, {}, warmupDiagnostics);
+                if (!warmup) {
+                    throw std::runtime_error(warmup.error().message);
                 }
-                const double mean = std::accumulate(latencies.begin(), latencies.end(), 0.0) /
-                                    static_cast<double>(latencies.size());
-                std::printf("candidates=%5.0f%% (%6zu docs)  mean=%8.1f us  p95=%8.1f us\n",
-                            fraction * 100.0, n_candidates, mean, percentile(latencies, 0.95));
+
+                std::vector<double> annLatencies;
+                std::vector<double> exactLatencies;
+                annLatencies.reserve(queries.size());
+                exactLatencies.reserve(queries.size());
+                std::uint64_t lookupNs = 0;
+                std::uint64_t projectionNs = 0;
+                std::uint64_t lutNs = 0;
+                std::uint64_t adcNs = 0;
+                std::uint64_t selectionNs = 0;
+                std::uint64_t materializationNs = 0;
+                std::uint64_t rerankNs = 0;
+                size_t candidateIndexPayloadBytes = 0;
+                size_t recallHits = 0;
+                size_t recallDenominator = 0;
+                for (const auto& q : queries) {
+                    VectorSearchDiagnostics annDiagnostics;
+                    const auto annStart = std::chrono::steady_clock::now();
+                    auto ann = backend.searchSimilarWithDiagnostics(q, cfg.k, -1.0F, std::nullopt,
+                                                                    candidates, {}, annDiagnostics);
+                    const auto annEnd = std::chrono::steady_clock::now();
+                    if (!ann) {
+                        throw std::runtime_error(ann.error().message);
+                    }
+                    VectorSearchDiagnostics exactDiagnostics;
+                    const auto exactStart = std::chrono::steady_clock::now();
+                    auto exact = backend.searchExactCandidatesWithDiagnostics(
+                        q, cfg.k, -1.0F, candidates, exactDiagnostics);
+                    const auto exactEnd = std::chrono::steady_clock::now();
+                    if (!exact) {
+                        throw std::runtime_error(exact.error().message);
+                    }
+
+                    annLatencies.push_back(
+                        std::chrono::duration<double, std::micro>(annEnd - annStart).count());
+                    exactLatencies.push_back(
+                        std::chrono::duration<double, std::micro>(exactEnd - exactStart).count());
+                    lookupNs += annDiagnostics.candidateLookupNanoseconds;
+                    projectionNs += annDiagnostics.candidateProjectionNanoseconds;
+                    lutNs += annDiagnostics.pqLutNanoseconds;
+                    adcNs += annDiagnostics.adcScoringNanoseconds;
+                    selectionNs += annDiagnostics.topKSelectionNanoseconds;
+                    materializationNs += annDiagnostics.resultMaterializationNanoseconds;
+                    rerankNs += annDiagnostics.exactRerankNanoseconds;
+                    candidateIndexPayloadBytes = std::max(
+                        candidateIndexPayloadBytes, annDiagnostics.candidateIndexPayloadBytes);
+
+                    std::unordered_set<std::string> exactIds;
+                    for (const auto& record : exact.value()) {
+                        exactIds.insert(record.chunk_id);
+                    }
+                    recallDenominator += exactIds.size();
+                    for (const auto& record : ann.value()) {
+                        recallHits += exactIds.contains(record.chunk_id) ? 1 : 0;
+                    }
+                }
+                const double divisor = static_cast<double>(queries.size());
+                const double annMean =
+                    std::accumulate(annLatencies.begin(), annLatencies.end(), 0.0) / divisor;
+                const double exactMean =
+                    std::accumulate(exactLatencies.begin(), exactLatencies.end(), 0.0) / divisor;
+                const auto meanUs = [divisor](std::uint64_t nanoseconds) {
+                    return static_cast<double>(nanoseconds) / (1000.0 * divisor);
+                };
+                const double recall =
+                    recallDenominator == 0
+                        ? 1.0
+                        : static_cast<double>(recallHits) / static_cast<double>(recallDenominator);
+                std::printf(
+                    "allowed_docs=%2zu allowed_vectors<=%3zu ann_mean=%8.1f us ann_p95=%8.1f us "
+                    "exact_mean=%8.1f us recall=%5.1f%% phases_us{lookup=%.1f projection=%.1f "
+                    "lut=%.1f adc=%.1f select=%.1f materialize=%.1f rerank=%.1f} "
+                    "candidate_index_payload_kib=%.1f\n",
+                    candidateCount, candidateCount * 4, annMean, percentile(annLatencies, 0.95),
+                    exactMean, recall * 100.0, meanUs(lookupNs), meanUs(projectionNs),
+                    meanUs(lutNs), meanUs(adcNs), meanUs(selectionNs), meanUs(materializationNs),
+                    meanUs(rerankNs), static_cast<double>(candidateIndexPayloadBytes) / 1024.0);
             }
             return 0;
         }

--- a/tests/benchmarks/xplan/artifacts.py
+++ b/tests/benchmarks/xplan/artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import platform
@@ -43,6 +44,19 @@ def try_git_sha(repo_root: Path) -> str | None:
     except (OSError, subprocess.SubprocessError):
         return None
     return None
+
+
+def file_sha256(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
 
 
 def host_info() -> dict[str, Any]:

--- a/tests/benchmarks/xplan/plans/search_generalized_memory_topology_gate.json
+++ b/tests/benchmarks/xplan/plans/search_generalized_memory_topology_gate.json
@@ -18,8 +18,7 @@
       "YAMS_TOPOLOGY_MIN_EDGE_SCORE": "0.25",
       "YAMS_TOPOLOGY_MAX_COMPONENT_DOCS": "64",
       "YAMS_VECTOR_MAX_RESULTS": "32",
-      "YAMS_VECTOR_SEARCH_ENGINE": "vec0",
-      "YAMS_VECTOR_VEC0_PHSS_ENABLED": "1"
+      "YAMS_VECTOR_SEARCH_ENGINE": "simeon_pq_adc"
     },
     "params": {
       "datasets": ["scifact", "nfcorpus"],
@@ -45,8 +44,7 @@
         "vector_result_budget": 32
       },
       "env": {
-        "YAMS_BENCH_TOPOLOGY_MODE": "disabled",
-        "YAMS_VECTOR_VEC0_PHSS_CANDIDATES": "32"
+        "YAMS_BENCH_TOPOLOGY_MODE": "disabled"
       },
       "params": {
         "require_topology_construction_stability": false
@@ -57,6 +55,7 @@
       "factors": {
         "topology_mode": "hybrid_assist",
         "topology_vector_policy": "shadow",
+        "topology_route_ann_candidate_limit": 64,
         "ann_candidate_budget": 32,
         "vector_result_budget": 32,
         "adaptive_routing": true,
@@ -65,11 +64,39 @@
       },
       "env": {
         "YAMS_BENCH_TOPOLOGY_MODE": "hybrid_assist",
-        "YAMS_BENCH_TOPOLOGY_VECTOR_POLICY": "shadow",
-        "YAMS_VECTOR_VEC0_PHSS_CANDIDATES": "32"
+        "YAMS_BENCH_TOPOLOGY_VECTOR_POLICY": "shadow"
       },
       "params": {
         "topology_vector_policy": "shadow",
+        "topology_route_ann_candidate_limit": 64,
+        "min_clusters": 1,
+        "max_clusters": 4,
+        "max_docs": 16,
+        "max_seed_documents": 16,
+        "adaptive_probe_score_gap": 0.05,
+        "narrow_min_boundary_margin": 0.2,
+        "min_route_score": 0.15
+      }
+    },
+    {
+      "name": "shadow_exact_margin020_min1",
+      "factors": {
+        "topology_mode": "hybrid_assist",
+        "topology_vector_policy": "shadow",
+        "topology_route_ann_candidate_limit": 0,
+        "ann_candidate_budget": 32,
+        "vector_result_budget": 32,
+        "adaptive_routing": true,
+        "confidence_margin": 0.2,
+        "min_clusters": 1
+      },
+      "env": {
+        "YAMS_BENCH_TOPOLOGY_MODE": "hybrid_assist",
+        "YAMS_BENCH_TOPOLOGY_VECTOR_POLICY": "shadow"
+      },
+      "params": {
+        "topology_vector_policy": "shadow",
+        "topology_route_ann_candidate_limit": 0,
         "min_clusters": 1,
         "max_clusters": 4,
         "max_docs": 16,
@@ -97,11 +124,11 @@
         "YAMS_BENCH_TOPOLOGY_BOUNDARY_SPILL": "1",
         "YAMS_BENCH_TOPOLOGY_BOUNDARY_SPILL_LIMIT": "1",
         "YAMS_BENCH_TOPOLOGY_BOUNDARY_SPILL_DISTANCE_RATIO": "1.05",
-        "YAMS_BENCH_TOPOLOGY_BOUNDARY_SPILL_RESIDUAL_PENALTY": "1.0",
-        "YAMS_VECTOR_VEC0_PHSS_CANDIDATES": "32"
+        "YAMS_BENCH_TOPOLOGY_BOUNDARY_SPILL_RESIDUAL_PENALTY": "1.0"
       },
       "params": {
         "topology_vector_policy": "narrow",
+        "topology_route_ann_candidate_limit": 64,
         "topology_boundary_spill": "1",
         "topology_boundary_spill_limit": 1,
         "topology_boundary_spill_distance_ratio": 1.05,
@@ -159,6 +186,10 @@
         "topology_narrow_rate",
         "topology_confidence_abstain_rate",
         "topology_snapshot_cache_hit_rate",
+        "topology_route_ann_rate",
+        "topology_route_ann_candidates_avg",
+        "topology_route_ann_distance_evaluations_avg",
+        "topology_route_exact_representative_distance_evaluations_avg",
         "topology_route_representative_distance_evaluations_avg",
         "topology_allowed_candidates_avg",
         "topology_vector_filter_rate",
@@ -177,6 +208,15 @@
         "vector_candidate_work_budget_avg",
         "vector_distance_evaluation_budget_avg",
         "vector_ann_candidate_budget_actual_avg",
+        "vector_candidate_index_cache_rate",
+        "vector_candidate_index_payload_bytes_max",
+        "vector_candidate_lookup_ms_avg",
+        "vector_candidate_projection_ms_avg",
+        "vector_pq_lut_ms_avg",
+        "vector_adc_scoring_ms_avg",
+        "vector_topk_selection_ms_avg",
+        "vector_result_materialization_ms_avg",
+        "vector_exact_rerank_ms_avg",
         "vector_total_exact_distance_evaluations_actual_avg",
         "steady_state_query_rate",
         "candidate_pre_fusion_hit_rate",
@@ -275,6 +315,10 @@
       "topology_narrow_rate",
       "topology_confidence_abstain_rate",
       "topology_snapshot_cache_hit_rate",
+      "topology_route_ann_rate",
+      "topology_route_ann_candidates_avg",
+      "topology_route_ann_distance_evaluations_avg",
+      "topology_route_exact_representative_distance_evaluations_avg",
       "topology_route_representative_distance_evaluations_avg",
       "topology_allowed_candidates_avg",
       "topology_vector_filter_rate",
@@ -293,6 +337,15 @@
       "vector_candidate_work_budget_avg",
       "vector_distance_evaluation_budget_avg",
       "vector_ann_candidate_budget_actual_avg",
+      "vector_candidate_index_cache_rate",
+      "vector_candidate_index_payload_bytes_max",
+      "vector_candidate_lookup_ms_avg",
+      "vector_candidate_projection_ms_avg",
+      "vector_pq_lut_ms_avg",
+      "vector_adc_scoring_ms_avg",
+      "vector_topk_selection_ms_avg",
+      "vector_result_materialization_ms_avg",
+      "vector_exact_rerank_ms_avg",
       "vector_total_exact_distance_evaluations_actual_avg",
       "steady_state_query_rate",
       "candidate_pre_fusion_hit_rate",

--- a/tests/benchmarks/xplan/plans/topology_routing_budget_ablation.json
+++ b/tests/benchmarks/xplan/plans/topology_routing_budget_ablation.json
@@ -1,6 +1,6 @@
 {
   "name": "topology_routing_budget_ablation",
-  "description": "Compact recall-work gate for the adaptive connected-component router versus global Vec0 PHSS. The routed arm is the measured topology winner; disproven fixed-width, KMeans, and global-hedge arms are intentionally excluded.",
+  "description": "Compact recall-work gate for cached centroid ANN versus exhaustive topology routing and global Vec0 PHSS at the same routed document budget.",
   "build_dir": "build/release",
   "artifact_root": "build/benchmarks",
   "timeout_sec": 7200,
@@ -72,12 +72,13 @@
       }
     },
     {
-      "name": "routed_cc_adaptive_docs16",
+      "name": "routed_cc_adaptive_exact_docs16",
       "factors": {
         "topology_mode": "hybrid_assist",
         "topology_vector_policy": "narrow",
         "route_candidate_budget": 16,
-        "adaptive_routing": true
+        "adaptive_routing": true,
+        "route_centroid_index": "exact"
       },
       "env": {
         "YAMS_BENCH_TOPOLOGY_MODE": "hybrid_assist",
@@ -89,6 +90,32 @@
         "max_clusters": 4,
         "max_docs": 16,
         "max_seed_documents": 16,
+        "topology_route_ann_candidate_limit": 0,
+        "adaptive_probe_score_gap": 0.05,
+        "narrow_min_boundary_margin": 0.02,
+        "min_route_score": 0.15
+      }
+    },
+    {
+      "name": "routed_cc_adaptive_ann64_docs16",
+      "factors": {
+        "topology_mode": "hybrid_assist",
+        "topology_vector_policy": "narrow",
+        "route_candidate_budget": 64,
+        "adaptive_routing": true,
+        "route_centroid_index": "hnsw"
+      },
+      "env": {
+        "YAMS_BENCH_TOPOLOGY_MODE": "hybrid_assist",
+        "YAMS_BENCH_TOPOLOGY_VECTOR_POLICY": "narrow"
+      },
+      "params": {
+        "topology_vector_policy": "narrow",
+        "min_clusters": 1,
+        "max_clusters": 4,
+        "max_docs": 16,
+        "max_seed_documents": 16,
+        "topology_route_ann_candidate_limit": 64,
         "adaptive_probe_score_gap": 0.05,
         "narrow_min_boundary_margin": 0.02,
         "min_route_score": 0.15
@@ -110,6 +137,11 @@
         "topology_route_available_avg",
         "topology_route_boundary_score_margin_avg",
         "topology_snapshot_cache_hit_rate",
+        "topology_route_ann_rate",
+        "topology_route_ann_candidates_avg",
+        "topology_route_ann_distance_evaluations_avg",
+        "topology_route_exact_representative_distance_evaluations_avg",
+        "topology_route_representative_distance_evaluations_avg",
         "topology_allowed_candidates_avg",
         "topology_vector_filter_allowed_candidates_avg",
         "topology_vector_filter_latency_ms_avg",
@@ -121,6 +153,15 @@
         "vector_rows_visited_actual_avg",
         "vector_exact_distance_evaluations_actual_avg",
         "vector_ann_candidate_budget_actual_avg",
+        "vector_candidate_index_cache_rate",
+        "vector_candidate_index_payload_bytes_max",
+        "vector_candidate_lookup_ms_avg",
+        "vector_candidate_projection_ms_avg",
+        "vector_pq_lut_ms_avg",
+        "vector_adc_scoring_ms_avg",
+        "vector_topk_selection_ms_avg",
+        "vector_result_materialization_ms_avg",
+        "vector_exact_rerank_ms_avg",
         "vector_total_rows_visited_actual_avg",
         "vector_total_exact_distance_evaluations_actual_avg"
       ]
@@ -142,6 +183,11 @@
       "topology_route_available_avg",
       "topology_route_boundary_score_margin_avg",
       "topology_snapshot_cache_hit_rate",
+      "topology_route_ann_rate",
+      "topology_route_ann_candidates_avg",
+      "topology_route_ann_distance_evaluations_avg",
+      "topology_route_exact_representative_distance_evaluations_avg",
+      "topology_route_representative_distance_evaluations_avg",
       "topology_allowed_candidates_avg",
       "topology_vector_filter_allowed_candidates_avg",
       "topology_vector_filter_latency_ms_avg",
@@ -149,6 +195,15 @@
       "vector_candidate_work_budget_avg",
       "vector_distance_evaluation_budget_avg",
       "vector_ann_candidate_budget_actual_avg",
+      "vector_candidate_index_cache_rate",
+      "vector_candidate_index_payload_bytes_max",
+      "vector_candidate_lookup_ms_avg",
+      "vector_candidate_projection_ms_avg",
+      "vector_pq_lut_ms_avg",
+      "vector_adc_scoring_ms_avg",
+      "vector_topk_selection_ms_avg",
+      "vector_result_materialization_ms_avg",
+      "vector_exact_rerank_ms_avg",
       "vector_total_rows_visited_actual_avg",
       "vector_total_exact_distance_evaluations_actual_avg"
     ]

--- a/tests/benchmarks/xplan/runner.py
+++ b/tests/benchmarks/xplan/runner.py
@@ -28,6 +28,7 @@ if str(XPLAN_ROOT) not in sys.path:
 from artifacts import (  # noqa: E402
     arm_layout,
     ensure_dir,
+    file_sha256,
     host_info,
     try_git_sha,
     utc_stamp,
@@ -267,6 +268,16 @@ def _filter_arms(plan: ExperimentPlan, only: list[str]) -> None:
         raise SystemExit(f"no arms matched filters: {only}")
 
 
+def _require_binary_identity(binary: Path, expected_sha256: str | None) -> None:
+    actual_sha256 = file_sha256(binary)
+    if expected_sha256 is None or actual_sha256 != expected_sha256:
+        raise RuntimeError(
+            "benchmark binary identity changed during the run: "
+            f"expected={expected_sha256 or 'missing'} actual={actual_sha256 or 'missing'} "
+            f"path={binary}"
+        )
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     repo_root = repo_root_from()
     plan_path = resolve_plan_path(args.plan, repo_root)
@@ -296,23 +307,15 @@ def cmd_run(args: argparse.Namespace) -> int:
         run_dir / "plan.resolved.json",
         plan.resolved_dict(stamp=stamp, repo_root=repo_root, git_sha=git_sha),
     )
-    write_mode_manifest(
-        run_dir / "mode_manifest.json",
-        runner="xplan",
-        plan_name=plan.name,
-        mode=plan.mode,
-        build_dir=str(build_dir),
-        extra={"git_sha": git_sha, "host": host_info(), "dry_run": bool(args.dry_run)},
-    )
 
     print(f"ARTIFACT={run_dir}", flush=True)
     print(f"plan={plan.name} arms={len(plan.arms)} build_dir={build_dir}", flush=True)
 
     # One pre-run compile for quality plans when binary is missing (workers skip
     # rebuilds if the binary already exists to avoid mid-run link races).
+    quality_bin = build_dir / "tests" / "benchmarks" / "retrieval_quality_bench"
+    needs_quality = any(s.worker == "retrieval_quality" for s in plan.steps)
     if not args.dry_run:
-        quality_bin = build_dir / "tests" / "benchmarks" / "retrieval_quality_bench"
-        needs_quality = any(s.worker == "retrieval_quality" for s in plan.steps)
         if needs_quality and not quality_bin.is_file():
             from workers.util import maybe_meson_compile
 
@@ -324,6 +327,20 @@ def cmd_run(args: argparse.Namespace) -> int:
                 binary=quality_bin,
                 force=True,
             )
+    quality_binary_sha256 = file_sha256(quality_bin) if needs_quality else None
+    write_mode_manifest(
+        run_dir / "mode_manifest.json",
+        runner="xplan",
+        plan_name=plan.name,
+        mode=plan.mode,
+        build_dir=str(build_dir),
+        extra={
+            "git_sha": git_sha,
+            "host": host_info(),
+            "dry_run": bool(args.dry_run),
+            "retrieval_quality_binary_sha256": quality_binary_sha256,
+        },
+    )
 
     arm_results: list[dict[str, Any]] = []
     any_hard_fail = False
@@ -337,7 +354,11 @@ def cmd_run(args: argparse.Namespace) -> int:
             mode=plan.mode,
             build_dir=str(build_dir),
             arm_name=arm.name,
-            extra={"factors": arm.factors, "dry_run": bool(args.dry_run)},
+            extra={
+                "factors": arm.factors,
+                "dry_run": bool(args.dry_run),
+                "retrieval_quality_binary_sha256": quality_binary_sha256,
+            },
         )
         write_json(
             arm_dir / "arm.json",
@@ -370,6 +391,8 @@ def cmd_run(args: argparse.Namespace) -> int:
         messages: list[str] = []
 
         try:
+            if needs_quality and not args.dry_run:
+                _require_binary_identity(quality_bin, quality_binary_sha256)
             repeats = max(1, plan.repeats)
             rep_metrics: list[dict[str, Any]] = []
             for rep in range(repeats):
@@ -424,6 +447,9 @@ def cmd_run(args: argparse.Namespace) -> int:
                         {"status": overall_status, "arm": arm.name, "rep": rep,
                          "metrics": rep_combined},
                     )
+
+            if needs_quality and not args.dry_run:
+                _require_binary_identity(quality_bin, quality_binary_sha256)
 
             combined_metrics = aggregate_reps(rep_metrics)
             combined_attrs["repeats"] = repeats

--- a/tests/benchmarks/xplan/test_xplan_contracts.py
+++ b/tests/benchmarks/xplan/test_xplan_contracts.py
@@ -7,6 +7,7 @@ import hashlib
 import io
 import json
 import signal
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -56,6 +57,31 @@ from workers.retrieval_quality import (  # noqa: E402
 
 
 class RetrievalQualityEnvironmentTests(unittest.TestCase):
+    def test_retrieval_quality_imports_without_posix_resource_module(self) -> None:
+        script = f"""
+import builtins
+import sys
+
+real_import = builtins.__import__
+
+def import_without_resource(name, *args, **kwargs):
+    if name == "resource":
+        raise ModuleNotFoundError("No module named 'resource'")
+    return real_import(name, *args, **kwargs)
+
+builtins.__import__ = import_without_resource
+sys.path.insert(0, {str(XPLAN_ROOT)!r})
+import workers.retrieval_quality
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
     def test_binary_identity_hashes_executable_contents(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             binary = Path(tmp) / "bench"

--- a/tests/benchmarks/xplan/test_xplan_contracts.py
+++ b/tests/benchmarks/xplan/test_xplan_contracts.py
@@ -27,6 +27,7 @@ from analyze_query_class import (  # noqa: E402
 from model import ExperimentPlan  # noqa: E402
 from report import _baseline_row  # noqa: E402
 import runner as xplan_runner  # noqa: E402
+from artifacts import file_sha256  # noqa: E402
 from workers.multi_client import _clone_corpus_seed, _metrics_from_record  # noqa: E402
 from workers.mixed_corpus import (  # noqa: E402
     analyze_mixed_cluster_overlap,
@@ -41,6 +42,7 @@ from workers.ingestion_e2e import (  # noqa: E402
 )
 from workers.retrieval_quality import (  # noqa: E402
     _benchmark_command,
+    _disable_semantic_neighbor_backfill,
     _mark_shared_topology_seed_reuse,
     _merge_benchmark_env,
     _reset_measured_outputs,
@@ -54,6 +56,25 @@ from workers.retrieval_quality import (  # noqa: E402
 
 
 class RetrievalQualityEnvironmentTests(unittest.TestCase):
+    def test_binary_identity_hashes_executable_contents(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "bench"
+            binary.write_bytes(b"retrieval-binary")
+            self.assertEqual(
+                file_sha256(binary), hashlib.sha256(b"retrieval-binary").hexdigest()
+            )
+
+    def test_binary_identity_rejects_mid_run_relink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "bench"
+            binary.write_bytes(b"first-binary")
+            expected = file_sha256(binary)
+            xplan_runner._require_binary_identity(binary, expected)
+
+            binary.write_bytes(b"second-binary")
+            with self.assertRaisesRegex(RuntimeError, "identity changed"):
+                xplan_runner._require_binary_identity(binary, expected)
+
     def test_report_replays_resolved_plan_instead_of_mutated_source(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -174,6 +195,13 @@ src/metadata/metadata_repository.cpp:1251: cachedExtractedCount_ <= cachedDocume
         env: dict[str, str] = {}
         _mark_shared_topology_seed_reuse(env)
         self.assertEqual(env["YAMS_BENCH_REUSE_SEEDED_TOPOLOGY_INPUTS"], "1")
+        self.assertEqual(env["YAMS_ENABLE_SEMANTIC_NEIGHBOR_BACKFILL"], "0")
+
+    def test_shared_seed_disables_background_topology_input_mutation(self) -> None:
+        env: dict[str, str] = {}
+        _disable_semantic_neighbor_backfill(env)
+        self.assertEqual(env["YAMS_ENABLE_SEMANTIC_NEIGHBOR_BACKFILL"], "0")
+        self.assertNotIn("YAMS_BENCH_REUSE_SEEDED_TOPOLOGY_INPUTS", env)
 
     def test_resolved_plan_preserves_repeat_and_baseline_identity(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -341,6 +369,10 @@ src/metadata/metadata_repository.cpp:1251: cachedExtractedCount_ <= cachedDocume
         self.assertTrue(
             plan["fixed"]["params"]["require_topology_construction_stability"]
         )
+        self.assertEqual(
+            plan["fixed"]["env"]["YAMS_VECTOR_SEARCH_ENGINE"], "simeon_pq_adc"
+        )
+        self.assertNotIn("YAMS_VECTOR_VEC0_PHSS_ENABLED", plan["fixed"]["env"])
         self.assertNotIn(
             "require_topology_construction_identity", plan["fixed"]["params"]
         )
@@ -350,8 +382,21 @@ src/metadata/metadata_repository.cpp:1251: cachedExtractedCount_ <= cachedDocume
             {
                 "global_ann_c32",
                 "shadow_margin020_min1",
+                "shadow_exact_margin020_min1",
                 "narrow_soar_lambda1_ratio105",
             },
+        )
+        self.assertEqual(
+            arms["shadow_margin020_min1"]["params"][
+                "topology_route_ann_candidate_limit"
+            ],
+            64,
+        )
+        self.assertEqual(
+            arms["shadow_exact_margin020_min1"]["params"][
+                "topology_route_ann_candidate_limit"
+            ],
+            0,
         )
         soar = arms["narrow_soar_lambda1_ratio105"]
         self.assertEqual(soar["params"]["topology_vector_policy"], "narrow")
@@ -523,6 +568,10 @@ src/metadata/metadata_repository.cpp:1251: cachedExtractedCount_ <= cachedDocume
                     "topology_weak_query_narrow_applied": "1",
                     "topology_route_available_count": "3",
                     "topology_route_boundary_score_margin": "0.25",
+                    "topology_route_ann_used": "1",
+                    "topology_route_ann_candidates": "6",
+                    "topology_route_ann_distance_evaluations": "4",
+                    "topology_route_exact_representative_distance_evaluations": "3",
                     "topology_route_confidence_abstained": "0",
                     "topology_snapshot_cache_hit": "0",
                     "topology_weak_query_allowed_candidates": "8",
@@ -532,12 +581,22 @@ src/metadata/metadata_repository.cpp:1251: cachedExtractedCount_ <= cachedDocume
                     "vector_search_rows_visited_actual": "16",
                     "vector_search_exact_distance_evaluations_actual": "8",
                     "vector_search_ann_candidate_budget_actual": "16",
+                    "vector_search_candidate_index_cache_used": "1",
+                    "vector_search_candidate_index_payload_bytes": "4096",
+                    "vector_search_candidate_lookup_ns": "2000000",
+                    "vector_search_candidate_projection_ns": "400000",
+                    "vector_search_pq_lut_ns": "600000",
+                    "vector_search_adc_scoring_ns": "800000",
+                    "vector_search_topk_selection_ns": "1000000",
+                    "vector_search_result_materialization_ns": "1200000",
+                    "vector_search_exact_rerank_ns": "1400000",
                     "topology_vector_filter_applied": "1",
                     "topology_vector_filter_fallback": "0",
                     "topology_vector_filter_matched": "6",
                     "topology_vector_filter_removed": "10",
                     "topology_vector_allowed_set_ann_applied": "1",
                     "topology_vector_allowed_set_ann_fallback": "0",
+                    "topology_vector_global_fill_count": "2",
                     "topology_vector_policy": "narrow",
                     "latency_ms": "30",
                     "topology_structure_candidate_count": "6",
@@ -556,6 +615,10 @@ src/metadata/metadata_repository.cpp:1251: cachedExtractedCount_ <= cachedDocume
                     "topology_weak_query_narrow_applied": "0",
                     "topology_route_available_count": "1",
                     "topology_route_boundary_score_margin": "0.05",
+                    "topology_route_ann_used": "0",
+                    "topology_route_ann_candidates": "0",
+                    "topology_route_ann_distance_evaluations": "0",
+                    "topology_route_exact_representative_distance_evaluations": "8",
                     "topology_route_confidence_abstained": "1",
                     "topology_snapshot_cache_hit": "1",
                     "topology_weak_query_allowed_candidates": "4",
@@ -565,12 +628,22 @@ src/metadata/metadata_repository.cpp:1251: cachedExtractedCount_ <= cachedDocume
                     "vector_search_rows_visited_actual": "8",
                     "vector_search_exact_distance_evaluations_actual": "4",
                     "vector_search_ann_candidate_budget_actual": "8",
+                    "vector_search_candidate_index_cache_used": "0",
+                    "vector_search_candidate_index_payload_bytes": "0",
+                    "vector_search_candidate_lookup_ns": "0",
+                    "vector_search_candidate_projection_ns": "0",
+                    "vector_search_pq_lut_ns": "0",
+                    "vector_search_adc_scoring_ns": "0",
+                    "vector_search_topk_selection_ns": "0",
+                    "vector_search_result_materialization_ns": "0",
+                    "vector_search_exact_rerank_ns": "0",
                     "topology_vector_filter_applied": "0",
                     "topology_vector_filter_fallback": "1",
                     "topology_vector_filter_matched": "0",
                     "topology_vector_filter_removed": "0",
                     "topology_vector_allowed_set_ann_applied": "0",
                     "topology_vector_allowed_set_ann_fallback": "1",
+                    "topology_vector_global_fill_count": "0",
                     "topology_vector_policy": "narrow",
                     "latency_ms": "10",
                     "topology_structure_candidate_count": "2",
@@ -597,6 +670,12 @@ src/metadata/metadata_repository.cpp:1251: cachedExtractedCount_ <= cachedDocume
         self.assertAlmostEqual(
             metrics["topology_route_boundary_score_margin_avg"], 0.15
         )
+        self.assertEqual(metrics["topology_route_ann_rate"], 0.5)
+        self.assertEqual(metrics["topology_route_ann_candidates_avg"], 3.0)
+        self.assertEqual(metrics["topology_route_ann_distance_evaluations_avg"], 2.0)
+        self.assertEqual(
+            metrics["topology_route_exact_representative_distance_evaluations_avg"], 5.5
+        )
         self.assertEqual(metrics["topology_snapshot_cache_hit_rate"], 0.5)
         self.assertEqual(metrics["topology_allowed_candidates_avg"], 6.0)
         self.assertEqual(metrics["topology_vector_filter_allowed_candidates_avg"], 8.0)
@@ -608,6 +687,15 @@ src/metadata/metadata_repository.cpp:1251: cachedExtractedCount_ <= cachedDocume
         self.assertEqual(metrics["vector_rows_visited_actual_avg"], 12.0)
         self.assertEqual(metrics["vector_exact_distance_evaluations_actual_avg"], 6.0)
         self.assertEqual(metrics["vector_ann_candidate_budget_actual_avg"], 12.0)
+        self.assertEqual(metrics["vector_candidate_index_cache_rate"], 0.5)
+        self.assertEqual(metrics["vector_candidate_index_payload_bytes_max"], 4096.0)
+        self.assertEqual(metrics["vector_candidate_lookup_ms_avg"], 1.0)
+        self.assertEqual(metrics["vector_candidate_projection_ms_avg"], 0.2)
+        self.assertEqual(metrics["vector_pq_lut_ms_avg"], 0.3)
+        self.assertEqual(metrics["vector_adc_scoring_ms_avg"], 0.4)
+        self.assertEqual(metrics["vector_topk_selection_ms_avg"], 0.5)
+        self.assertEqual(metrics["vector_result_materialization_ms_avg"], 0.6)
+        self.assertEqual(metrics["vector_exact_rerank_ms_avg"], 0.7)
         self.assertEqual(metrics["vector_candidate_work_budget_avg"], 10.0)
         self.assertEqual(metrics["vector_total_rows_visited_actual_avg"], 12.0)
         self.assertEqual(metrics["vector_total_exact_distance_evaluations_actual_avg"], 6.0)
@@ -617,6 +705,8 @@ src/metadata/metadata_repository.cpp:1251: cachedExtractedCount_ <= cachedDocume
         self.assertEqual(metrics["topology_vector_filter_removed_avg"], 5.0)
         self.assertEqual(metrics["topology_vector_allowed_set_ann_rate"], 0.5)
         self.assertEqual(metrics["topology_vector_allowed_set_ann_fallback_rate"], 0.5)
+        self.assertEqual(metrics["topology_vector_global_fill_count_sum"], 2.0)
+        self.assertEqual(metrics["topology_vector_global_fill_count_avg"], 1.0)
         self.assertEqual(metrics["topology_structure_candidate_count_avg"], 4.0)
         self.assertAlmostEqual(metrics["topology_structure_scale_agreement_avg"], 0.6)
         self.assertAlmostEqual(metrics["topology_structure_overlap_support_avg"], 0.4)

--- a/tests/benchmarks/xplan/workers/retrieval_quality.py
+++ b/tests/benchmarks/xplan/workers/retrieval_quality.py
@@ -118,9 +118,15 @@ def describe_process_failure(returncode: int, output: str) -> str | None:
     return f"{summary}; last output:\n{tail}"
 
 
+def _disable_semantic_neighbor_backfill(env: dict[str, str]) -> None:
+    """Prevent the daemon from mutating benchmark topology inputs in the background."""
+    env["YAMS_ENABLE_SEMANTIC_NEIGHBOR_BACKFILL"] = "0"
+
+
 def _mark_shared_topology_seed_reuse(env: dict[str, str]) -> None:
     """Keep cloned topology inputs immutable while allowing per-arm reconstruction."""
     env["YAMS_BENCH_REUSE_SEEDED_TOPOLOGY_INPUTS"] = "1"
+    _disable_semantic_neighbor_backfill(env)
 
 
 def _truthy(val: Any) -> bool:
@@ -257,12 +263,17 @@ def parse_debug_jsonl(path: Path, *, top_k: int = 10) -> dict[str, Any]:
         "topology_vector_filter_removed": 0,
         "topology_vector_allowed_set_ann_applied_queries": 0,
         "topology_vector_allowed_set_ann_fallback_queries": 0,
+        "topology_vector_global_fill_count": 0,
         "topology_shadow_evaluated_queries": 0,
         "topology_shadow_narrow_proposed_queries": 0,
         "topology_shadow_retained_candidates": 0,
         "topology_shadow_removed_candidates": 0,
         "route_representative_distance_evaluations": 0,
         "route_representative_count_max": 0,
+        "route_ann_used_queries": 0,
+        "route_ann_candidates": 0,
+        "route_ann_distance_evaluations": 0,
+        "route_exact_representative_distance_evaluations": 0,
     }
     added_vals: list[int] = []
     routed_docs: list[int] = []
@@ -271,6 +282,9 @@ def parse_debug_jsonl(path: Path, *, top_k: int = 10) -> dict[str, Any]:
     route_boundary_score_margin_vals: list[float] = []
     route_representative_distance_evaluation_vals: list[int] = []
     route_representative_count_max_vals: list[int] = []
+    route_ann_candidate_vals: list[int] = []
+    route_ann_distance_evaluation_vals: list[int] = []
+    route_exact_representative_distance_evaluation_vals: list[int] = []
     structure_evidence_vals: dict[str, list[float]] = {
         "candidate_count": [],
         "scale_agreement": [],
@@ -287,11 +301,23 @@ def parse_debug_jsonl(path: Path, *, top_k: int = 10) -> dict[str, Any]:
     vector_rows_visited_actual_vals: list[int] = []
     vector_exact_distance_evaluations_actual_vals: list[int] = []
     vector_ann_candidate_budget_actual_vals: list[int] = []
+    vector_candidate_index_cache_queries = 0
+    vector_candidate_index_payload_bytes_vals: list[int] = []
+    vector_phase_ns_vals: dict[str, list[int]] = {
+        "candidate_lookup": [],
+        "candidate_projection": [],
+        "pq_lut": [],
+        "adc_scoring": [],
+        "topk_selection": [],
+        "result_materialization": [],
+        "exact_rerank": [],
+    }
     topology_vector_filter_matched_vals: list[int] = []
     topology_vector_filter_removed_vals: list[int] = []
     topology_vector_filter_allowed_candidate_vals: list[int] = []
     topology_vector_filter_latency_vals: list[float] = []
     topology_vector_abstain_latency_vals: list[float] = []
+    topology_vector_global_fill_count_vals: list[int] = []
     skip_reasons: dict[str, int] = {}
     scoring_modes: dict[str, int] = {}
     routing_modes: dict[str, int] = {}
@@ -351,12 +377,18 @@ def parse_debug_jsonl(path: Path, *, top_k: int = 10) -> dict[str, Any]:
         "vector_ann_candidate_budget_actual": "vector_search_ann_candidate_budget_actual",
         "topology_vector_filter_matched": "topology_vector_filter_matched",
         "topology_vector_filter_removed": "topology_vector_filter_removed",
+        "topology_vector_global_fill_count": "topology_vector_global_fill_count",
         "topology_shadow_retained_candidates": "topology_shadow_retained_candidates",
         "topology_shadow_removed_candidates": "topology_shadow_removed_candidates",
         "route_representative_distance_evaluations": (
             "topology_route_representative_distance_evaluations"
         ),
         "route_representative_count_max": "topology_route_representative_count_max",
+        "route_ann_candidates": "topology_route_ann_candidates",
+        "route_ann_distance_evaluations": "topology_route_ann_distance_evaluations",
+        "route_exact_representative_distance_evaluations": (
+            "topology_route_exact_representative_distance_evaluations"
+        ),
     }
 
     for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
@@ -535,6 +567,17 @@ def parse_debug_jsonl(path: Path, *, top_k: int = 10) -> dict[str, Any]:
             counters["topology_vector_allowed_set_ann_applied_queries"] += 1
         if _truthy(stats.get("topology_vector_allowed_set_ann_fallback")):
             counters["topology_vector_allowed_set_ann_fallback_queries"] += 1
+        if _truthy(stats.get("topology_route_ann_used")):
+            counters["route_ann_used_queries"] += 1
+        if _truthy(stats.get("vector_search_candidate_index_cache_used")):
+            vector_candidate_index_cache_queries += 1
+        vector_candidate_index_payload_bytes_vals.append(
+            _as_int(stats.get("vector_search_candidate_index_payload_bytes"))
+        )
+        for phase_name in vector_phase_ns_vals:
+            vector_phase_ns_vals[phase_name].append(
+                _as_int(stats.get(f"vector_search_{phase_name}_ns"))
+            )
         if _truthy(stats.get("topology_shadow_evaluated")):
             counters["topology_shadow_evaluated_queries"] += 1
             if stats.get("topology_shadow_proposed_action") == "narrow":
@@ -568,10 +611,18 @@ def parse_debug_jsonl(path: Path, *, top_k: int = 10) -> dict[str, Any]:
                 topology_vector_filter_matched_vals.append(v)
             elif dst == "topology_vector_filter_removed":
                 topology_vector_filter_removed_vals.append(v)
+            elif dst == "topology_vector_global_fill_count":
+                topology_vector_global_fill_count_vals.append(v)
             elif dst == "route_representative_distance_evaluations":
                 route_representative_distance_evaluation_vals.append(v)
             elif dst == "route_representative_count_max":
                 route_representative_count_max_vals.append(v)
+            elif dst == "route_ann_candidates":
+                route_ann_candidate_vals.append(v)
+            elif dst == "route_ann_distance_evaluations":
+                route_ann_distance_evaluation_vals.append(v)
+            elif dst == "route_exact_representative_distance_evaluations":
+                route_exact_representative_distance_evaluation_vals.append(v)
 
         try:
             margin = stats.get("topology_route_boundary_score_margin")
@@ -650,6 +701,9 @@ def parse_debug_jsonl(path: Path, *, top_k: int = 10) -> dict[str, Any]:
         "topology_vector_filter_removed_sum": float(
             counters["topology_vector_filter_removed"]
         ),
+        "topology_vector_global_fill_count_sum": float(
+            counters["topology_vector_global_fill_count"]
+        ),
         "topology_shadow_retained_candidates_sum": float(
             counters["topology_shadow_retained_candidates"]
         ),
@@ -675,6 +729,13 @@ def parse_debug_jsonl(path: Path, *, top_k: int = 10) -> dict[str, Any]:
         ),
         "topology_route_representative_distance_evaluations_sum": float(
             counters["route_representative_distance_evaluations"]
+        ),
+        "topology_route_ann_candidates_sum": float(counters["route_ann_candidates"]),
+        "topology_route_ann_distance_evaluations_sum": float(
+            counters["route_ann_distance_evaluations"]
+        ),
+        "topology_route_exact_representative_distance_evaluations_sum": float(
+            counters["route_exact_representative_distance_evaluations"]
         ),
     }
     for mkey, mval in (hybrid_summary_metrics or {}).items():
@@ -751,6 +812,19 @@ def parse_debug_jsonl(path: Path, *, top_k: int = 10) -> dict[str, Any]:
         metrics["vector_ann_candidate_budget_actual_avg"] = float(
             statistics.mean(vector_ann_candidate_budget_actual_vals)
         )
+    if hybrid:
+        metrics["vector_candidate_index_cache_rate"] = float(
+            vector_candidate_index_cache_queries
+        ) / float(hybrid)
+    if vector_candidate_index_payload_bytes_vals:
+        metrics["vector_candidate_index_payload_bytes_max"] = float(
+            max(vector_candidate_index_payload_bytes_vals)
+        )
+    for phase_name, values in vector_phase_ns_vals.items():
+        if values:
+            metrics[f"vector_{phase_name}_ms_avg"] = float(
+                statistics.mean(values)
+            ) / 1_000_000.0
     if topology_vector_filter_matched_vals:
         metrics["topology_vector_filter_matched_avg"] = float(
             statistics.mean(topology_vector_filter_matched_vals)
@@ -759,6 +833,11 @@ def parse_debug_jsonl(path: Path, *, top_k: int = 10) -> dict[str, Any]:
         metrics["topology_vector_filter_removed_avg"] = float(
             statistics.mean(topology_vector_filter_removed_vals)
         )
+    metrics["topology_vector_global_fill_count_avg"] = (
+        float(statistics.mean(topology_vector_global_fill_count_vals))
+        if topology_vector_global_fill_count_vals
+        else 0.0
+    )
     metrics["topology_vector_filter_allowed_candidates_avg"] = (
         float(statistics.mean(topology_vector_filter_allowed_candidate_vals))
         if topology_vector_filter_allowed_candidate_vals
@@ -790,6 +869,19 @@ def parse_debug_jsonl(path: Path, *, top_k: int = 10) -> dict[str, Any]:
         metrics["topology_route_representative_count_max"] = float(
             max(route_representative_count_max_vals)
         )
+    metrics["topology_route_ann_candidates_avg"] = (
+        float(statistics.mean(route_ann_candidate_vals)) if route_ann_candidate_vals else 0.0
+    )
+    metrics["topology_route_ann_distance_evaluations_avg"] = (
+        float(statistics.mean(route_ann_distance_evaluation_vals))
+        if route_ann_distance_evaluation_vals
+        else 0.0
+    )
+    metrics["topology_route_exact_representative_distance_evaluations_avg"] = (
+        float(statistics.mean(route_exact_representative_distance_evaluation_vals))
+        if route_exact_representative_distance_evaluation_vals
+        else 0.0
+    )
     for evidence_name, values in structure_evidence_vals.items():
         metrics[f"topology_structure_{evidence_name}_avg"] = (
             float(statistics.mean(values)) if values else 0.0
@@ -821,6 +913,9 @@ def parse_debug_jsonl(path: Path, *, top_k: int = 10) -> dict[str, Any]:
         ) / float(hybrid)
         metrics["topology_vector_allowed_set_ann_fallback_rate"] = float(
             counters["topology_vector_allowed_set_ann_fallback_queries"]
+        ) / float(hybrid)
+        metrics["topology_route_ann_rate"] = float(
+            counters["route_ann_used_queries"]
         ) / float(hybrid)
         metrics["topology_shadow_evaluation_rate"] = float(
             counters["topology_shadow_evaluated_queries"]
@@ -1168,6 +1263,10 @@ def run_retrieval_quality(ctx: WorkerContext) -> WorkerResult:
                 "topology_route_boundary_score_margin_avg": 0.0,
                 "topology_route_representative_distance_evaluations_avg": 0.0,
                 "topology_route_representative_count_max": 0.0,
+                "topology_route_ann_rate": 0.0,
+                "topology_route_ann_candidates_avg": 0.0,
+                "topology_route_ann_distance_evaluations_avg": 0.0,
+                "topology_route_exact_representative_distance_evaluations_avg": 0.0,
                 "topology_construction_fingerprint_count": 0.0,
                 "topology_structure_candidate_count_avg": 0.0,
                 "topology_structure_scale_agreement_avg": 0.0,
@@ -1185,12 +1284,22 @@ def run_retrieval_quality(ctx: WorkerContext) -> WorkerResult:
                 "vector_rows_visited_actual_avg": 0.0,
                 "vector_exact_distance_evaluations_actual_avg": 0.0,
                 "vector_ann_candidate_budget_actual_avg": 0.0,
+                "vector_candidate_index_cache_rate": 0.0,
+                "vector_candidate_index_payload_bytes_max": 0.0,
+                "vector_candidate_lookup_ms_avg": 0.0,
+                "vector_candidate_projection_ms_avg": 0.0,
+                "vector_pq_lut_ms_avg": 0.0,
+                "vector_adc_scoring_ms_avg": 0.0,
+                "vector_topk_selection_ms_avg": 0.0,
+                "vector_result_materialization_ms_avg": 0.0,
+                "vector_exact_rerank_ms_avg": 0.0,
                 "vector_total_rows_visited_actual_avg": 0.0,
                 "vector_total_exact_distance_evaluations_actual_avg": 0.0,
                 "topology_vector_filter_rate": 0.0,
                 "topology_vector_filter_fallback_rate": 0.0,
                 "topology_vector_filter_matched_avg": 0.0,
                 "topology_vector_filter_removed_avg": 0.0,
+                "topology_vector_global_fill_count_avg": 0.0,
                 "topology_vector_filter_allowed_candidates_avg": 0.0,
                 "topology_vector_filter_latency_ms_avg": 0.0,
                 "topology_vector_abstain_latency_ms_avg": 0.0,
@@ -1325,6 +1434,9 @@ def run_retrieval_quality(ctx: WorkerContext) -> WorkerResult:
         ),
         "topology_route_representative_limit": (
             "YAMS_BENCH_TOPOLOGY_ROUTE_REPRESENTATIVE_LIMIT"
+        ),
+        "topology_route_ann_candidate_limit": (
+            "YAMS_BENCH_TOPOLOGY_ROUTE_ANN_CANDIDATE_LIMIT"
         ),
         "topology_source": "YAMS_BENCH_TOPOLOGY_SOURCE",
         "route_scoring": "YAMS_BENCH_TOPOLOGY_ROUTE_SCORING",
@@ -1513,6 +1625,8 @@ def run_retrieval_quality(ctx: WorkerContext) -> WorkerResult:
         if not ready_marker.is_file():
             shared_state_root.mkdir(parents=True, exist_ok=True)
             prime_env = dict(env)
+            if source == "vector":
+                _disable_semantic_neighbor_backfill(prime_env)
             prime_env["YAMS_BENCH_WARM_CACHE_DIR"] = str(seed_dir)
             prime_env["YAMS_BENCH_DEBUG_FILE"] = str(shared_state_root / "prime_debug.jsonl")
             prime_env["YAMS_BENCH_TOPOLOGY_CLUSTER_OUTPUT"] = str(

--- a/tests/benchmarks/xplan/workers/retrieval_quality.py
+++ b/tests/benchmarks/xplan/workers/retrieval_quality.py
@@ -11,7 +11,6 @@ import json
 import math
 import os
 import re
-import resource
 import shutil
 import signal
 import statistics
@@ -36,6 +35,11 @@ from workers.mixed_corpus import (
     materialize_mixed_beir_manifest,
 )
 from workers.util import maybe_meson_compile, resolve_binary, run_captured
+
+try:
+    import resource as _resource
+except ModuleNotFoundError:  # Windows has no POSIX resource module.
+    _resource = None
 
 _METRIC_RE = re.compile(
     r"^\s*(MRR \(Mean Reciprocal Rank\)|Recall@K|Precision@K|"
@@ -73,6 +77,18 @@ EXPANSION_PRESETS: dict[str, dict[str, str]] = {
 _NON_VECTOR_SOURCES = frozenset(
     {"fts5", "keyphrase", "segment_keyphrase", "kg", "gliner", "header", "theme"}
 )
+
+
+def _child_resource_usage() -> tuple[float, float] | None:
+    """Return cumulative child CPU seconds and max RSS MiB when supported."""
+    if _resource is None:
+        return None
+    usage = _resource.getrusage(_resource.RUSAGE_CHILDREN)
+    rss_scale = 1.0 / (1024 * 1024) if sys.platform == "darwin" else 1.0 / 1024
+    return (
+        float(usage.ru_utime + usage.ru_stime),
+        float(usage.ru_maxrss) * rss_scale,
+    )
 
 
 def _benchmark_command(binary: Path, benchmark_filter: str) -> list[str]:
@@ -1680,7 +1696,7 @@ def run_retrieval_quality(ctx: WorkerContext) -> WorkerResult:
         env["YAMS_BENCH_WARM_CACHE_DIR"] = str(isolated_data_dir)
         if source == "vector":
             _mark_shared_topology_seed_reuse(env)
-    ru_before = resource.getrusage(resource.RUSAGE_CHILDREN)
+    resource_before = _child_resource_usage()
     wall_start = time.monotonic()
     try:
         proc = run_captured(
@@ -1699,14 +1715,7 @@ def run_retrieval_quality(ctx: WorkerContext) -> WorkerResult:
             message=f"retrieval_quality timed out: {exc}",
         )
     wall_sec = time.monotonic() - wall_start
-    ru_after = resource.getrusage(resource.RUSAGE_CHILDREN)
-    # CPU time (utime+stime) is additive across children → reliable per-arm delta.
-    proc_cpu_sec = (ru_after.ru_utime + ru_after.ru_stime) - (
-        ru_before.ru_utime + ru_before.ru_stime
-    )
-    # ru_maxrss is a high-water mark (bytes on macOS, KiB on Linux); whole-process, coarse.
-    rss_scale = 1.0 / (1024 * 1024) if sys.platform == "darwin" else 1.0 / 1024
-    proc_maxrss_mb = float(ru_after.ru_maxrss) * rss_scale
+    resource_after = _child_resource_usage()
 
     (ctx.arm_dir / "exit_code").write_text(
         str(proc.returncode) + "\n", encoding="utf-8"
@@ -1765,9 +1774,12 @@ def run_retrieval_quality(ctx: WorkerContext) -> WorkerResult:
         )
         metrics.update(cluster_report.get("metrics") or {})
         write_json(ctx.arm_dir / "mixed_cluster_overlap.json", cluster_report)
-    metrics["proc_cpu_sec"] = float(proc_cpu_sec)
     metrics["proc_wall_sec"] = float(wall_sec)
-    metrics["proc_maxrss_mb"] = float(proc_maxrss_mb)
+    if resource_before is not None and resource_after is not None:
+        # CPU time is additive across children, so the delta is reliable per arm. Max RSS is
+        # a whole-process high-water mark and remains a deliberately coarse observation.
+        metrics["proc_cpu_sec"] = resource_after[0] - resource_before[0]
+        metrics["proc_maxrss_mb"] = resource_after[1]
 
     seed_enabled = _truthy(env.get("YAMS_BENCH_SEED_SEMANTIC_NEIGHBORS", "0"))
     require_steady = _truthy(

--- a/tests/integration/daemon/client_timeout_recovery_test.cpp
+++ b/tests/integration/daemon/client_timeout_recovery_test.cpp
@@ -429,10 +429,7 @@ TEST_CASE("Client timeout recovery: Error message quality",
     auto client = createClient(harness.socketPath());
 
     SECTION("Provides descriptive errors when daemon unavailable") {
-        ListRequest req1;
-        req1.limit = 10;
-        auto result1 = yams::cli::run_sync(client.list(req1), 2s);
-        REQUIRE(result1.has_value());
+        REQUIRE(listWithRetry(client));
 
         std::this_thread::sleep_for(500ms);
 

--- a/tests/integration/smoke/cli_subprocess_segfault_regression_smoke_catch2_test.cpp
+++ b/tests/integration/smoke/cli_subprocess_segfault_regression_smoke_catch2_test.cpp
@@ -615,7 +615,7 @@ TEST_CASE("CliSubprocessSegfaultRegressionSmoke.ShortLivedCommandsExitCleanly",
     REQUIRE(warmListOk);
 
     SubprocessResult addResult;
-    const bool addOk = waitForCommandSuccess(*yamsBinary, {"add", docPath.string()}, baseEnv,
+    const bool addOk = waitForCommandSuccess(*yamsBinary, {"add", docPath.string()}, probeEnv,
                                              scaledTimeout(20s), &addResult);
     INFO(describeFailure({"add", docPath.string()}, addResult) << "\ndaemon log:\n"
                                                                << readTextFile(daemonLogPath));

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2497,8 +2497,17 @@ if catch2_dep.found()
 
   test('metadata_schema', catch2_metadata_schema_exe,
     suite: ['catch2', 'unit', 'metadata', 'schema'],
+    args: ['~[slow]', '--allow-running-no-tests'],
     env: { 'LD_LIBRARY_PATH': _test_env_ld_library_path },
-    timeout: 300  # Comprehensive tests including performance metrics
+    timeout: 300
+  )
+
+  test('metadata_schema_slow', catch2_metadata_schema_exe,
+    suite: ['catch2', 'slow', 'metadata', 'schema'],
+    args: ['[slow]', '--allow-running-no-tests'],
+    env: { 'LD_LIBRARY_PATH': _test_env_ld_library_path },
+    timeout: 300,
+    is_parallel: false
   )
 
   test('fts5_failure_scenarios', catch2_fts5_failure_scenarios_exe,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1505,6 +1505,7 @@ if catch2_dep.found()
         'unit/vector/embedding_service_synthetic_catch2_test.cpp',
         'unit/vector/sqlite_vec_backend_comprehensive_catch2_test.cpp',
         'unit/vector/sqlite_vec_backend_persistence_catch2_test.cpp',
+        'unit/vector/static_cosine_ann_index_catch2_test.cpp',
         'unit/vector/sqlite_vec_c_api_smoke_catch2_test.cpp',
         'unit/vector/vector_schema_migration_vec0_catch2_test.cpp',
         'unit/vector/vector_dimension_validation_catch2_test.cpp',

--- a/tests/unit/app/services/document_service_test.cpp
+++ b/tests/unit/app/services/document_service_test.cpp
@@ -134,10 +134,14 @@ struct DocumentFixture {
         StoreDocumentRequest storeReq1;
         storeReq1.path = testFile1.string();
         storeReq1.tags = {"test", "document"};
+        storeReq1.metadata = {{"owner", "trace"}, {"source", "note"}, {"task", "alpha"}};
+        storeReq1.sessionId = "session-a";
 
         StoreDocumentRequest storeReq2;
         storeReq2.path = testFile2.string();
         storeReq2.tags = {"test", "markdown"};
+        storeReq2.metadata = {{"owner", "trace"}, {"source", "code"}, {"task", "beta"}};
+        storeReq2.sessionId = "session-b";
 
         StoreDocumentRequest storeReq3;
         storeReq3.path = testFile3.string();
@@ -574,6 +578,71 @@ TEST_CASE("DocumentService - Listing", "[document][service][listing]") {
             }
         }
         CHECK(foundMarkdown);
+    }
+
+    SECTION("List with all metadata filters") {
+        ListDocumentsRequest request;
+        request.limit = 100;
+        request.metadataFilters = {{"source", "note"}, {"task", "alpha"}};
+
+        auto result = fixture.documentService_->list(request);
+
+        REQUIRE(result);
+        REQUIRE(result.value().documents.size() == 1);
+        CHECK(result.value().documents.front().hash == fixture.testHash1_);
+    }
+
+    SECTION("List with contradictory metadata filters") {
+        ListDocumentsRequest request;
+        request.limit = 100;
+        request.metadataFilters = {{"source", "code"}, {"task", "alpha"}};
+
+        auto result = fixture.documentService_->list(request);
+
+        REQUIRE(result);
+        CHECK(result.value().documents.empty());
+    }
+
+    SECTION("List with any metadata filter") {
+        ListDocumentsRequest request;
+        request.limit = 100;
+        request.metadataFilters = {{"source", "code"}, {"task", "alpha"}};
+        request.matchAllMetadata = false;
+
+        auto result = fixture.documentService_->list(request);
+
+        REQUIRE(result);
+        REQUIRE(result.value().documents.size() == 2);
+        CHECK(std::ranges::any_of(result.value().documents,
+                                  [&](const auto& doc) { return doc.hash == fixture.testHash1_; }));
+        CHECK(std::ranges::any_of(result.value().documents,
+                                  [&](const auto& doc) { return doc.hash == fixture.testHash2_; }));
+    }
+
+    SECTION("List keeps session filter mandatory with any metadata filter") {
+        ListDocumentsRequest request;
+        request.limit = 100;
+        request.sessionId = "session-a";
+        request.metadataFilters = {{"source", "code"}, {"task", "alpha"}};
+        request.matchAllMetadata = false;
+
+        auto result = fixture.documentService_->list(request);
+
+        REQUIRE(result);
+        REQUIRE(result.value().documents.size() == 1);
+        CHECK(result.value().documents.front().hash == fixture.testHash1_);
+    }
+
+    SECTION("List applies metadata filters before pagination") {
+        ListDocumentsRequest request;
+        request.limit = 1;
+        request.metadataFilters = {{"task", "alpha"}};
+
+        auto result = fixture.documentService_->list(request);
+
+        REQUIRE(result);
+        REQUIRE(result.value().documents.size() == 1);
+        CHECK(result.value().documents.front().hash == fixture.testHash1_);
     }
 
     SECTION("List with type filter") {

--- a/tests/unit/app/services/graph_context_service_catch2_test.cpp
+++ b/tests/unit/app/services/graph_context_service_catch2_test.cpp
@@ -274,6 +274,32 @@ TEST_CASE("GraphContextService explore clamps zero-based symbol lines",
     CHECK((result.value().files.front().content.find("1\tint zeroBased() {") != std::string::npos));
 }
 
+TEST_CASE("GraphContextService explore tolerates stale symbol lines past end of file",
+          "[services][graph][context]") {
+    GraphContextServiceFixture fixture;
+    auto sourcePath = fixture.writeSource("src/stale_lines.cpp",
+                                          {"int staleLocation() {", "    return 42;", "}"});
+    auto staleLineSym =
+        fixture.symbol(sourcePath, "staleLocation", "demo::staleLocation", 100, 104);
+    fixture.upsertSymbols({staleLineSym});
+
+    auto service = makeGraphContextService(fixture.kgStore, fixture.metadataRepo);
+    REQUIRE((service != nullptr));
+
+    GraphExploreRequest req;
+    req.query = "staleLocation";
+
+    auto result = service->explore(req);
+    REQUIRE((result.has_value()));
+    REQUIRE((result.value().files.size() == 1));
+    CHECK(result.value().truncated);
+    CHECK((result.value().files.front().mode == GraphContextSnippetMode::Omitted));
+    CHECK(result.value().files.front().truncated);
+    CHECK(result.value().files.front().content.empty());
+    REQUIRE((result.value().warnings.size() == 1));
+    CHECK((result.value().warnings.front().find("stale source location") != std::string::npos));
+}
+
 TEST_CASE("GraphContextService explore supports file path queries", "[services][graph][context]") {
     GraphContextServiceFixture fixture;
     auto sourcePath =

--- a/tests/unit/cli/daemon_helpers_pool_catch2_test.cpp
+++ b/tests/unit/cli/daemon_helpers_pool_catch2_test.cpp
@@ -6,6 +6,9 @@
 #include <thread>
 
 #include <yams/cli/daemon_helpers.h>
+#include <yams/daemon/client/sandbox_probe.h>
+
+#include "../../common/test_helpers_catch2.h"
 
 using namespace std::chrono_literals;
 
@@ -53,4 +56,33 @@ TEST_CASE("is_transport_failure classifies 'Daemon not ready yet' as transport",
 
     yams::Error notFound{ErrorCode::NotFound, "missing key"};
     CHECK_FALSE(yams::cli::is_transport_failure(notFound));
+}
+
+TEST_CASE("Explicit pinned socket bypasses the generic sandbox probe", "[cli][daemon][transport]") {
+    struct ProbeReset {
+        ~ProbeReset() { yams::daemon::set_unix_socket_probe_for_tests(nullptr); }
+    } probeReset;
+
+    yams::daemon::set_unix_socket_probe_for_tests([] { return false; });
+    yams::test::ScopedEnvVar embedded("YAMS_EMBEDDED", std::nullopt);
+    yams::test::ScopedEnvVar inDaemon("YAMS_IN_DAEMON", std::nullopt);
+    yams::test::ScopedEnvVar config(
+        "YAMS_CONFIG", std::string("/nonexistent/yams-daemon-helper-test-config.toml"));
+    yams::test::ScopedEnvVar socketPath("YAMS_DAEMON_SOCKET_PATH",
+                                        std::string("/tmp/yams-pinned-test.sock"));
+    yams::test::ScopedEnvVar legacySocket("YAMS_DAEMON_SOCKET", std::nullopt);
+    yams::test::ScopedEnvVar noAutoStart("YAMS_CLI_DISABLE_DAEMON_AUTOSTART", std::string("1"));
+
+    yams::daemon::ClientConfig configRequest;
+    auto plan = yams::cli::prepare_cli_daemon_client_plan(
+        configRequest, yams::cli::CliDaemonAccessPolicy::AllowInProcessFallback);
+
+    REQUIRE(plan);
+    const auto& resolved = plan.value();
+    CHECK(resolved.resolvedMode == yams::daemon::ClientTransportMode::Socket);
+    CHECK(resolved.config.transportMode == yams::daemon::ClientTransportMode::Socket);
+    CHECK(resolved.config.socketPath == "/tmp/yams-pinned-test.sock");
+    CHECK(resolved.requireSocket);
+    CHECK_FALSE(resolved.allowInProcessFallback);
+    CHECK_FALSE(resolved.config.autoStart);
 }

--- a/tests/unit/daemon/components/config_resolver_test.cpp
+++ b/tests/unit/daemon/components/config_resolver_test.cpp
@@ -545,6 +545,7 @@ min_clusters = 1
 max_clusters = 3
 max_seed_documents = 24
 representative_limit = 2
+ann_candidate_limit = 16
 adaptive_probe_score_gap = 0.07
 narrow_min_boundary_margin = 0.03
 max_docs = 42
@@ -567,6 +568,8 @@ rrf_k = 33
     CHECK(*policy.maxSeedDocuments == 24U);
     REQUIRE(policy.representativeLimit.has_value());
     CHECK(*policy.representativeLimit == 2U);
+    REQUIRE(policy.annCandidateLimit.has_value());
+    CHECK(*policy.annCandidateLimit == 16U);
     REQUIRE(policy.adaptiveProbeScoreGap.has_value());
     CHECK(*policy.adaptiveProbeScoreGap == Catch::Approx(0.07F));
     REQUIRE(policy.narrowMinBoundaryMargin.has_value());

--- a/tests/unit/metadata/metadata_schema_catch2_test.cpp
+++ b/tests/unit/metadata/metadata_schema_catch2_test.cpp
@@ -926,7 +926,7 @@ TEST_CASE_METHOD(MetadataSchemaFixture, "Extraction status handling",
 }
 
 TEST_CASE_METHOD(MetadataSchemaFixture, "Performance metrics",
-                 "[unit][metadata][schema][performance]") {
+                 "[unit][metadata][schema][performance][slow]") {
     const int numDocs = 1000;
     auto start = std::chrono::high_resolution_clock::now();
 

--- a/tests/unit/search/search_engine_config_catch2_test.cpp
+++ b/tests/unit/search/search_engine_config_catch2_test.cpp
@@ -319,6 +319,7 @@ TEST_CASE("SearchEngineConfig default values", "[search][config][catch2]") {
     CHECK(cfg.topologyMaxClusters == 2U);
     CHECK(cfg.topologyMinClusters == 1U);
     CHECK(cfg.topologyMaxSeedDocuments == 32U);
+    CHECK(cfg.topologyRoutingAnnCandidateLimit == 64U);
     CHECK(cfg.topologyAdaptiveProbeScoreGap == Approx(0.0F));
     CHECK(cfg.topologyNarrowMinBoundaryMargin == Approx(0.2F));
     CHECK(std::string_view(SearchEngineConfig::topologyVectorPolicyToString(
@@ -343,6 +344,7 @@ TEST_CASE("SearchEngineConfig preserves typed execution policy across tuning",
     configured.topologyMaxClusters = 3;
     configured.topologyMinClusters = 2;
     configured.topologyMaxSeedDocuments = 24;
+    configured.topologyRoutingAnnCandidateLimit = 16;
     configured.topologyAdaptiveProbeScoreGap = 0.08F;
     configured.topologyNarrowMinBoundaryMargin = 0.12F;
     configured.topologyMaxDocs = 48;
@@ -365,6 +367,7 @@ TEST_CASE("SearchEngineConfig preserves typed execution policy across tuning",
     CHECK(tuned.topologyMaxClusters == 3);
     CHECK(tuned.topologyMinClusters == 2);
     CHECK(tuned.topologyMaxSeedDocuments == 24);
+    CHECK(tuned.topologyRoutingAnnCandidateLimit == 16);
     CHECK(tuned.topologyAdaptiveProbeScoreGap == Approx(0.08F));
     CHECK(tuned.topologyNarrowMinBoundaryMargin == Approx(0.12F));
     CHECK(tuned.topologyMaxDocs == 48);

--- a/tests/unit/search/search_engine_topology_catch2_test.cpp
+++ b/tests/unit/search/search_engine_topology_catch2_test.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <yams/metadata/connection_pool.h>
@@ -277,6 +278,23 @@ SearchEngineConfig topologyRoutingTestConfig(bool enabled) {
     return config;
 }
 
+Result<SearchResponse>
+runTopologySearch(TopologySearchFixture& fix,
+                  const std::shared_ptr<vector::EmbeddingGenerator>& generator,
+                  const SearchEngineConfig& config, std::size_t limit) {
+    SearchExecutionContext context = defaultSearchExecutionContext();
+    context.freshness.lexicalReady = true;
+    context.freshness.vectorReady = true;
+    context.freshness.kgReady = true;
+    context.freshness.topologyReady = true;
+    SearchExecutionContextGuard contextGuard(context);
+
+    SearchEngine engine(fix.repo, fix.vectorDb, generator, fix.kgStore, config);
+    SearchParams params;
+    params.limit = limit;
+    return engine.searchWithResponse("unmatched query", params);
+}
+
 } // namespace
 
 TEST_CASE("SearchEngine topology routing narrows weak-query vector candidates",
@@ -382,6 +400,136 @@ TEST_CASE("SearchEngine topology routing narrows weak-query vector candidates",
     auto cachedResponse = engine.searchWithResponse("unmatched query", params);
     REQUIRE(cachedResponse.has_value());
     CHECK((cachedResponse.value().debugStats.at("topology_snapshot_cache_hit") == "1"));
+}
+
+TEST_CASE("SearchEngine topology routes Simeon PQ over allowed documents",
+          "[search][topology][spq][catch2]") {
+    TopologySearchFixture fix{vector::VectorSearchEngine::SimeonPqAdc};
+    seedTopologyDocuments(fix);
+    seedTwoClusterTopology(fix);
+    REQUIRE(fix.vectorDb->buildIndex());
+
+    auto generator = makeFixedGenerator({0.1F, 0.9F});
+    auto config = topologyRoutingTestConfig(true);
+    config.topologyRoutingMode = SearchEngineConfig::TopologyRoutingMode::HybridAssist;
+    config.topologyNarrowMinBoundaryMargin = 0.0F;
+    config.topologyMaxDocs = 1;
+
+    auto response = runTopologySearch(fix, generator, config, 4);
+    REQUIRE(response.has_value());
+
+    const auto& debug = response.value().debugStats;
+    CHECK(debug.at("topology_weak_query_allowed_candidates") == "2");
+    CHECK(debug.at("topology_vector_allowed_set_ann_applied") == "1");
+    CHECK(debug.at("topology_vector_allowed_set_ann_fallback") == "0");
+    CHECK(debug.at("topology_weak_query_narrow_applied") == "1");
+    CHECK(debug.at("vector_search_ann_candidate_budget_actual") == "2");
+    CHECK(debug.at("vector_search_rows_visited_actual") == "2");
+    CHECK(debug.at("vector_search_exact_distance_evaluations_actual") == "2");
+    REQUIRE_FALSE(response.value().results.empty());
+    CHECK(response.value().results.front().document.sha256Hash == "y2");
+}
+
+TEST_CASE("SearchEngine topology balances query-ranked members across selected routes",
+          "[search][topology][spq][balance][catch2]") {
+    TopologySearchFixture fix{vector::VectorSearchEngine::SimeonPqAdc};
+    seedTopologyDocuments(fix);
+    seedTwoClusterTopology(fix);
+    REQUIRE(fix.vectorDb->buildIndex());
+
+    auto generator = makeFixedGenerator({0.0F, 1.0F});
+    auto config = topologyRoutingTestConfig(true);
+    config.topologyRoutingMode = SearchEngineConfig::TopologyRoutingMode::HybridAssist;
+    config.topologyNarrowMinBoundaryMargin = 0.0F;
+    config.topologyMinClusters = 2;
+    config.topologyMaxClusters = 2;
+    config.topologyMaxDocs = 2;
+    config.similarityThreshold = -1.0F;
+
+    auto response = runTopologySearch(fix, generator, config, 2);
+    REQUIRE(response.has_value());
+    REQUIRE(response.value().results.size() == 2U);
+
+    std::unordered_set<std::string> resultHashes;
+    for (const auto& result : response.value().results) {
+        resultHashes.insert(result.document.sha256Hash);
+    }
+    CHECK((resultHashes.contains("x1") || resultHashes.contains("x2")));
+    CHECK((resultHashes.contains("y1") || resultHashes.contains("y2")));
+}
+
+TEST_CASE("SearchEngine topology keeps confident Simeon routes bounded without global fill",
+          "[search][topology][spq][fill][catch2]") {
+    TopologySearchFixture fix{vector::VectorSearchEngine::SimeonPqAdc};
+    seedTopologyDocuments(fix);
+    seedTwoClusterTopology(fix);
+    REQUIRE(fix.vectorDb->buildIndex());
+
+    auto generator = makeFixedGenerator({0.0F, 1.0F});
+    auto config = topologyRoutingTestConfig(true);
+    config.topologyRoutingMode = SearchEngineConfig::TopologyRoutingMode::HybridAssist;
+    config.topologyNarrowMinBoundaryMargin = 0.0F;
+    config.topologyMinClusters = 1;
+    config.topologyMaxClusters = 1;
+    config.topologyMaxDocs = 4;
+    config.similarityThreshold = -1.0F;
+
+    auto response = runTopologySearch(fix, generator, config, 4);
+    REQUIRE(response.has_value());
+    CHECK(response.value().results.size() == 2U);
+    CHECK(response.value().debugStats.at("topology_vector_global_fill_count") == "0");
+    CHECK(response.value().debugStats.at("vector_search_ann_candidate_budget_actual") == "2");
+}
+
+TEST_CASE("SearchEngine topology fills unused routed Vec0 slots from global ANN",
+          "[search][topology][vec0][fill][catch2]") {
+    TopologySearchFixture fix{vector::VectorSearchEngine::Vec0L2};
+    seedTopologyDocuments(fix);
+    seedTwoClusterTopology(fix);
+    REQUIRE(fix.vectorDb->buildIndex());
+
+    auto generator = makeFixedGenerator({0.0F, 1.0F});
+    auto config = topologyRoutingTestConfig(true);
+    config.topologyRoutingMode = SearchEngineConfig::TopologyRoutingMode::HybridAssist;
+    config.topologyNarrowMinBoundaryMargin = 0.0F;
+    config.topologyMinClusters = 1;
+    config.topologyMaxClusters = 1;
+    config.topologyMaxDocs = 4;
+    config.similarityThreshold = -1.0F;
+
+    auto response = runTopologySearch(fix, generator, config, 4);
+    REQUIRE(response.has_value());
+    CHECK(response.value().results.size() == 4U);
+    CHECK(response.value().debugStats.at("topology_vector_global_fill_count") == "2");
+}
+
+TEST_CASE("SearchEngine topology abstains from narrowing at an ambiguous route boundary",
+          "[search][topology][spq][confidence][catch2]") {
+    TopologySearchFixture fix{vector::VectorSearchEngine::SimeonPqAdc};
+    seedTopologyDocuments(fix);
+    seedTwoClusterTopology(fix);
+    REQUIRE(fix.vectorDb->buildIndex());
+
+    auto generator = makeFixedGenerator({1.0F, 1.0F});
+    auto config = topologyRoutingTestConfig(true);
+    config.topologyRoutingMode = SearchEngineConfig::TopologyRoutingMode::HybridAssist;
+    config.topologySparseDenseAlpha = 0.0F;
+    config.topologyMinClusters = 1;
+    config.topologyMaxClusters = 1;
+    config.topologyNarrowMinBoundaryMargin = 0.20F;
+    config.topologyMaxDocs = 2;
+    config.similarityThreshold = -1.0F;
+
+    auto response = runTopologySearch(fix, generator, config, 4);
+    REQUIRE(response.has_value());
+    CHECK(response.value().results.size() == 4U);
+
+    const auto& debug = response.value().debugStats;
+    CHECK(debug.at("topology_route_confidence_abstained") == "1");
+    CHECK(debug.at("topology_weak_query_skip_reason") == "route_low_confidence");
+    CHECK(debug.at("topology_weak_query_narrow_applied") == "0");
+    CHECK(debug.at("topology_vector_allowed_set_ann_applied") == "0");
+    CHECK(debug.at("vector_search_ann_candidate_budget_actual") == "4");
 }
 
 TEST_CASE("SearchEngine topology shadow annotates global results without removing candidates",
@@ -902,6 +1050,7 @@ TEST_CASE("Topology routing options preserve the typed product configuration",
     config.topologyMinClusters = 2;
     config.topologyMaxClusters = 5;
     config.topologyRoutingRepresentativeLimit = 3;
+    config.topologyRoutingAnnCandidateLimit = 19;
     config.topologyAdaptiveProbeScoreGap = 0.07F;
     config.topologyNarrowMinBoundaryMargin = 0.11F;
     config.topologyMaxDocs = 17;
@@ -921,6 +1070,7 @@ TEST_CASE("Topology routing options preserve the typed product configuration",
     CHECK(options.minClusters == 2U);
     CHECK(options.maxClusters == 5U);
     CHECK(options.representativeLimit == 3U);
+    CHECK(options.denseAnnCandidateLimit == 19U);
     CHECK(options.adaptiveProbeScoreGap == Catch::Approx(0.07F));
     CHECK(options.narrowMinBoundaryMargin == Catch::Approx(0.11F));
     CHECK(options.maxDocs == 17U);
@@ -1067,6 +1217,9 @@ TEST_CASE("Topology routing exposes selected multiscale structural evidence from
     const auto session = runTopologyRoutingSession(request, fix.repo, fix.kgStore);
 
     REQUIRE(session.artifactAdmitted);
+    REQUIRE(session.routeAllowedDocumentHashGroups.size() == 2U);
+    CHECK(session.routeAllowedDocumentHashGroups[0].contains("y1"));
+    CHECK(session.routeAllowedDocumentHashGroups[1].contains("y1"));
     REQUIRE(session.candidateStructureEvidence.contains("y1"));
     const auto& evidence = session.candidateStructureEvidence.at("y1");
     CHECK(evidence.scaleAgreement == Catch::Approx(1.0F));

--- a/tests/unit/search/search_tracing_catch2_test.cpp
+++ b/tests/unit/search/search_tracing_catch2_test.cpp
@@ -192,6 +192,10 @@ TEST_CASE("recordTopologyRoutingDebug emits the legacy topology key set",
     session.confidenceAbstained = true;
     session.routeRepresentativeDistanceEvaluations = 7;
     session.routeRepresentativeCountMax = 4;
+    session.routeAnnUsed = true;
+    session.routeAnnCandidates = 6;
+    session.routeAnnDistanceEvaluations = 4;
+    session.routeExactRepresentativeDistanceEvaluations = 3;
     session.addedCandidateHashes = {"hash-a", "hash-b"};
     session.routedCandidateHashes = {"hash-c", "hash-a"};
     session.candidateStructureEvidence.emplace("hash-a",
@@ -245,6 +249,10 @@ TEST_CASE("recordTopologyRoutingDebug emits the legacy topology key set",
     CHECK(debug.at("topology_route_confidence_abstained") == "1");
     CHECK(debug.at("topology_route_representative_distance_evaluations") == "7");
     CHECK(debug.at("topology_route_representative_count_max") == "4");
+    CHECK(debug.at("topology_route_ann_used") == "1");
+    CHECK(debug.at("topology_route_ann_candidates") == "6");
+    CHECK(debug.at("topology_route_ann_distance_evaluations") == "4");
+    CHECK(debug.at("topology_route_exact_representative_distance_evaluations") == "3");
     CHECK(debug.at("topology_weak_query_routed_docs") == "5");
     CHECK(debug.at("topology_weak_query_added_candidates") == "4");
     CHECK(debug.at("topology_weak_query_duplicate_candidates") == "3");

--- a/tests/unit/search/search_tuner_catch2_test.cpp
+++ b/tests/unit/search/search_tuner_catch2_test.cpp
@@ -22,10 +22,10 @@
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
-#include <thread>
 #include <type_traits>
 #include <utility>
 
+#include <yams/compat/thread_stop_compat.h>
 #include <yams/compat/unistd.h>
 #include <yams/search/search_engine_builder.h>
 #include <yams/search/search_tuner.h>
@@ -47,14 +47,14 @@ TEST_CASE("SearchTuner parameter snapshots are safe during observation",
 
     std::atomic<bool> start{false};
     std::atomic<bool> snapshotsValid{true};
-    std::jthread writer([&] {
+    yams::compat::jthread writer([&] {
         while (!start.load(std::memory_order_acquire)) {
         }
         for (std::size_t i = 0; i < 1000; ++i) {
             tuner.observe(telemetry);
         }
     });
-    std::jthread reader([&] {
+    yams::compat::jthread reader([&] {
         while (!start.load(std::memory_order_acquire)) {
         }
         for (std::size_t i = 0; i < 1000; ++i) {
@@ -79,7 +79,7 @@ TEST_CASE("SearchTuner snapshot keeps config and parameters correlated",
     telemetry.latencyMs = 200.0;
 
     std::atomic<bool> start{false};
-    std::jthread writer([&] {
+    yams::compat::jthread writer([&] {
         while (!start.load(std::memory_order_acquire)) {
         }
         for (std::size_t i = 0; i < 500; ++i) {

--- a/tests/unit/topology/topology_baseline_catch2_test.cpp
+++ b/tests/unit/topology/topology_baseline_catch2_test.cpp
@@ -2,8 +2,11 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <filesystem>
 #include <memory>
+#include <numbers>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -466,6 +469,50 @@ TEST_CASE("Sparse-guided topology routing reuses a prepared membership index",
     CHECK(work.seedClusterLookups == 3);
     CHECK(work.clusterMemberHashesScanned == 0);
     CHECK(work.queryNormEvaluations == 1);
+}
+
+TEST_CASE("Sparse-guided topology routing shortlists centroids with cached ANN",
+          "[unit][topology][routing][ann]") {
+    TopologyArtifactBatch batch;
+    constexpr std::size_t clusterCount = 128;
+    batch.clusters.reserve(clusterCount);
+    for (std::size_t index = 0; index < clusterCount; ++index) {
+        const auto angle = static_cast<float>(index) * 2.0F * std::numbers::pi_v<float> /
+                           static_cast<float>(clusterCount);
+        batch.clusters.push_back(ClusterArtifact{
+            .clusterId = "cluster-" + std::to_string(index),
+            .memberCount = 1,
+            .memberDocumentHashes = {"doc-" + std::to_string(index)},
+            .centroidEmbedding = {std::cos(angle), std::sin(angle)},
+        });
+    }
+
+    const auto routeIndex = SparseGuidedClusterRouter::buildRouteIndex(batch);
+    SparseGuidedClusterRouter router;
+    TopologyRouteRequest request;
+    request.limit = 1;
+    request.queryEmbedding = {1.0F, 0.0F};
+    request.sparseDenseAlpha = 0.0F;
+    request.denseAnnCandidateLimit = 8;
+    SparseRouteWork work;
+
+    auto routed = router.route(request, batch, routeIndex, &work);
+
+    REQUIRE(routed.has_value());
+    REQUIRE(routed.value().size() == 1U);
+    CHECK(routed.value().front().clusterId == "cluster-0");
+    CHECK(work.denseAnnUsed);
+    CHECK(work.denseAnnCandidates <= 8U);
+    CHECK(work.denseAnnDistanceEvaluations > 0U);
+    CHECK(work.exactRepresentativeDistanceEvaluations <= 8U);
+
+    request.seedDocumentHashes = {"doc-64"};
+    request.sparseDenseAlpha = 1.0F;
+    work = {};
+    routed = router.route(request, batch, routeIndex, &work);
+    REQUIRE(routed.has_value());
+    REQUIRE(routed.value().size() == 1U);
+    CHECK(routed.value().front().clusterId == "cluster-64");
 }
 
 TEST_CASE("Topology construction emits a deterministic bounded diverse routing cover",

--- a/tests/unit/vector/sqlite_vec_backend_comprehensive_catch2_test.cpp
+++ b/tests/unit/vector/sqlite_vec_backend_comprehensive_catch2_test.cpp
@@ -602,6 +602,65 @@ TEST_CASE_METHOD(SqliteVecBackendFixture, "SqliteVecBackend SPQ rerank improves 
     CHECK((recall_rerank8 >= 0.85));
 }
 
+TEST_CASE_METHOD(SqliteVecBackendFixture,
+                 "SqliteVecBackend Simeon PQ ranking is independent of insertion order",
+                 "[vector][backend][search][spq][determinism][catch2]") {
+    skipIfNeeded();
+
+    constexpr size_t kDim = 32;
+    constexpr size_t kCorpus = 96;
+    constexpr size_t kTopK = 8;
+
+    std::vector<VectorRecord> records;
+    records.reserve(kCorpus);
+    for (size_t i = 0; i < kCorpus; ++i) {
+        records.push_back(createVectorRecord("stable_" + std::to_string(i),
+                                             createEmbedding(kDim, static_cast<float>(i + 1))));
+    }
+
+    const auto buildBackend = [&](bool reverseInsertion) {
+        SqliteVecBackend::Config config;
+        config.search_engine = VectorSearchEngine::SimeonPqAdc;
+        config.embedding_dim = kDim;
+        config.simeon_pq_subquantizers = 8;
+        config.simeon_pq_centroids = 2;
+        config.simeon_pq_train_limit = 32;
+        config.simeon_pq_rerank_factor = 1;
+
+        auto backend = std::make_unique<SqliteVecBackend>(config);
+        REQUIRE((backend->initialize(":memory:").has_value()));
+        REQUIRE((backend->createTables(kDim).has_value()));
+        if (reverseInsertion) {
+            auto reversed = records;
+            std::ranges::reverse(reversed);
+            REQUIRE((backend->insertVectorsBatch(reversed).has_value()));
+        } else {
+            REQUIRE((backend->insertVectorsBatch(records).has_value()));
+        }
+        REQUIRE((backend->buildIndex().has_value()));
+        return backend;
+    };
+
+    auto forward = buildBackend(false);
+    auto reverse = buildBackend(true);
+    for (size_t queryIndex = 0; queryIndex < 12; ++queryIndex) {
+        const auto query = createEmbedding(kDim, static_cast<float>(5000 + queryIndex));
+        auto forwardResult = forward->searchSimilar(query, kTopK, -1.0F, std::nullopt, {});
+        auto reverseResult = reverse->searchSimilar(query, kTopK, -1.0F, std::nullopt, {});
+        REQUIRE((forwardResult.has_value()));
+        REQUIRE((reverseResult.has_value()));
+
+        std::vector<std::string> forwardIds;
+        std::vector<std::string> reverseIds;
+        std::ranges::transform(forwardResult.value(), std::back_inserter(forwardIds),
+                               &VectorRecord::chunk_id);
+        std::ranges::transform(reverseResult.value(), std::back_inserter(reverseIds),
+                               &VectorRecord::chunk_id);
+        CAPTURE(queryIndex, forwardIds, reverseIds);
+        CHECK((forwardIds == reverseIds));
+    }
+}
+
 TEST_CASE_METHOD(SqliteVecBackendFixture, "SqliteVecBackend vec0 search engine basic",
                  "[vector][backend][search][vec0][catch2]") {
     skipIfNeeded();
@@ -860,6 +919,57 @@ TEST_CASE_METHOD(SqliteVecBackendFixture,
     for (const auto& r : filterResult.value()) {
         CHECK((r.document_hash == "doc_A"));
     }
+}
+
+TEST_CASE_METHOD(SqliteVecBackendFixture,
+                 "SqliteVecBackend Simeon PQ routes candidate documents through ADC",
+                 "[vector][backend][search][filter][spq][diagnostics][catch2]") {
+    skipIfNeeded();
+
+    constexpr size_t kDim = 64;
+    SqliteVecBackend::Config config;
+    config.search_engine = VectorSearchEngine::SimeonPqAdc;
+    config.embedding_dim = kDim;
+    config.simeon_pq_subquantizers = 8;
+    config.simeon_pq_rerank_factor = 2;
+    SqliteVecBackend backend(config);
+    REQUIRE((backend.initialize(":memory:").has_value()));
+    REQUIRE((backend.createTables(kDim).has_value()));
+
+    std::vector<std::vector<float>> embeddings;
+    for (int i = 0; i < 24; ++i) {
+        embeddings.push_back(createEmbedding(kDim, static_cast<float>(i + 1)));
+        REQUIRE((backend
+                     .insertVector(createVectorRecord("spq_route_" + std::to_string(i),
+                                                      embeddings.back(),
+                                                      "route_doc_" + std::to_string(i)))
+                     .has_value()));
+    }
+    REQUIRE((backend.buildIndex().has_value()));
+
+    const std::unordered_set<std::string> routedDocuments = {"route_doc_3", "route_doc_11",
+                                                             "route_doc_19"};
+    VectorSearchDiagnostics diagnostics;
+    auto routed =
+        backend.searchSimilarWithDiagnostics(embeddings[11], routedDocuments.size(), -1.0F,
+                                             std::nullopt, routedDocuments, {}, diagnostics);
+    REQUIRE((routed.has_value()));
+    REQUIRE((routed.value().size() == routedDocuments.size()));
+    CHECK((routed.value().front().document_hash == "route_doc_11"));
+    for (const auto& record : routed.value()) {
+        CHECK((routedDocuments.contains(record.document_hash)));
+    }
+
+    CHECK((diagnostics.usedAnn));
+    CHECK_FALSE(diagnostics.usedExactScan);
+    CHECK((diagnostics.annCandidateBudget == routedDocuments.size()));
+    CHECK((diagnostics.rowsVisited == routedDocuments.size()));
+    CHECK((diagnostics.exactDistanceEvaluations == routedDocuments.size()));
+    CHECK((diagnostics.usedCandidateIndexCache));
+    CHECK((diagnostics.candidateIndexPayloadBytes > 0));
+    CHECK((diagnostics.candidateLookupCount == 1));
+    CHECK((diagnostics.materializedRows == routedDocuments.size()));
+    CHECK((diagnostics.returnedRows == routedDocuments.size()));
 }
 
 TEST_CASE_METHOD(SqliteVecBackendFixture, "SqliteVecBackend searchSimilar with metadata_filters",

--- a/tests/unit/vector/static_cosine_ann_index_catch2_test.cpp
+++ b/tests/unit/vector/static_cosine_ann_index_catch2_test.cpp
@@ -1,0 +1,82 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <yams/vector/static_cosine_ann_index.h>
+
+#include <array>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+using yams::vector::StaticCosineAnnIndex;
+
+TEST_CASE("Static cosine ANN preserves external IDs and reports traversal work",
+          "[unit][vector][ann][routing]") {
+    const std::array<std::size_t, 4> ids{10, 20, 30, 40};
+    const std::array<std::vector<float>, 4> vectors{
+        std::vector<float>{1.0F, 0.0F},
+        std::vector<float>{0.0F, 1.0F},
+        std::vector<float>{-1.0F, 0.0F},
+        std::vector<float>{0.0F, -1.0F},
+    };
+
+    auto built = StaticCosineAnnIndex::build(ids, vectors);
+    REQUIRE(built.has_value());
+    REQUIRE(built.value());
+    CHECK(built.value()->size() == ids.size());
+    CHECK(built.value()->dimension() == 2U);
+
+    const std::array<float, 2> query{0.05F, 1.0F};
+    auto result = built.value()->search(query, 2);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value().hits.size() == 2U);
+    CHECK(result.value().hits.front().id == 20U);
+    CHECK(result.value().distanceEvaluations > 0U);
+}
+
+TEST_CASE("Static cosine ANN rejects inconsistent dimensions", "[unit][vector][ann][routing]") {
+    const std::array<std::size_t, 2> ids{1, 2};
+    const std::array<std::vector<float>, 2> vectors{
+        std::vector<float>{1.0F, 0.0F},
+        std::vector<float>{0.0F, 1.0F, 0.0F},
+    };
+
+    const auto built = StaticCosineAnnIndex::build(ids, vectors);
+    REQUIRE_FALSE(built.has_value());
+    CHECK(built.error().code == yams::ErrorCode::InvalidArgument);
+}
+
+TEST_CASE("Static cosine ANN supports concurrent immutable searches",
+          "[unit][vector][ann][routing][concurrency]") {
+    const std::array<std::size_t, 4> ids{10, 20, 30, 40};
+    const std::array<std::vector<float>, 4> vectors{
+        std::vector<float>{1.0F, 0.0F},
+        std::vector<float>{0.0F, 1.0F},
+        std::vector<float>{-1.0F, 0.0F},
+        std::vector<float>{0.0F, -1.0F},
+    };
+    auto built = StaticCosineAnnIndex::build(ids, vectors);
+    REQUIRE(built.has_value());
+    const auto index = built.value();
+
+    std::atomic<std::size_t> failures{0};
+    std::vector<std::thread> readers;
+    for (std::size_t reader = 0; reader < 8; ++reader) {
+        readers.emplace_back([&, reader, index] {
+            const std::array<float, 2> query = reader % 2 == 0 ? std::array<float, 2>{1.0F, 0.05F}
+                                                               : std::array<float, 2>{0.05F, 1.0F};
+            const std::size_t expectedId = reader % 2 == 0 ? 10U : 20U;
+            for (std::size_t iteration = 0; iteration < 100; ++iteration) {
+                auto result = index->search(query, 2);
+                if (!result || result.value().hits.size() != 2U ||
+                    result.value().hits.front().id != expectedId ||
+                    result.value().distanceEvaluations == 0U) {
+                    failures.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+    for (auto& reader : readers) {
+        reader.join();
+    }
+    CHECK(failures.load(std::memory_order_relaxed) == 0U);
+}


### PR DESCRIPTION
## Summary

- Bound topology-assisted search work with cached route membership, static cosine-ANN centroid shortlisting, and explicit allowed-document budgets for SPQ.
- Extend xplan and retrieval benchmarks with stable experiment identity plus route, cache, phase, candidate, and distance-work metrics for repeated routed-vs-global comparisons.
- Harden adjacent runtime paths: serialize detached work cancellation, honor pinned daemon sockets, filter metadata before paging, and omit stale graph snippets instead of aborting.
- Keep the expanded surface portable with the repository jthread compatibility layer, Windows-safe xplan imports, isolated timing tests, and cold-cache ARM64 release builds that use hosted CMake.
- Advance the managed Simeon pointer for specialized PQ inner-product queries.

## Search and benchmark details

- Product topology routing remains the context around hybrid retrieval; global lexical/vector inputs remain available for recall preservation.
- Routed vector work is now observable at equal candidate and distance-evaluation budgets instead of being inferred from wall-clock latency alone.
- The generalized-memory and topology-routing plans record cache reuse, route application, shortlist work, and engine phase costs with repeat-safe artifact identity.
- Unit coverage exercises allowed-document filtering, topology route bounds, static cosine ANN behavior, tracing, and backend accounting.

## Reliability fixes

- Treat persisted symbol ranges beyond the current source file as recoverable corpus drift, with an omitted/truncated snippet and warning rather than a debug assertion abort.
- Reuse the retrying readiness probe in the timeout-recovery integration test while preserving the post-shutdown timeout and error-message assertions.
- Resolve Conan CMake tool requirements from the hosted runner's installed CMake, removing the ARM64 nightly's cold-cache dependency on cmake.org. The failure being addressed is [Release run 29677242967](https://github.com/trvon/yams/actions/runs/29677242967).

