### PR TITLE
chore(topology): remove parked join knob

### DIFF
--- a/formal/topology/Yams/Topology/Artifacts.lean
+++ b/formal/topology/Yams/Topology/Artifacts.lean
@@ -74,7 +74,6 @@ structure TopologyBuildConfig where
   dirtyRegionExpansion : DirtyRegionExpansionMode := .priorClusterAndNeighbors
   kmeansK : Nat := 0
   kmeansMaxIterations : Nat := 10
-  minSimilarityToJoin : Rat := 45 / 100
   deriving Repr, BEq
 
 structure TopologyDirtyRegion where

--- a/include/yams/topology/topology_artifacts.h
+++ b/include/yams/topology/topology_artifacts.h
@@ -88,13 +88,10 @@ struct TopologyBuildConfig {
         DirtyRegionExpansionMode::PriorClusterAndNeighbors};
     Duration budget{Duration{250}};
     // Phase S: KMeans engine knobs.
-    // kmeansK: target cluster count for KMeans engines (0 = auto: max(64, min(300, sqrt(n)))).
-    // kmeansMaxIterations: Lloyd iteration cap during buildArtifacts.
-    // minSimilarityToJoin: cosine threshold below which an incremental update spawns a
-    //   new cluster instead of assigning to nearest existing centroid (default 0.45).
+    // kmeansK: target cluster count for KMeans engines (0 = auto: round(sqrt(n)) clamped to [2,
+    // n]). kmeansMaxIterations: Lloyd iteration cap during buildArtifacts.
     std::size_t kmeansK{0};
     std::size_t kmeansMaxIterations{10};
-    float minSimilarityToJoin{0.45F};
     // Total dense route representatives per cluster, including the centroid. Values above one
     // add deterministic diverse member embeddings. The default preserves centroid-only routing.
     std::size_t routingRepresentativeCount{1};


### PR DESCRIPTION
## Problem

The parked topology join threshold remained exposed in generated/runtime artifacts even though it was no longer an active product lever.

## Solution

Remove the unused `minSimilarityToJoin` field from the Lean artifact and public topology artifact structure.

## Release Note
- [x] Internal only (no user-facing release note)
- User-facing summary (1-2 bullets, outcome-focused):
- Migration or operator note (if needed):

## Breaking Changes
- [x] None
- [ ] Yes — details:

## Tests
- [ ] Unit
- [ ] Integration
- [ ] Performance (if applicable)

Validation: formatting, portability, OpenGrep, DCO, commitlint, and diff checks passed. Origin CI is pending.

## Documentation
- [ ] CHANGELOG updated (user-visible changes)
- [ ] Docs updated (README/docs/*)
- [ ] Stability note updated (if interfaces change)

## AI usage
- [ ] No AI used
- [x] AI used in an assistive role only, and I manually reviewed the full change
- [x] If AI was used, I disclosed the use and can explain every part of this PR

## Links
- Stack: #67, layer 1 of 5

## Sign-off
- [x] DCO: Please include a `Signed-off-by: Your Name <you@example.com>` line in each commit if using DCO
