### PR TITLE
perf(search): favor lexical mixed defaults

### DIFF
--- a/include/yams/search/search_engine_config.h
+++ b/include/yams/search/search_engine_config.h
@@ -75,12 +75,15 @@ struct SearchEngineConfig {
         return "AUTO";
     }
 
-    float textWeight = 0.70f;
+    // xplan scifact + nfcorpus transfer gate (repeats=3): pure vector fusion at 0.30
+    // reduced quality and added latency. Keep graph-vector evidence while making lexical the
+    // primary product path; profile-specific configurations may still opt into pure vectors.
+    float textWeight = 1.00f;
     float simeonTextWeight = 0.15f;
     float graphTextWeight = 0.12f;
     float pathTreeWeight = 0.08f;
     float kgWeight = 0.04f;
-    float vectorWeight = 0.30f;
+    float vectorWeight = 0.00f;
     float graphVectorWeight = 0.08f;
     float vectorOnlyPenalty = 0.8f;
     float vectorOnlyThreshold = 0.90f;

--- a/tests/unit/search/search_engine_config_catch2_test.cpp
+++ b/tests/unit/search/search_engine_config_catch2_test.cpp
@@ -30,6 +30,15 @@ TEST_CASE("navigationZoomLevelToString covers all zoom levels", "[search][config
     CHECK(std::string(SearchEngineConfig::navigationZoomLevelToString(Z::Street)) == "STREET");
 }
 
+TEST_CASE("default mixed weights favor lexical and graph-vector evidence",
+          "[search][config][catch2]") {
+    const SearchEngineConfig cfg;
+
+    CHECK(cfg.textWeight == Approx(1.0F));
+    CHECK(cfg.vectorWeight == Approx(0.0F));
+    CHECK(cfg.graphVectorWeight == Approx(0.08F));
+}
+
 // ────────────────────────────────────────────────────────────────────────────────
 // forProfile
 // ────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The mixed-search defaults underweighted lexical retrieval relative to measured product-path behavior.

## Solution

Adjust the typed search-engine defaults to favor lexical retrieval while retaining hybrid components, with unit coverage for the resulting configuration.

## Release Note
- [ ] Internal only (no user-facing release note)
- User-facing summary (1-2 bullets, outcome-focused):
  - Mixed search favors lexical matches more strongly by default.
- Migration or operator note (if needed): No configuration migration is required.

## Breaking Changes
- [x] None
- [ ] Yes — details:

## Tests
- [x] Unit
- [ ] Integration
- [x] Performance (if applicable)

Current-head 3-repeat product baseline: SciFact MRR@10 0.6737, NDCG@10 0.7067, Recall@10 0.8133, p50 18.00 ms; NFCorpus MRR@10 0.4853, NDCG@10 0.2644, Recall@10 0.1239, p50 18.50 ms. SciFact quality was unchanged versus the matching canonical configuration; no decision-grade NFCorpus latency claim is made because p95 variance was high. Origin CI is pending.

## Documentation
- [ ] CHANGELOG updated (user-visible changes)
- [ ] Docs updated (README/docs/*)
- [ ] Stability note updated (if interfaces change)

## AI usage
- [ ] No AI used
- [x] AI used in an assistive role only, and I manually reviewed the full change
- [x] If AI was used, I disclosed the use and can explain every part of this PR

## Links
- Stack: #67, layer 4 of 5
- Benchmark artifact: `build/benchmarks/search_product_clean_baseline/20260823T021205068463Z-60303894742f`

## Sign-off
- [x] DCO: every commit contains `Signed-off-by: trvon <git@trevon.dev>`
