### PR TITLE
fix(p2p): replicate content deletion

### DIFF
--- a/include/yams/daemon/components/ServiceManager.h
+++ b/include/yams/daemon/components/ServiceManager.h
@@ -205,8 +205,10 @@ public:
     Result<void> enrollP2pPeer(std::string_view nodeId, std::string_view spkiPin);
     Result<p2p::P2pLocalIdentity> getP2pIdentity() const;
     Result<std::vector<p2p::PeerRegistryRecord>> listP2pPeers() const;
-    Result<void> stageMemorySyncDocumentDelete(std::string_view contentHash);
-    Result<void> publishMemorySyncDocumentDelete(std::string_view contentHash);
+    Result<void> stageMemorySyncDocumentDelete(std::string_view contentHash,
+                                               bool retainContent = false);
+    Result<void> publishMemorySyncDocumentDelete(std::string_view contentHash,
+                                                 bool retainContent = false);
 
     struct SearchLoadMetrics {
         std::uint32_t active{0};
@@ -443,6 +445,10 @@ public:
     void testingSetMemorySyncStageObserver(std::function<void(std::string_view)> observer) {
         std::lock_guard<std::mutex> lock(memorySyncStageObserverMutex_);
         memorySyncStageObserver_ = std::move(observer);
+    }
+    void testingSetMemorySyncDeleteOutboxObserver(std::function<void(std::string_view)> observer) {
+        std::lock_guard<std::mutex> lock(memorySyncDeleteOutboxObserverMutex_);
+        memorySyncDeleteOutboxObserver_ = std::move(observer);
     }
     void testingApplyMemorySyncWinners() { applyMemorySyncWinners(); }
     void testingPublishMemorySyncBackfill() { publishMemorySyncBackfill(); }
@@ -798,6 +804,7 @@ private:
                                                memory_sync::EraseReadinessProbe probe) const;
     void publishMemorySyncBackfill() noexcept;
     void notifyMemorySyncStage(std::string_view stage) noexcept;
+    void notifyMemorySyncDeleteOutboxStage(std::string_view stage) noexcept;
     Result<std::size_t> applyMemorySyncContentBlobs();
     boost::asio::awaitable<bool> initializeMetadataDatabaseAt(const std::filesystem::path& dbPath,
                                                               yams::compat::stop_token token);
@@ -934,6 +941,9 @@ private:
     // Started after storage/content-store init, stopped during shutdown.
     std::unique_ptr<yams::memory_sync::MemorySyncService> memorySync_;
     std::unique_ptr<yams::daemon::p2p::P2pManager> p2pManager_;
+    mutable std::mutex memorySyncDeleteOutboxMutex_;
+    mutable std::mutex memorySyncDeleteOutboxObserverMutex_;
+    std::function<void(std::string_view)> memorySyncDeleteOutboxObserver_;
     mutable std::mutex memorySyncStageObserverMutex_;
     std::function<void(std::string_view)> memorySyncStageObserver_;
     bool memorySyncVectorRebuildDirty_{false};

--- a/include/yams/memory_sync/memory_sync.h
+++ b/include/yams/memory_sync/memory_sync.h
@@ -87,6 +87,13 @@ struct PendingEraseIntent {
     std::uint64_t preparedCounter{0};
 };
 
+/// One member of an all-or-rollback pre-delete staging batch.
+struct EraseStageRequest {
+    std::string logicalKey;
+    std::string tombstonePayload;
+    EraseReadinessProbe readinessProbe{EraseReadinessProbe::Explicit};
+};
+
 struct WriterHistoryCommitment {
     std::uint64_t counter{0};
     std::string digest;
@@ -244,6 +251,13 @@ public:
                 return {};
             }
         } else {
+            auto allIntents = loadEraseIntents();
+            if (!allIntents) {
+                return allIntents.error();
+            }
+            if (allIntents.value().size() >= limits_.maxMergedKeys) {
+                return Error{ErrorCode::ResourceExhausted, "durable erase outbox limit reached"};
+            }
             intent.logicalKey = logicalKey;
             intent.tombstonePayload = std::move(tombstonePayload);
             intent.readinessProbe = readinessProbe;
@@ -288,6 +302,79 @@ public:
         }
         intent.preparedCommitment = std::move(commitment.value());
         return storeEraseIntent(intent);
+    }
+
+    /// Reserve capacity for a related set of pre-delete intents before storing any member.
+    /// Backend failures roll back only intents newly created by this call.
+    Result<void> stageErases(std::span<const EraseStageRequest> requests) {
+        if (requests.empty()) {
+            return {};
+        }
+        auto existing = loadEraseIntents();
+        if (!existing) {
+            return existing.error();
+        }
+
+        std::set<std::string> existingKeys;
+        for (const auto& intent : existing.value()) {
+            existingKeys.insert(intent.logicalKey);
+        }
+        std::set<std::string> requestedKeys;
+        std::size_t newIntentCount = 0;
+        for (const auto& request : requests) {
+            if (auto valid = validateLogicalKey(request.logicalKey); !valid) {
+                return valid.error();
+            }
+            if (request.tombstonePayload.size() > limits_.maxEnvelopeBytes) {
+                return Error{ErrorCode::InvalidArgument,
+                             "memory sync tombstone payload exceeds envelope limit"};
+            }
+            if (!requestedKeys.insert(request.logicalKey).second) {
+                return Error{ErrorCode::InvalidArgument,
+                             "erase staging batch contains a duplicate logical key"};
+            }
+            const auto retained = std::ranges::find_if(existing.value(), [&](const auto& intent) {
+                return intent.logicalKey == request.logicalKey;
+            });
+            if (retained != existing.value().end() &&
+                (retained->tombstonePayload != request.tombstonePayload ||
+                 retained->readinessProbe != request.readinessProbe)) {
+                return Error{ErrorCode::InvalidState,
+                             "staged erase payload conflicts with retained intent"};
+            }
+            newIntentCount += existingKeys.contains(request.logicalKey) ? 0U : 1U;
+        }
+        if (existing.value().size() > limits_.maxMergedKeys ||
+            newIntentCount > limits_.maxMergedKeys - existing.value().size()) {
+            return Error{ErrorCode::ResourceExhausted,
+                         "erase staging batch exceeds the durable outbox limit"};
+        }
+
+        std::vector<std::string> newlyStored;
+        newlyStored.reserve(newIntentCount);
+        for (const auto& request : requests) {
+            auto staged = stageErase(request.logicalKey, request.tombstonePayload, false,
+                                     request.readinessProbe);
+            if (!staged) {
+                std::string rollbackFailure;
+                for (auto key = newlyStored.rbegin(); key != newlyStored.rend(); ++key) {
+                    if (auto cancelled = cancelStagedErase(*key); !cancelled) {
+                        rollbackFailure += rollbackFailure.empty() ? "" : "; ";
+                        rollbackFailure += *key + ": " + cancelled.error().message;
+                    }
+                }
+                if (!rollbackFailure.empty()) {
+                    return Error{staged.error().code,
+                                 staged.error().message +
+                                     "; batch rollback failed: " + rollbackFailure};
+                }
+                return staged.error();
+            }
+            if (!existingKeys.contains(request.logicalKey)) {
+                newlyStored.push_back(request.logicalKey);
+            }
+        }
+        return {};
     }
 
     Result<std::vector<PendingEraseIntent>> pendingErases() {
@@ -2150,6 +2237,13 @@ private:
         if (!intent.ready || !intent.record || !isSha256Digest(intent.recordHash)) {
             return Error{ErrorCode::InvalidState, "erase intent is not prepared"};
         }
+        const auto retainCommittedWinner = [&] {
+            const auto winner = merged_.find(intent.logicalKey);
+            if (winner == merged_.end() ||
+                resolveLww(*intent.record, winner->second) == LwwDecision::First) {
+                merged_[intent.logicalKey] = *intent.record;
+            }
+        };
         const auto operation = operations_.find(intent.record->operationId);
         if (operation != operations_.end()) {
             if (operation->second != std::pair{intent.recordHash, intent.logicalKey}) {
@@ -2162,6 +2256,7 @@ private:
                 return Error{ErrorCode::InvalidState,
                              "prepared erase index lacks a durable history commitment"};
             }
+            retainCommittedWinner();
             return backend_->remove(eraseOutboxKey(intent.logicalKey));
         }
         const auto prior = historyCommitments_.find(nodeId_);
@@ -2201,6 +2296,7 @@ private:
         operations_[intent.record->operationId] = {intent.recordHash, intent.logicalKey};
         version_.merge(intent.record->vv);
         logicalClock_ = std::max(logicalClock_, intent.record->ts.logical);
+        retainCommittedWinner();
         return backend_->remove(eraseOutboxKey(intent.logicalKey));
     }
 

--- a/include/yams/memory_sync/memory_sync_service.h
+++ b/include/yams/memory_sync/memory_sync_service.h
@@ -184,6 +184,11 @@ public:
         return loop_.stageErase(key, std::move(tombstonePayload), ready, readinessProbe);
     }
 
+    Result<void> stageErases(std::span<const EraseStageRequest> requests) {
+        std::lock_guard<std::mutex> lock(loopMutex_);
+        return loop_.stageErases(requests);
+    }
+
     Result<std::vector<PendingEraseIntent>> pendingErases() {
         std::lock_guard<std::mutex> lock(loopMutex_);
         return loop_.pendingErases();
@@ -280,6 +285,15 @@ public:
             return Error{ErrorCode::NotFound, "memory sync blob was not hydrated during sync"};
         }
         return cached->second;
+    }
+
+    [[nodiscard]] bool hasCommittedTombstone(std::string_view key) const noexcept {
+        const auto state = committedSnapshot();
+        if (!state) {
+            return false;
+        }
+        const auto record = state->merged.find(std::string(key));
+        return record != state->merged.end() && record->second.isTombstone();
     }
 
     std::size_t mergedRecordCount() const noexcept {

--- a/src/daemon/components/ServiceManager.cpp
+++ b/src/daemon/components/ServiceManager.cpp
@@ -5,6 +5,7 @@
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cctype>
 #include <cerrno>
@@ -23,7 +24,6 @@
 #include <string>
 #include <system_error>
 #include <unordered_map>
-#include <unordered_set>
 #include <yams/common/fs_utils.h>
 #include <yams/config/config_helpers.h>
 #include <yams/config/config_migration.h>
@@ -2292,7 +2292,8 @@ Result<std::vector<p2p::PeerRegistryRecord>> ServiceManager::listP2pPeers() cons
     return p2pManager_->peers();
 }
 
-Result<void> ServiceManager::stageMemorySyncDocumentDelete(std::string_view contentHash) {
+Result<void> ServiceManager::stageMemorySyncDocumentDelete(std::string_view contentHash,
+                                                           bool retainContent) {
     if (!memorySync_) {
         return {};
     }
@@ -2309,8 +2310,14 @@ Result<void> ServiceManager::stageMemorySyncDocumentDelete(std::string_view cont
     if (!document) {
         return document.error();
     }
-    const std::string key =
+    if (retainContent && !document.value()) {
+        return Error{ErrorCode::InvalidArgument, "retaining content requires an existing document"};
+    }
+    const std::string documentKey =
         std::string(memory_sync::memoryStoreName(memory_sync::MemoryStore::Document)) + "/" +
+        std::string(contentHash);
+    const std::string blobKey =
+        std::string(memory_sync::memoryStoreName(memory_sync::MemoryStore::ContentBlob)) + "/" +
         std::string(contentHash);
     auto probe = memory_sync::EraseReadinessProbe::MetadataAbsent;
     if (!document.value()) {
@@ -2329,30 +2336,80 @@ Result<void> ServiceManager::stageMemorySyncDocumentDelete(std::string_view cont
         }
         probe = memory_sync::EraseReadinessProbe::ContentAbsent;
     }
-    return memorySync_->stageErase(key, std::string(contentHash), false, probe);
+    if (retainContent) {
+        const std::array requests{
+            memory_sync::EraseStageRequest{documentKey, std::string(contentHash),
+                                           memory_sync::EraseReadinessProbe::MetadataAbsent}};
+        return memorySync_->stageErases(requests);
+    }
+
+    // Content bytes are independently addressable by hash, so standard deletion requires two
+    // durable intents. Reserve both bounded outbox slots before exposing either to the drainer.
+    const std::array requests{
+        memory_sync::EraseStageRequest{blobKey, std::string(contentHash),
+                                       memory_sync::EraseReadinessProbe::ContentAbsent},
+        memory_sync::EraseStageRequest{documentKey, std::string(contentHash), probe}};
+    return memorySync_->stageErases(requests);
 }
 
-Result<void> ServiceManager::publishMemorySyncDocumentDelete(std::string_view contentHash) {
+Result<void> ServiceManager::publishMemorySyncDocumentDelete(std::string_view contentHash,
+                                                             bool retainContent) {
     if (!memorySync_) {
         return {};
     }
-    const std::string key =
+    std::lock_guard<std::mutex> deleteLock(memorySyncDeleteOutboxMutex_);
+    notifyMemorySyncDeleteOutboxStage("delete_publish_locked");
+    const std::string documentKey =
         std::string(memory_sync::memoryStoreName(memory_sync::MemoryStore::Document)) + "/" +
+        std::string(contentHash);
+    const std::string blobKey =
+        std::string(memory_sync::memoryStoreName(memory_sync::MemoryStore::ContentBlob)) + "/" +
         std::string(contentHash);
     auto intents = memorySync_->pendingErases();
     if (!intents) {
         return intents.error();
     }
-    const auto intent = std::ranges::find_if(
-        intents.value(), [&](const auto& candidate) { return candidate.logicalKey == key; });
-    if (intent != intents.value().end()) {
+
+    bool found = false;
+    const std::vector<std::string> keys = retainContent
+                                              ? std::vector<std::string>{documentKey}
+                                              : std::vector<std::string>{blobKey, documentKey};
+    for (const auto& key : keys) {
+        const auto intent = std::ranges::find_if(
+            intents.value(), [&](const auto& candidate) { return candidate.logicalKey == key; });
+        if (intent == intents.value().end()) {
+            continue;
+        }
+        found = true;
         const auto probe = intent->readinessProbe;
-        return memorySync_->publishStagedErase(
-            key, [this, contentHash = std::string(contentHash), probe] {
-                return memorySyncDeleteLocallyAbsent(contentHash, probe);
-            });
+        if (auto published = memorySync_->publishStagedErase(
+                key, [this, contentHash = std::string(contentHash),
+                      probe] { return memorySyncDeleteLocallyAbsent(contentHash, probe); });
+            !published) {
+            if (published.error().code == ErrorCode::NotFound) {
+                auto refreshed = memorySync_->pendingErases();
+                if (!refreshed) {
+                    return refreshed.error();
+                }
+                const bool stillPending =
+                    std::ranges::any_of(refreshed.value(), [&](const auto& candidate) {
+                        return candidate.logicalKey == key;
+                    });
+                if (!stillPending && memorySync_->hasCommittedTombstone(key)) {
+                    continue;
+                }
+            }
+            return published.error();
+        }
     }
-    return Error{ErrorCode::NotFound, "replicated deletion was not durably staged"};
+    if (!found) {
+        if (memorySync_->hasCommittedTombstone(documentKey) &&
+            (retainContent || memorySync_->hasCommittedTombstone(blobKey))) {
+            return {};
+        }
+        return Error{ErrorCode::NotFound, "replicated deletion was not durably staged"};
+    }
+    return {};
 }
 
 Result<std::size_t> ServiceManager::applyMemorySyncContentBlobs() {
@@ -2421,6 +2478,22 @@ void ServiceManager::notifyMemorySyncStage(std::string_view stage) noexcept {
     }
 }
 
+void ServiceManager::notifyMemorySyncDeleteOutboxStage(std::string_view stage) noexcept {
+    std::function<void(std::string_view)> observer;
+    {
+        std::lock_guard<std::mutex> lock(memorySyncDeleteOutboxObserverMutex_);
+        observer = memorySyncDeleteOutboxObserver_;
+    }
+    if (!observer) {
+        return;
+    }
+    try {
+        observer(stage);
+    } catch (...) {
+        spdlog::warn("[ServiceManager] memory_sync delete outbox observer threw at {}", stage);
+    }
+}
+
 Result<bool>
 ServiceManager::memorySyncDeleteLocallyAbsent(std::string_view contentHash,
                                               memory_sync::EraseReadinessProbe probe) const {
@@ -2452,14 +2525,18 @@ ServiceManager::memorySyncDeleteLocallyAbsent(std::string_view contentHash,
 
 bool ServiceManager::drainMemorySyncDocumentDeleteOutbox() noexcept {
     try {
+        notifyMemorySyncDeleteOutboxStage("delete_drain_waiting");
+        std::lock_guard<std::mutex> deleteLock(memorySyncDeleteOutboxMutex_);
         auto intents = memorySync_->pendingErases();
         if (!intents) {
             spdlog::warn("[ServiceManager] memory_sync delete outbox scan failed: {}",
                          intents.error().message);
             return true;
         }
-        const std::string prefix =
+        const std::string documentPrefix =
             std::string(memory_sync::memoryStoreName(memory_sync::MemoryStore::Document)) + "/";
+        const std::string blobPrefix =
+            std::string(memory_sync::memoryStoreName(memory_sync::MemoryStore::ContentBlob)) + "/";
         auto pending = std::move(intents.value());
         std::ranges::sort(pending, [](const auto& lhs, const auto& rhs) {
             const auto lhsCounter =
@@ -2468,11 +2545,17 @@ bool ServiceManager::drainMemorySyncDocumentDeleteOutbox() noexcept {
                 rhs.prepared ? rhs.preparedCounter : std::numeric_limits<std::uint64_t>::max();
             return std::tuple{lhsCounter, lhs.logicalKey} < std::tuple{rhsCounter, rhs.logicalKey};
         });
+        const auto validDocumentIntent = [&](const auto& intent) {
+            return intent.logicalKey == documentPrefix + intent.tombstonePayload;
+        };
+        const auto validBlobIntent = [&](const auto& intent) {
+            return intent.logicalKey == blobPrefix + intent.tombstonePayload;
+        };
+
         bool eligible = false;
         for (const auto& intent : pending) {
-            if (!intent.logicalKey.starts_with(prefix) ||
-                !memory_sync::isSha256Digest(intent.tombstonePayload) ||
-                intent.logicalKey != prefix + intent.tombstonePayload) {
+            if (!memory_sync::isSha256Digest(intent.tombstonePayload) ||
+                (!validDocumentIntent(intent) && !validBlobIntent(intent))) {
                 continue;
             }
             auto absent =
@@ -2494,7 +2577,11 @@ bool ServiceManager::drainMemorySyncDocumentDeleteOutbox() noexcept {
                 continue;
             }
             eligible = true;
-            if (auto published = publishMemorySyncDocumentDelete(intent.tombstonePayload);
+            if (auto published = memorySync_->publishStagedErase(
+                    intent.logicalKey,
+                    [this, contentHash = intent.tombstonePayload, probe = intent.readinessProbe] {
+                        return memorySyncDeleteLocallyAbsent(contentHash, probe);
+                    });
                 !published) {
                 spdlog::warn("[ServiceManager] memory_sync delete outbox retry failed: {}",
                              published.error().message);

--- a/src/daemon/components/dispatcher/request_dispatcher_documents.cpp
+++ b/src/daemon/components/dispatcher/request_dispatcher_documents.cpp
@@ -1390,8 +1390,9 @@ boost::asio::awaitable<Response> RequestDispatcher::handleDeleteRequest(const De
             serviceReq.recursive = req.recursive;
             serviceReq.verbose = req.verbose;
             if (!req.dryRun) {
-                serviceReq.beforeDelete = [manager = serviceManager_](std::string_view hash) {
-                    return manager->stageMemorySyncDocumentDelete(hash);
+                serviceReq.beforeDelete = [manager = serviceManager_,
+                                           retainContent = req.keepRefs](std::string_view hash) {
+                    return manager->stageMemorySyncDocumentDelete(hash, retainContent);
                 };
             }
             if (!req.directory.empty()) {
@@ -1457,9 +1458,11 @@ boost::asio::awaitable<Response> RequestDispatcher::handleDeleteRequest(const De
             if (!replicatedDeletes.empty()) {
                 auto published = co_await yams::daemon::dispatch::offload_to_worker(
                     serviceManager_,
-                    [manager = serviceManager_, hashes = std::move(replicatedDeletes)] {
+                    [manager = serviceManager_, hashes = std::move(replicatedDeletes),
+                     retainContent = req.keepRefs] {
                         for (const auto& hash : hashes) {
-                            if (auto result = manager->publishMemorySyncDocumentDelete(hash);
+                            if (auto result =
+                                    manager->publishMemorySyncDocumentDelete(hash, retainContent);
                                 !result) {
                                 return result;
                             }

--- a/tests/integration/daemon/memory_sync_service_integration_test.cpp
+++ b/tests/integration/daemon/memory_sync_service_integration_test.cpp
@@ -5,10 +5,12 @@
 #include <nlohmann/json.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <memory>
 #include <optional>
 #include <sstream>
@@ -18,13 +20,16 @@
 
 #include <yams/api/content_store.h>
 #include <yams/crypto/hasher.h>
+#include <yams/daemon/client/daemon_client.h>
 #include <yams/daemon/components/ServiceManager.h>
+#include <yams/daemon/ipc/ipc_protocol.h>
 #include <yams/memory_sync/memory_sync_service.h>
 #include <yams/memory_sync/records.h>
 #include <yams/metadata/knowledge_graph_store.h>
 #include <yams/metadata/metadata_repository.h>
 #include <yams/storage/storage_backend.h>
 
+#include "test_async_helpers.h"
 #include "test_daemon_harness.h"
 
 using namespace std::chrono_literals;
@@ -425,6 +430,233 @@ sync_interval_ms = 25
     REQUIRE(serviceManager->deleteMemorySync("user-delete").has_value());
     REQUIRE(peer.syncOnce().has_value());
     CHECK_FALSE(peer.readCached("user/user-delete").has_value());
+
+    harness.stop();
+    CHECK(harness.shutdownSucceeded());
+}
+
+TEST_CASE("Production document deletion also replicates content-byte deletion",
+          "[integration][daemon][memory-sync][deletion]") {
+    auto options = makeMemorySyncHarnessOptions("123e4567-e89b-42d3-a456-426614174020",
+                                                "delete-integrity-corpus");
+    yams::test::DaemonHarness harness{std::move(options)};
+    REQUIRE(harness.start(30s));
+
+    auto* serviceManager = harness.daemon()->getServiceManager();
+    REQUIRE(serviceManager != nullptr);
+    auto* daemonSync = serviceManager->testingMemorySyncService();
+    REQUIRE(daemonSync != nullptr);
+    auto contentStore = serviceManager->getContentStore();
+    REQUIRE(contentStore != nullptr);
+    auto repository = serviceManager->getMetadataRepo();
+    REQUIRE(repository != nullptr);
+
+    const auto payload = bytes("production-delete-content");
+    auto stored = contentStore->storeBytes(payload);
+    REQUIRE(stored.has_value());
+    const auto& hash = stored.value().contentHash;
+
+    yams::metadata::BatchDocumentInsert insert;
+    insert.info.filePath = "/local/corpus/delete-me.md";
+    insert.info.fileName = "delete-me.md";
+    insert.info.fileExtension = ".md";
+    insert.info.fileSize = static_cast<std::int64_t>(payload.size());
+    insert.info.sha256Hash = hash;
+    insert.info.mimeType = "text/markdown";
+    std::vector<yams::metadata::BatchDocumentInsert> inserts;
+    inserts.push_back(std::move(insert));
+    REQUIRE(repository->batchInsertDocumentsWithMetadata(inserts).has_value());
+
+    yams::memory_sync::MetadataDocumentRecord record;
+    record.documentId = hash;
+    record.contentHash = hash;
+    record.filePath = "/local/corpus/delete-me.md";
+    record.fileName = "delete-me.md";
+    record.fileExtension = ".md";
+    record.fileSize = static_cast<std::int64_t>(payload.size());
+    record.mimeType = "text/markdown";
+    const std::string documentKey = "document/" + hash;
+    const std::string blobKey = "content-blob/" + hash;
+    const auto serialized = nlohmann::json(record).dump();
+    REQUIRE(daemonSync->publish(documentKey, bytes(serialized)).has_value());
+    REQUIRE(daemonSync->publish(blobKey, payload).has_value());
+
+    yams::memory_sync::MemorySyncService peer{
+        makeFilesystemBackend(harness.dataDir() / "shared-memory"),
+        yams::memory_sync::MemorySyncConfig{"delete-peer", 60'000, "delete-integrity-corpus", 1}};
+    REQUIRE(peer.syncOnce().has_value());
+    REQUIRE(peer.readCached(documentKey).has_value());
+    REQUIRE(peer.readCached(blobKey).has_value());
+
+    // Exercise the real IPC dispatcher, including its pre-delete staging and post-delete
+    // publication hooks.
+    yams::daemon::ClientConfig clientConfig;
+    clientConfig.socketPath = harness.socketPath();
+    clientConfig.connectTimeout = 5s;
+    clientConfig.requestTimeout = 10s;
+    clientConfig.autoStart = false;
+    yams::daemon::DaemonClient client{clientConfig};
+    REQUIRE(yams::cli::run_sync(client.connect(), 5s).has_value());
+    yams::daemon::DeleteRequest deleteRequest;
+    deleteRequest.hash = hash;
+    const auto writerCounterBeforeDelete =
+        peer.currentVersion().get("123e4567-e89b-42d3-a456-426614174020");
+    std::promise<void> publisherLockedPromise;
+    auto publisherLocked = publisherLockedPromise.get_future();
+    std::promise<void> drainerWaitingPromise;
+    auto drainerWaiting = drainerWaitingPromise.get_future();
+    std::promise<void> releasePublisherPromise;
+    auto releasePublisher = releasePublisherPromise.get_future().share();
+    std::atomic<bool> publisherSignalled{false};
+    std::atomic<bool> drainerSignalled{false};
+    serviceManager->testingSetMemorySyncDeleteOutboxObserver([&](std::string_view stage) {
+        if (stage == "delete_publish_locked" && !publisherSignalled.exchange(true)) {
+            publisherLockedPromise.set_value();
+            releasePublisher.wait();
+        } else if (stage == "delete_drain_waiting" && !drainerSignalled.exchange(true)) {
+            drainerWaitingPromise.set_value();
+        }
+    });
+    auto deleteCall = std::async(std::launch::async, [&] {
+        return yams::cli::run_sync(client.call<yams::daemon::DeleteRequest>(deleteRequest), 10s);
+    });
+    const auto publisherStatus = publisherLocked.wait_for(5s);
+    if (publisherStatus != std::future_status::ready) {
+        releasePublisherPromise.set_value();
+        FAIL("delete publisher did not reach the serialized outbox section");
+    }
+    auto competingDrainer = std::async(
+        std::launch::async, [serviceManager] { serviceManager->testingApplyMemorySyncWinners(); });
+    const auto drainerStatus = drainerWaiting.wait_for(5s);
+    releasePublisherPromise.set_value();
+    REQUIRE(drainerStatus == std::future_status::ready);
+    auto deleted = deleteCall.get();
+    competingDrainer.get();
+    serviceManager->testingSetMemorySyncDeleteOutboxObserver({});
+    REQUIRE(deleted.has_value());
+    CHECK(deleted.value().successCount == 1);
+    auto pendingErases = daemonSync->pendingErases();
+    REQUIRE(pendingErases.has_value());
+    CHECK(pendingErases.value().empty());
+    auto firstPublisher = std::async(std::launch::async, [serviceManager, hash] {
+        return serviceManager->publishMemorySyncDocumentDelete(hash);
+    });
+    auto secondPublisher = std::async(std::launch::async, [serviceManager, hash] {
+        return serviceManager->publishMemorySyncDocumentDelete(hash);
+    });
+    CHECK(firstPublisher.get().has_value());
+    CHECK(secondPublisher.get().has_value());
+
+    REQUIRE(peer.syncOnce().has_value());
+    CHECK_FALSE(peer.readCached(documentKey).has_value());
+    CHECK_FALSE(peer.readCached(blobKey).has_value());
+    CHECK(peer.currentVersion().get("123e4567-e89b-42d3-a456-426614174020") ==
+          writerCounterBeforeDelete + 2);
+
+    // --keep-refs carries its retain-content mode through durable staging and publication. Its
+    // document-only completion remains idempotent without inventing a content tombstone.
+    const auto retainedPayload = bytes("retained-production-content");
+    auto retainedStored = contentStore->storeBytes(retainedPayload);
+    REQUIRE(retainedStored.has_value());
+    const auto& retainedHash = retainedStored.value().contentHash;
+    yams::metadata::BatchDocumentInsert retainedInsert;
+    retainedInsert.info.filePath = "/local/corpus/retained.md";
+    retainedInsert.info.fileName = "retained.md";
+    retainedInsert.info.fileExtension = ".md";
+    retainedInsert.info.fileSize = static_cast<std::int64_t>(retainedPayload.size());
+    retainedInsert.info.sha256Hash = retainedHash;
+    retainedInsert.info.mimeType = "text/markdown";
+    std::vector<yams::metadata::BatchDocumentInsert> retainedInserts;
+    retainedInserts.push_back(std::move(retainedInsert));
+    REQUIRE(repository->batchInsertDocumentsWithMetadata(retainedInserts).has_value());
+
+    record.documentId = retainedHash;
+    record.contentHash = retainedHash;
+    record.filePath = "/local/corpus/retained.md";
+    record.fileName = "retained.md";
+    record.fileSize = static_cast<std::int64_t>(retainedPayload.size());
+    const std::string retainedDocumentKey = "document/" + retainedHash;
+    const std::string retainedBlobKey = "content-blob/" + retainedHash;
+    REQUIRE(
+        daemonSync->publish(retainedDocumentKey, bytes(nlohmann::json(record).dump())).has_value());
+    REQUIRE(daemonSync->publish(retainedBlobKey, retainedPayload).has_value());
+    REQUIRE(peer.syncOnce().has_value());
+    const auto writerCounterBeforeRetainedDelete =
+        peer.currentVersion().get("123e4567-e89b-42d3-a456-426614174020");
+
+    yams::daemon::DeleteRequest retainDeleteRequest;
+    retainDeleteRequest.hash = retainedHash;
+    retainDeleteRequest.keepRefs = true;
+    auto retainedDelete =
+        yams::cli::run_sync(client.call<yams::daemon::DeleteRequest>(retainDeleteRequest), 10s);
+    REQUIRE(retainedDelete.has_value());
+    CHECK(retainedDelete.value().successCount == 1);
+    auto retainedLocally = contentStore->exists(retainedHash);
+    REQUIRE(retainedLocally.has_value());
+    CHECK(retainedLocally.value());
+    REQUIRE(serviceManager->publishMemorySyncDocumentDelete(retainedHash, true).has_value());
+    REQUIRE(peer.syncOnce().has_value());
+    CHECK_FALSE(peer.readCached(retainedDocumentKey).has_value());
+    CHECK(peer.readCached(retainedBlobKey).has_value());
+    CHECK(peer.currentVersion().get("123e4567-e89b-42d3-a456-426614174020") ==
+          writerCounterBeforeRetainedDelete + 1);
+
+    // If local deletion is interrupted after removing bytes but before removing metadata, drain
+    // only the ready blob tombstone. The document intent must survive for a later metadata repair.
+    const auto interruptedPayload = bytes("interrupted-production-delete");
+    auto interruptedStored = contentStore->storeBytes(interruptedPayload);
+    REQUIRE(interruptedStored.has_value());
+    const auto& interruptedHash = interruptedStored.value().contentHash;
+    yams::metadata::BatchDocumentInsert interruptedInsert;
+    interruptedInsert.info.filePath = "/local/corpus/interrupted.md";
+    interruptedInsert.info.fileName = "interrupted.md";
+    interruptedInsert.info.fileExtension = ".md";
+    interruptedInsert.info.fileSize = static_cast<std::int64_t>(interruptedPayload.size());
+    interruptedInsert.info.sha256Hash = interruptedHash;
+    interruptedInsert.info.mimeType = "text/markdown";
+    std::vector<yams::metadata::BatchDocumentInsert> interruptedInserts;
+    interruptedInserts.push_back(std::move(interruptedInsert));
+    REQUIRE(repository->batchInsertDocumentsWithMetadata(interruptedInserts).has_value());
+
+    record.documentId = interruptedHash;
+    record.contentHash = interruptedHash;
+    record.filePath = "/local/corpus/interrupted.md";
+    record.fileName = "interrupted.md";
+    record.fileSize = static_cast<std::int64_t>(interruptedPayload.size());
+    const std::string interruptedDocumentKey = "document/" + interruptedHash;
+    const std::string interruptedBlobKey = "content-blob/" + interruptedHash;
+    REQUIRE(daemonSync->publish(interruptedDocumentKey, bytes(nlohmann::json(record).dump()))
+                .has_value());
+    REQUIRE(daemonSync->publish(interruptedBlobKey, interruptedPayload).has_value());
+    REQUIRE(peer.syncOnce().has_value());
+    REQUIRE(peer.readCached(interruptedDocumentKey).has_value());
+    REQUIRE(peer.readCached(interruptedBlobKey).has_value());
+
+    REQUIRE(serviceManager->stageMemorySyncDocumentDelete(interruptedHash).has_value());
+    auto removedBytes = contentStore->remove(interruptedHash);
+    REQUIRE(removedBytes.has_value());
+    REQUIRE(removedBytes.value());
+    serviceManager->testingApplyMemorySyncWinners();
+    REQUIRE(peer.syncOnce().has_value());
+    CHECK(peer.readCached(interruptedDocumentKey).has_value());
+    CHECK_FALSE(peer.readCached(interruptedBlobKey).has_value());
+    pendingErases = daemonSync->pendingErases();
+    REQUIRE(pendingErases.has_value());
+    CHECK(std::ranges::any_of(pendingErases.value(), [&](const auto& intent) {
+        return intent.logicalKey == interruptedDocumentKey;
+    }));
+    CHECK_FALSE(std::ranges::any_of(pendingErases.value(), [&](const auto& intent) {
+        return intent.logicalKey == interruptedBlobKey;
+    }));
+
+    auto interruptedDocument = repository->getDocumentByHash(interruptedHash);
+    REQUIRE(interruptedDocument.has_value());
+    REQUIRE(interruptedDocument.value().has_value());
+    REQUIRE(repository->deleteDocument(interruptedDocument.value()->id).has_value());
+    serviceManager->testingApplyMemorySyncWinners();
+    REQUIRE(peer.syncOnce().has_value());
+    CHECK_FALSE(peer.readCached(interruptedDocumentKey).has_value());
+    CHECK(daemonSync->pendingErases().value().empty());
 
     harness.stop();
     CHECK(harness.shutdownSucceeded());

--- a/tests/integration/daemon/meson.build
+++ b/tests/integration/daemon/meson.build
@@ -612,6 +612,14 @@ else
       timeout: 60,
       args: ['Daemon memory sync periodically converges and stops cleanly', '--allow-running-no-tests'],
     )
+    test('daemon_memory_sync_delete_integrity',
+      memory_sync_service_integration_exe,
+      suite: ['integration', 'daemon', 'catch2', 'memory-sync'],
+      env: _daemon_test_env,
+      is_parallel: false,
+      timeout: 60,
+      args: ['Production document deletion also replicates content-byte deletion', '--allow-running-no-tests'],
+    )
     test('daemon_memory_sync_apply_stop',
       memory_sync_service_integration_exe,
       suite: ['integration', 'daemon', 'catch2', 'memory-sync'],

--- a/tests/unit/daemon/daemon_metrics_status_test.cpp
+++ b/tests/unit/daemon/daemon_metrics_status_test.cpp
@@ -623,7 +623,7 @@ public:
                                                api::ProgressCallback) override {
         return ErrorCode::NotImplemented;
     }
-    Result<bool> exists(const std::string&) const override { return ErrorCode::NotImplemented; }
+    Result<bool> exists(const std::string& hash) const override { return blobs_.contains(hash); }
     Result<bool> remove(const std::string& hash) override {
         if (auto it = removeResults_.find(hash); it != removeResults_.end()) {
             return it->second;
@@ -2368,7 +2368,7 @@ TEST_CASE("RequestDispatcher: document handlers cover direct helper and error br
         CHECK(lifecycle.removedHashes().front() == successDoc.sha256Hash);
     }
 
-    SECTION("delete publishes a durable document tombstone") {
+    SECTION("delete publishes durable document and content tombstones") {
         auto repo = std::make_shared<StubPruneMetadataRepository>();
         auto store = std::make_shared<StubContentStore>();
         const std::string hash(64, 'a');
@@ -2399,9 +2399,11 @@ TEST_CASE("RequestDispatcher: document handlers cover direct helper and error br
         memory_sync::VersionVector empty;
         auto deltas = svc.testingMemorySyncService()->exportLocalDeltasAfter(empty, 4);
         REQUIRE(deltas.has_value());
-        REQUIRE(deltas.value().deltas.size() == 1);
-        CHECK(deltas.value().deltas.front().logicalKey == "document/" + hash);
-        CHECK(deltas.value().deltas.front().record.isTombstone());
+        REQUIRE(deltas.value().deltas.size() == 2);
+        CHECK(deltas.value().deltas[0].logicalKey == "content-blob/" + hash);
+        CHECK(deltas.value().deltas[0].record.isTombstone());
+        CHECK(deltas.value().deltas[1].logicalKey == "document/" + hash);
+        CHECK(deltas.value().deltas[1].record.isTombstone());
     }
 
     SECTION("delete reports missing content store") {

--- a/tests/unit/memory_sync/memory_sync_catch2_test.cpp
+++ b/tests/unit/memory_sync/memory_sync_catch2_test.cpp
@@ -3,6 +3,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
 #include <cstring>
 #include <filesystem>
 #include <set>
@@ -560,6 +561,39 @@ TEST_CASE("erase outbox retains an unready pre-delete intent across restart",
     CHECK_FALSE(pending.value().front().ready);
     REQUIRE(restarted.syncFully().has_value());
     CHECK_FALSE(restarted.hasMergedRecord("document/" + std::string(64, 'a')));
+}
+
+TEST_CASE("erase staging batches reserve bounded outbox capacity atomically",
+          "[memory-sync][tombstone][outbox][bounds]") {
+    BackendFixture fixture{"erase-outbox-batch-bounds"};
+    MemorySyncLimits limits;
+    limits.maxMergedKeys = 2;
+    MemorySyncLoop loop{fixture.backend, "writer", "local-test-corpus", 1, false, limits};
+    REQUIRE(loop.stageErase("user/existing", "existing", false).has_value());
+
+    const std::string hash(64, 'a');
+    const std::array batch{
+        EraseStageRequest{"content-blob/" + hash, hash, EraseReadinessProbe::ContentAbsent},
+        EraseStageRequest{"document/" + hash, hash, EraseReadinessProbe::MetadataAbsent}};
+    auto rejected = loop.stageErases(batch);
+    REQUIRE_FALSE(rejected.has_value());
+    CHECK(rejected.error().code == yams::ErrorCode::ResourceExhausted);
+
+    auto pending = loop.pendingErases();
+    REQUIRE(pending.has_value());
+    REQUIRE(pending.value().size() == 1);
+    CHECK(pending.value().front().logicalKey == "user/existing");
+
+    limits.maxMergedKeys = 3;
+    MemorySyncLoop expanded{fixture.backend, "writer", "local-test-corpus", 1, false, limits};
+    REQUIRE(expanded.stageErases(batch).has_value());
+    pending = expanded.pendingErases();
+    REQUIRE(pending.has_value());
+    CHECK(pending.value().size() == 3);
+    auto singleOverflow = expanded.stageErase("user/overflow", "overflow", false);
+    REQUIRE_FALSE(singleOverflow.has_value());
+    CHECK(singleOverflow.error().code == yams::ErrorCode::ResourceExhausted);
+    REQUIRE(expanded.pendingErases().value().size() == 3);
 }
 
 TEST_CASE("malformed erase outbox entries fail closed without deletion",


### PR DESCRIPTION
## Stack

- Parent: #68 (`fix/p2p-correctness-pr` → `experimental`)
- This draft targets `fix/p2p-correctness-pr` and must be reviewed/landed as part of that stack.
- Do not merge or deploy independently from the parent correctness series.

## Summary

Closes the deletion-integrity P1 disclosed on #68: a production document deletion previously published only `document/<hash>`, leaving `content-blob/<hash>` remotely retrievable by hash.

This layer now:

- durably reserves document and content-blob erase intents before local mutation;
- bounds both single and batch staging against the durable outbox limit;
- publishes the blob tombstone before the document tombstone;
- serializes request publication against restart/background draining;
- makes repeated publication idempotent from committed tombstone state;
- preserves unready document intent after an interrupted content-first deletion;
- carries `--keep-refs` as an explicit document-only deletion mode;
- keeps committed local tombstones visible without waiting for another reconciliation;
- registers the production deletion gate with Meson.

## AI disclosure

This change was developed with extensive AI assistance, including test design, implementation, and adversarial review. It has not yet received full human maintainer review.

No merge, deployment, production restart, remote corpus mutation, SourceHut push, force update, or promotion to `main` is part of this PR.
