### PR TITLE
fix(p2p): harden bootstrap trust

### DIFF
--- a/docs/p2p.md
+++ b/docs/p2p.md
@@ -16,6 +16,8 @@ corpus_id = "team-memory"
 corpus_epoch = 1
 mode = "persistent"
 allow_first_contact = false
+writer_auth_required = true
+writer_auth_manifest = "/absolute/path/to/writers.json"
 ```
 
 Requirements:
@@ -24,13 +26,54 @@ Requirements:
 - Use the same `corpus_id` and positive `corpus_epoch` on intended peers.
 - Keep the node ID and data directory across restarts.
 - Expose the listen port only on networks where the peer should reach it. YAMS encrypts and authenticates the session; the network itself need not be trusted.
-- The daemon creates an owner-only persistent Ed25519 identity under its data directory unless `identity_key` points to an existing key.
+- Direct transport requires a usable writer-authentication manifest bound to the same node, corpus, and epoch. The manifest must contain the local Ed25519 private key and every trusted writer public key needed to verify retained history and cold-bootstrap snapshots.
+- The manifest and trusted public-key files must be regular files owned by the daemon user and protected against group/other writes; Windows DACLs must be protected from inheritance and grant write authority only to that user. Public readability is allowed.
+- When `identity_key` is omitted, direct transport reuses the manifest's local private key for TLS identity. Otherwise the daemon creates or loads an owner-only persistent key; Unix group/other permissions and Windows ACL entries outside the file owner fail closed.
 
-Generate a node ID when needed:
+Generate a node ID and owner-only Ed25519 writer key when needed:
 
 ```bash
 uuidgen | tr '[:upper:]' '[:lower:]'
+openssl genpkey -algorithm ED25519 -out writer-private.pem
+openssl pkey -in writer-private.pem -pubout -out writer-public.pem
+chmod 600 writer-private.pem # Unix; use an owner-only ACL on Windows
+chmod go-w writer-public.pem # protect trust membership from writes
 ```
+
+Each node's manifest binds the local key and all operator-approved writer public keys to one corpus epoch:
+
+```json
+{
+  "schema_version": 1,
+  "corpus_id": "team-memory",
+  "corpus_epoch": 1,
+  "local_key": {
+    "writer_id": "123e4567-e89b-42d3-a456-426614174000",
+    "key_id": "node-a-v1",
+    "private_key_path": "writer-private.pem"
+  },
+  "trusted_writers": [
+    {
+      "writer_id": "123e4567-e89b-42d3-a456-426614174000",
+      "key_id": "node-a-v1",
+      "public_key_path": "writer-public.pem"
+    },
+    {
+      "writer_id": "223e4567-e89b-42d3-a456-426614174000",
+      "key_id": "node-b-v1",
+      "public_key_path": "peer-writer-public.pem"
+    }
+  ]
+}
+```
+
+Relative key paths resolve from the manifest directory. Distribute public keys and certificate pins through a separate trusted channel; never distribute the private key or rely on TOFU for cold bootstrap authority.
+
+### Upgrade from unsigned direct history
+
+Direct stores created before authenticated envelopes have unknown signing provenance and are not migrated silently. Startup fails closed if `data_dir/p2p/op-store` contains history without the matching `authenticated-store-v1.json` marker. Preserve that store for audit, configure and distribute new writer manifests, advance `corpus_epoch`, move the old `op-store` out of the active data directory, and bootstrap a fresh authenticated store. Do not copy or locally re-sign old envelopes into the new epoch.
+
+The trust-schema upgrade also invalidates every legacy `pinned_by_operator` bit because older `connect ?pin=` calls could set it without enrollment. Re-run `yams p2p enroll` for each verified peer; ordinary TOFU and connection pins remain non-authoritative.
 
 Restart both daemons after changing configuration, then confirm the compact status:
 
@@ -68,7 +111,7 @@ yams p2p peers --json
 yams p2p connect "host.example:9721?pin=<peer-sha256-spki-pin>&remember=false"
 ```
 
-Setting `allow_first_contact = true` explicitly restores legacy TOFU enrollment and emits a startup warning. It permits unsolicited peers to request enrollment and is not recommended for normal operation.
+Setting `allow_first_contact = true` explicitly restores legacy TOFU recognition and emits a startup warning. It permits unsolicited peers to persist a certificate pin, but that pin is not operator enrollment and can never authorize cold bootstrap. Promote the exact existing node/pin only with `yams p2p enroll` after verification through a separate trusted channel.
 
 Disconnect and disable automatic reconnect:
 
@@ -80,7 +123,7 @@ Direct protocol v4 is full mesh: with three nodes, connect every pair. Protocol 
 
 Inbound TCP handshakes use a bounded pre-authentication pool that is separate from the bounded mutually authenticated session pool, so a stalled unauthenticated TLS client cannot reserve an application-session slot. Both pools have hard implementation ceilings independent of caller configuration. TLS handshakes retain their own short deadline, while every accepted or initiated connection also receives one absolute transport I/O deadline shared by all later protocol frames; repeated small frames cannot extend it. Local handler work between I/O calls remains cooperative and must preserve its own operation bounds. Listener, session, and reconnect thread boundaries contain and report exceptions instead of terminating the daemon. Shutdown schedules socket cancellation on each connection's own I/O context before joining workers, avoiding concurrent TLS socket teardown.
 
-A durably empty enrolled node can cold-bootstrap from a previously operator-pinned peer. The peer sends a bounded snapshot of current winners at its exact handshake-frozen frontier, including original schema-v4 writer signatures and a detached witness signature over the complete snapshot root. The receiver requires exact corpus, epoch, frontier, commitment, key, payload-hash, aggregate-byte, and resident-state bounds before staging anything. A durable journal promotes the snapshot idempotently across restart; the journal signature is reverified before recovery. The installed commitments preserve causal continuation, so later traffic still requires the next contiguous writer counter and valid dependencies. Same-session TOFU, non-empty targets, quarantined source state, malformed signatures, and oversized snapshots fail closed.
+A durably empty enrolled node can cold-bootstrap only when both peers were explicitly operator-enrolled and usable writer authentication is configured. The peer sends a bounded snapshot of current winners at its exact handshake-frozen frontier, including original schema-v4 writer signatures and a detached witness signature over the complete snapshot root. The receiver requires exact corpus, epoch, frontier, commitment, key, payload-hash, aggregate-byte, and resident-state bounds before staging anything. A durable journal promotes the snapshot idempotently across restart; the journal signature is reverified before recovery. The installed commitments preserve causal continuation, so later traffic still requires the next contiguous writer counter and valid dependencies. Same-session TOFU, non-empty targets, quarantined source state, malformed signatures, and oversized snapshots fail closed.
 
 Local document deletion first writes a node/corpus-scoped durable outbox intent. If the daemon stops after local removal but before tombstone publication, restart probes the recorded metadata/content absence condition, prepares one exact signed tombstone envelope, and retries it idempotently. The outbox entry is removed only after the tombstone index and full-history commitment are durable; the tombstone itself remains retained until the configured replica acknowledgement policy permits collection.
 

--- a/include/yams/daemon/components/AsyncInitOrchestrator.h
+++ b/include/yams/daemon/components/AsyncInitOrchestrator.h
@@ -11,7 +11,9 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <future>
+#include <mutex>
 
 namespace yams::daemon {
 namespace detail {
@@ -55,8 +57,13 @@ public:
     /// Attempt to transition to "started". Returns false if another thread
     /// already started the async init.
     bool tryStart() {
+        std::lock_guard lock(futureMutex_);
         bool expected = false;
-        return started_.compare_exchange_strong(expected, true, std::memory_order_acq_rel);
+        if (!started_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+            return false;
+        }
+        futureInstallationComplete_ = false;
+        return true;
     }
 
     /// Attempt to transition to "metadata warmup started". Returns true if
@@ -66,41 +73,74 @@ public:
     }
 
     /// Stop-token passed to the async init coroutine.
-    detail::AsyncInitStopToken getStopToken() { return stopSource_.get_token(); }
+    detail::AsyncInitStopToken getStopToken() {
+        std::lock_guard lock(futureMutex_);
+        return stopSource_.get_token();
+    }
 
     /// Store the future returned by co_spawn.
-    void setFuture(std::future<void> fut) { future_ = std::move(fut); }
+    void setFuture(std::future<void> fut) {
+        {
+            std::lock_guard lock(futureMutex_);
+            future_ = std::move(fut);
+            futureInstallationComplete_ = true;
+        }
+        futureInstalled_.notify_all();
+    }
+
+    /// Complete a start attempt that exited before spawning a coroutine.
+    void markFutureNotExpected() {
+        {
+            std::lock_guard lock(futureMutex_);
+            futureInstallationComplete_ = true;
+        }
+        futureInstalled_.notify_all();
+    }
 
     /// Reset lifecycle state so the daemon can be re-initialized after a
     /// restart. Does not affect an in-flight future — callers must drain it
     /// first via requestStopAndWait().
-    void resetForRestart() { stopSource_ = detail::AsyncInitStopSource{}; }
+    void resetForRestart() {
+        std::lock_guard waitLock(waitMutex_);
+        std::lock_guard lock(futureMutex_);
+        stopSource_ = detail::AsyncInitStopSource{};
+        started_.store(false, std::memory_order_release);
+        metadataWarmupStarted_.store(false, std::memory_order_release);
+        futureInstallationComplete_ = true;
+    }
 
     /// Request cancellation and wait up to `timeout` for the coroutine to
     /// complete. Safe to call when no future has been stored.
     /// Returns true if the coroutine finished (or was never started),
     /// false if the wait timed out.
     bool requestStopAndWait(std::chrono::milliseconds timeout) {
-        if (stopSource_.stop_possible()) {
-            stopSource_.request_stop();
+        std::lock_guard waitLock(waitMutex_);
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        std::future<void> future;
+        {
+            std::unique_lock lock(futureMutex_);
+            if (stopSource_.stop_possible()) {
+                stopSource_.request_stop();
+            }
+            if (!futureInstalled_.wait_until(lock, deadline,
+                                             [this] { return futureInstallationComplete_; })) {
+                return false;
+            }
+            if (!future_.valid()) {
+                return true;
+            }
+            future = std::move(future_);
         }
-        if (!future_.valid()) {
-            return true;
-        }
-        auto status = future_.wait_for(timeout);
-        if (status == std::future_status::timeout) {
+        if (future.wait_until(deadline) == std::future_status::timeout) {
+            std::lock_guard lock(futureMutex_);
+            future_ = std::move(future);
             return false;
         }
         try {
-            future_.get();
-        } catch (const std::exception&) {
-            future_ = std::future<void>();
-            return true;
+            future.get();
         } catch (...) {
-            future_ = std::future<void>();
-            return true;
+            // Async initialization failures are surfaced through service state.
         }
-        future_ = std::future<void>();
         return true;
     }
 
@@ -108,7 +148,11 @@ private:
     std::atomic<bool> started_{false};
     std::atomic<bool> metadataWarmupStarted_{false};
     detail::AsyncInitStopSource stopSource_;
+    std::mutex waitMutex_;
+    std::mutex futureMutex_;
+    std::condition_variable futureInstalled_;
     std::future<void> future_;
+    bool futureInstallationComplete_{true};
 };
 
 } // namespace yams::daemon

--- a/include/yams/daemon/components/ServiceManager.h
+++ b/include/yams/daemon/components/ServiceManager.h
@@ -729,6 +729,11 @@ public:
 #endif
 
 #if YAMS_DAEMON_TEST_HOOKS_ENABLED
+    YAMS_DAEMON_TEST_HOOK static Result<std::string>
+    __test_loadOrCreateP2pPrivateKey(const std::filesystem::path& keyPath);
+    YAMS_DAEMON_TEST_HOOK static Result<void>
+    __test_writeProtectedP2pPrivateKey(const std::filesystem::path& keyPath,
+                                       std::string_view contents);
     YAMS_DAEMON_TEST_HOOK void __test_setModelProviderDegraded(bool degraded,
                                                                const std::string& error = {});
 #endif

--- a/include/yams/daemon/p2p/p2p_protocol.h
+++ b/include/yams/daemon/p2p/p2p_protocol.h
@@ -30,6 +30,7 @@ inline constexpr std::size_t kMaxP2pWriterWindowBytes = std::size_t{64} * 1024 *
 
 struct PeerTrustDecision {
     bool firstContactPinned{false};
+    bool pinnedByOperator{false};
 };
 
 /// Validate and lowercase a SHA-256 SPKI pin for stable storage/comparison.
@@ -55,11 +56,14 @@ class InMemoryPeerTrustStore final : public IPeerTrustStore {
 public:
     Result<PeerTrustDecision> verifyOrPin(std::string_view nodeId, std::string_view spkiPin,
                                           bool allowFirstContact) override;
+    /// Test/in-process equivalent of explicit operator enrollment.
+    Result<void> enrollOperatorPeer(std::string_view nodeId, std::string_view spkiPin);
     [[nodiscard]] std::optional<std::string> pinnedPin(std::string_view nodeId) const override;
 
 private:
     mutable std::mutex mutex_;
     std::map<std::string, std::string> pins_;
+    std::set<std::string> operatorPinnedNodes_;
 };
 
 struct PeerHandshakeConfig {
@@ -96,6 +100,7 @@ struct PeerHandshakeResult {
     bool peerPrefixVerified{false};
     bool peerPrefixMatches{false};
     bool firstContactPinned{false};
+    bool pinnedByOperator{false};
 
     [[nodiscard]] std::uint64_t peerWatermark(std::string_view writerId) const;
 };

--- a/include/yams/daemon/p2p/peer_registry.h
+++ b/include/yams/daemon/p2p/peer_registry.h
@@ -56,7 +56,7 @@ public:
                                  std::uint64_t corpusEpoch,
                                  const memory_sync::VersionVector& lastSeenVersion,
                                  std::int64_t lastConnectedMs, std::string_view endpoint = {},
-                                 bool remembered = false, bool pinnedByOperator = false);
+                                 bool remembered = false);
     Result<std::vector<PeerRegistryRecord>> listPeers() const;
     Result<void> removePeer(std::string_view nodeId);
 
@@ -64,6 +64,7 @@ private:
     PeerRegistry(std::unique_ptr<metadata::Database> database, std::size_t maxPeers);
     Result<void> initializeSchema();
     Result<std::optional<std::string>> findPinLocked(std::string_view nodeId) const;
+    Result<bool> operatorPinnedLocked(std::string_view nodeId) const;
     Result<std::size_t> peerCountLocked() const;
 
     mutable std::mutex mutex_;

--- a/include/yams/memory_sync/memory_sync.h
+++ b/include/yams/memory_sync/memory_sync.h
@@ -134,11 +134,14 @@ public:
                    std::string corpusId = "local-test-corpus", std::uint64_t corpusEpoch = 1,
                    bool allowLegacyUnbound = false, MemorySyncLimits limits = {},
                    MemorySyncControl control = {}, TombstoneGcPolicy tombstoneGc = {},
-                   std::shared_ptr<const WriterAuthenticator> writerAuth = {})
+                   std::shared_ptr<const WriterAuthenticator> writerAuth = {},
+                   std::string controlScope = {})
         : backend_(&backend), nodeId_(std::move(nodeId)), corpusId_(std::move(corpusId)),
           corpusEpoch_(corpusEpoch), allowLegacyUnbound_(allowLegacyUnbound), limits_(limits),
           control_(std::move(control)), tombstoneGc_(std::move(tombstoneGc)),
-          writerAuth_(std::move(writerAuth)) {}
+          writerAuth_(std::move(writerAuth)),
+          controlScope_(controlScope.empty() ? corpusId_ + ":" + std::to_string(corpusEpoch_)
+                                             : std::move(controlScope)) {}
 
     /// Publish `content` under `logicalKey`. Stores the content-addressed blob and
     /// an index record stamped with this node's version vector and hybrid timestamp.
@@ -596,6 +599,11 @@ public:
                 quarantine(key, record.error().message);
                 continue;
             }
+            const bool authenticationRequired = writerAuth_ && writerAuth_->required();
+            if (authenticationRequired &&
+                record.value().schemaVersion != kAuthenticatedMemoryIndexSchemaVersion) {
+                legacyUnauthenticatedHistory_ = true;
+            }
             std::string candidateRecordHash = expectedRecordHash;
             if (record.value().schemaVersion < kMemoryIndexSchemaVersion) {
                 if (!allowLegacyUnbound_ || (writerAuth_ && writerAuth_->required())) {
@@ -631,7 +639,6 @@ public:
             }
             const bool authenticatedSchema =
                 record.value().schemaVersion == kAuthenticatedMemoryIndexSchemaVersion;
-            const bool authenticationRequired = writerAuth_ && writerAuth_->required();
             if ((authenticatedSchema || authenticationRequired) &&
                 (!writerAuth_ || !writerAuth_->verify(record.value()))) {
                 recordAuthFailure();
@@ -1441,6 +1448,10 @@ public:
         return quarantined_;
     }
 
+    [[nodiscard]] bool legacyUnauthenticatedHistoryObserved() const noexcept {
+        return legacyUnauthenticatedHistory_;
+    }
+
     /// Read only the last periodically reconciled winner. Daemon IPC uses this
     /// path so polling a peer cannot manufacture convergence by forcing sync.
     [[nodiscard]] Result<std::vector<std::byte>> readCached(std::string_view logicalKey) const {
@@ -1632,19 +1643,22 @@ private:
                                    {"counter", commitment.counter},
                                    {"digest", commitment.digest}});
         }
-        const auto encoded =
-            nlohmann::json{{"schema_version", 1},
-                           {"corpus_id", corpusId_},
-                           {"corpus_epoch", corpusEpoch_},
-                           {"witness", std::string(witness)},
-                           {"frontier", snapshot.frontier},
-                           {"commitments", std::move(commitments)},
-                           {"record_count", snapshot.winners.size()},
-                           {"root_digest", snapshot.rootDigest},
-                           {"witness_key_id", snapshot.witnessSignature.keyId},
-                           {"witness_algorithm", snapshot.witnessSignature.algorithm},
-                           {"witness_signature", snapshot.witnessSignature.signature}}
-                .dump();
+        auto artifact = nlohmann::json{{"schema_version", 1},
+                                       {"corpus_id", corpusId_},
+                                       {"corpus_epoch", corpusEpoch_},
+                                       {"witness", std::string(witness)},
+                                       {"frontier", snapshot.frontier},
+                                       {"commitments", std::move(commitments)},
+                                       {"record_count", snapshot.winners.size()},
+                                       {"root_digest", snapshot.rootDigest},
+                                       {"witness_key_id", snapshot.witnessSignature.keyId},
+                                       {"witness_algorithm", snapshot.witnessSignature.algorithm},
+                                       {"witness_signature", snapshot.witnessSignature.signature}};
+        if (auto signedArtifact = signControlArtifact(artifact, "cold-bootstrap-journal-v1");
+            !signedArtifact) {
+            return signedArtifact.error();
+        }
+        const auto encoded = artifact.dump();
         if (encoded.size() > limits_.maxEnvelopeBytes) {
             return Error{ErrorCode::ResourceExhausted,
                          "cold bootstrap journal exceeds envelope bound"};
@@ -1667,6 +1681,10 @@ private:
             const std::string_view text(reinterpret_cast<const char*>(encoded.value().data()),
                                         encoded.value().size());
             const auto json = nlohmann::json::parse(text);
+            if (auto authenticated = verifyControlArtifact(json, "cold-bootstrap-journal-v1");
+                !authenticated) {
+                return authenticated.error();
+            }
             if (!json.is_object() || json.at("schema_version").get<std::uint32_t>() != 1 ||
                 json.at("corpus_id").get<std::string>() != corpusId_ ||
                 json.at("corpus_epoch").get<std::uint64_t>() != corpusEpoch_ ||
@@ -2523,6 +2541,70 @@ private:
         return text;
     }
 
+    Result<void> signControlArtifact(nlohmann::json& artifact, std::string_view domain) const {
+        const bool required = writerAuth_ && writerAuth_->required();
+        artifact["authenticated_writers"] = required;
+        artifact["control_scope"] = controlScope_;
+        artifact.erase("control_signature");
+        if (!required) {
+            return {};
+        }
+        const auto canonical = artifact.dump();
+        const auto digest = hashContent(std::span<const std::byte>{
+            reinterpret_cast<const std::byte*>(canonical.data()), canonical.size()});
+        auto signature = writerAuth_->signDigest(domain, digest);
+        if (!signature) {
+            return signature.error();
+        }
+        artifact["control_signature"] = {{"writer_id", signature.value().writerId},
+                                         {"key_id", signature.value().keyId},
+                                         {"algorithm", signature.value().algorithm},
+                                         {"signature", signature.value().signature}};
+        return {};
+    }
+
+    Result<void> verifyControlArtifact(const nlohmann::json& artifact, std::string_view domain,
+                                       bool requireLocalSigner = true) const {
+        const bool required = writerAuth_ && writerAuth_->required();
+        if (artifact.value("authenticated_writers", false) != required) {
+            return Error{ErrorCode::InvalidData,
+                         "control artifact writer-authentication mode mismatch"};
+        }
+        if (!required) {
+            return {};
+        }
+        if (controlScope_.empty() ||
+            artifact.value("control_scope", std::string{}) != controlScope_) {
+            return Error{ErrorCode::InvalidData,
+                         "control artifact writer-authentication scope mismatch"};
+        }
+        try {
+            const auto& encoded = artifact.at("control_signature");
+            DetachedWriterSignature signature{
+                .writerId = encoded.at("writer_id").get<std::string>(),
+                .keyId = encoded.at("key_id").get<std::string>(),
+                .algorithm = encoded.at("algorithm").get<std::string>(),
+                .signature = encoded.at("signature").get<std::string>()};
+            if (requireLocalSigner && signature.writerId != nodeId_) {
+                return Error{ErrorCode::Unauthorized,
+                             "control artifact was not signed by the local writer"};
+            }
+            auto unsignedArtifact = artifact;
+            unsignedArtifact.erase("control_signature");
+            const auto canonical = unsignedArtifact.dump();
+            const auto digest = hashContent(std::span<const std::byte>{
+                reinterpret_cast<const std::byte*>(canonical.data()), canonical.size()});
+            if (!writerAuth_->verifyDigest(signature, domain, digest)) {
+                return Error{ErrorCode::Unauthorized,
+                             "control artifact writer signature is invalid"};
+            }
+            return {};
+        } catch (const std::exception& error) {
+            return Error{ErrorCode::InvalidData,
+                         std::string("control artifact signature is malformed: ") + error.what()};
+        }
+    }
+
     std::string historyEntryKey(std::string_view writerId, std::uint64_t counter) const {
         return "history/counter-v1/" + historyScopeHash(writerId) + "/" + paddedCounter(counter);
     }
@@ -2549,14 +2631,20 @@ private:
             const std::string_view text(reinterpret_cast<const char*>(encoded.value().data()),
                                         encoded.value().size());
             const auto json = nlohmann::json::parse(text);
+            if (auto authenticated = verifyControlArtifact(json, "history-entry-v1", false);
+                !authenticated) {
+                return authenticated.error();
+            }
             HistoryEntry entry{.writerId = json.at("writer_id").get<std::string>(),
                                .counter = json.at("counter").get<std::uint64_t>(),
                                .logicalKey = json.at("logical_key").get<std::string>(),
                                .recordHash = json.at("record_hash").get<std::string>(),
                                .prefixDigest = json.at("prefix_digest").get<std::string>()};
-            if (json.at("schema_version").get<std::uint32_t>() != 1 || entry.writerId != writerId ||
-                entry.counter != counter || !isSha256Digest(entry.recordHash) ||
-                !isSha256Digest(entry.prefixDigest) ||
+            if (json.at("schema_version").get<std::uint32_t>() != 1 ||
+                json.value("authenticated_writers", false) !=
+                    (writerAuth_ && writerAuth_->required()) ||
+                entry.writerId != writerId || entry.counter != counter ||
+                !isSha256Digest(entry.recordHash) || !isSha256Digest(entry.prefixDigest) ||
                 !validateLogicalKey(entry.logicalKey).has_value()) {
                 return Error{ErrorCode::InvalidData, "writer counter entry is inconsistent"};
             }
@@ -2600,12 +2688,15 @@ private:
             }
             return {};
         }
-        const auto json = nlohmann::json{{"schema_version", 1},
-                                         {"writer_id", expected.writerId},
-                                         {"counter", expected.counter},
-                                         {"logical_key", expected.logicalKey},
-                                         {"record_hash", expected.recordHash},
-                                         {"prefix_digest", expected.prefixDigest}};
+        auto json = nlohmann::json{{"schema_version", 1},
+                                   {"writer_id", expected.writerId},
+                                   {"counter", expected.counter},
+                                   {"logical_key", expected.logicalKey},
+                                   {"record_hash", expected.recordHash},
+                                   {"prefix_digest", expected.prefixDigest}};
+        if (auto signedArtifact = signControlArtifact(json, "history-entry-v1"); !signedArtifact) {
+            return signedArtifact.error();
+        }
         const auto text = json.dump();
         if (text.size() > limits_.maxEnvelopeBytes) {
             return Error{ErrorCode::ResourceExhausted,
@@ -2618,12 +2709,17 @@ private:
 
     Result<void> storeHistoryMigrationState(std::string_view writerId,
                                             const HistoryMigrationState& state) {
-        const auto json = nlohmann::json{{"schema_version", 1},
-                                         {"phase", state.phase},
-                                         {"cursor", state.cursor},
-                                         {"target_counter", state.targetCounter},
-                                         {"next_counter", state.nextCounter},
-                                         {"prefix_digest", state.prefixDigest}};
+        auto json = nlohmann::json{{"schema_version", 1},
+                                   {"writer_id", writerId},
+                                   {"phase", state.phase},
+                                   {"cursor", state.cursor},
+                                   {"target_counter", state.targetCounter},
+                                   {"next_counter", state.nextCounter},
+                                   {"prefix_digest", state.prefixDigest}};
+        if (auto signedArtifact = signControlArtifact(json, "history-migration-state-v1");
+            !signedArtifact) {
+            return signedArtifact.error();
+        }
         const auto encoded = json.dump();
         return backend_->store(
             historyMigrationStateKey(writerId),
@@ -2648,6 +2744,11 @@ private:
             const std::string_view text(reinterpret_cast<const char*>(encoded.value().data()),
                                         encoded.value().size());
             const auto json = nlohmann::json::parse(text);
+            if (auto authenticated =
+                    verifyControlArtifact(json, "history-migration-state-v1", false);
+                !authenticated) {
+                return authenticated.error();
+            }
             HistoryMigrationState state{
                 .phase = json.at("phase").get<std::string>(),
                 .cursor = json.at("cursor").get<std::string>(),
@@ -2655,6 +2756,9 @@ private:
                 .nextCounter = json.at("next_counter").get<std::uint64_t>(),
                 .prefixDigest = json.at("prefix_digest").get<std::string>()};
             if (json.at("schema_version").get<std::uint32_t>() != 1 ||
+                json.at("writer_id").get<std::string>() != writerId ||
+                json.value("authenticated_writers", false) !=
+                    (writerAuth_ && writerAuth_->required()) ||
                 (state.phase != "scan" && state.phase != "finalize") || state.targetCounter == 0 ||
                 state.nextCounter == 0 ||
                 (state.nextCounter > 1 && !isSha256Digest(state.prefixDigest))) {
@@ -2673,11 +2777,15 @@ private:
         if (!exists) {
             return exists.error();
         }
-        const auto json = nlohmann::json{{"schema_version", 1},
-                                         {"writer_id", candidate.writerId},
-                                         {"counter", candidate.counter},
-                                         {"logical_key", candidate.logicalKey},
-                                         {"record_hash", candidate.recordHash}};
+        auto json = nlohmann::json{{"schema_version", 1},
+                                   {"writer_id", candidate.writerId},
+                                   {"counter", candidate.counter},
+                                   {"logical_key", candidate.logicalKey},
+                                   {"record_hash", candidate.recordHash}};
+        if (auto signedArtifact = signControlArtifact(json, "history-migration-candidate-v1");
+            !signedArtifact) {
+            return signedArtifact.error();
+        }
         const auto encoded = json.dump();
         if (exists.value()) {
             auto prior = backend_->retrieve(key);
@@ -2712,11 +2820,18 @@ private:
             const std::string_view text(reinterpret_cast<const char*>(encoded.value().data()),
                                         encoded.value().size());
             const auto json = nlohmann::json::parse(text);
+            if (auto authenticated =
+                    verifyControlArtifact(json, "history-migration-candidate-v1", false);
+                !authenticated) {
+                return authenticated.error();
+            }
             HistoryEntry candidate{.writerId = json.at("writer_id").get<std::string>(),
                                    .counter = json.at("counter").get<std::uint64_t>(),
                                    .logicalKey = json.at("logical_key").get<std::string>(),
                                    .recordHash = json.at("record_hash").get<std::string>()};
             if (json.at("schema_version").get<std::uint32_t>() != 1 ||
+                json.value("authenticated_writers", false) !=
+                    (writerAuth_ && writerAuth_->required()) ||
                 candidate.writerId != writerId || candidate.counter != counter ||
                 !isSha256Digest(candidate.recordHash) ||
                 !validateLogicalKey(candidate.logicalKey).has_value()) {
@@ -2937,6 +3052,10 @@ private:
             const std::string_view text(reinterpret_cast<const char*>(encoded.value().data()),
                                         encoded.value().size());
             const auto json = nlohmann::json::parse(text);
+            if (auto authenticated = verifyControlArtifact(json, "replication-checkpoint-v1");
+                !authenticated) {
+                return authenticated.error();
+            }
             if (json.at("schema_version").get<std::uint32_t>() != 1 ||
                 json.at("corpus_id").get<std::string>() != corpusId_ ||
                 json.at("corpus_epoch").get<std::uint64_t>() != corpusEpoch_ ||
@@ -2995,13 +3114,16 @@ private:
                                       {"counter", commitment.counter},
                                       {"digest", commitment.digest}});
         }
-        const std::string encoded = nlohmann::json{
-            {"schema_version", 1},
-            {"corpus_id", corpusId_},
-            {"corpus_epoch", corpusEpoch_},
-            {"quarantined_writers", std::move(quarantineJson)},
-            {"commitments",
-             std::move(commitmentJson)}}.dump();
+        auto artifact = nlohmann::json{{"schema_version", 1},
+                                       {"corpus_id", corpusId_},
+                                       {"corpus_epoch", corpusEpoch_},
+                                       {"quarantined_writers", std::move(quarantineJson)},
+                                       {"commitments", std::move(commitmentJson)}};
+        if (auto signedArtifact = signControlArtifact(artifact, "replication-checkpoint-v1");
+            !signedArtifact) {
+            return signedArtifact.error();
+        }
+        const std::string encoded = artifact.dump();
         if (encoded.size() > limits_.maxEnvelopeBytes) {
             return Error{ErrorCode::ResourceExhausted,
                          "replication checkpoint exceeds envelope limit"};
@@ -3359,6 +3481,7 @@ private:
     MemorySyncControl control_;
     TombstoneGcPolicy tombstoneGc_;
     std::shared_ptr<const WriterAuthenticator> writerAuth_;
+    std::string controlScope_;
     VersionVector version_;
     std::uint64_t logicalClock_{0};
     std::map<std::string, MemoryIndexRecord> merged_;
@@ -3380,6 +3503,7 @@ private:
     bool recoveringColdBootstrap_{false};
     std::uint64_t durableQuarantineGeneration_{0};
     std::size_t authFailures_{0};
+    bool legacyUnauthenticatedHistory_{false};
 };
 
 } // namespace yams::memory_sync

--- a/include/yams/memory_sync/memory_sync_config.h
+++ b/include/yams/memory_sync/memory_sync_config.h
@@ -69,6 +69,7 @@ struct MemorySyncDaemonConfig {
     bool allowLegacyUnbound{false};         /// one-time schema-v2 migration gate
     bool writerAuthRequired{false};         /// require schema-v4 Ed25519 envelopes
     std::string writerAuthManifestPath;     /// ACL-protected corpus/epoch key manifest
+    std::string controlScope;               /// authenticated local-store generation
 
     /// Parse `memory_sync.*` keys from a flat `section.key -> value` map.
     static MemorySyncDaemonConfig fromToml(const std::map<std::string, std::string>& flat) {
@@ -200,8 +201,15 @@ inline Result<std::string> readWriterAuthFile(const std::filesystem::path& path,
     return content;
 }
 
+using WriterPrivateKeyReader =
+    std::function<Result<std::string>(const std::filesystem::path& path)>;
+using WriterTrustFileReader =
+    std::function<Result<std::string>(const std::filesystem::path& path, std::size_t maxBytes)>;
+
 inline Result<std::shared_ptr<const WriterAuthenticator>>
-loadWriterAuthenticator(const MemorySyncDaemonConfig& config) {
+loadWriterAuthenticator(const MemorySyncDaemonConfig& config,
+                        const WriterPrivateKeyReader& privateKeyReader = {},
+                        const WriterTrustFileReader& trustFileReader = {}) {
     if (!config.writerAuthRequired) {
         return std::shared_ptr<const WriterAuthenticator>{};
     }
@@ -215,7 +223,8 @@ loadWriterAuthenticator(const MemorySyncDaemonConfig& config) {
     }
 
     const std::filesystem::path manifestPath(config.writerAuthManifestPath);
-    auto manifestBytes = readWriterAuthFile(manifestPath);
+    auto manifestBytes = trustFileReader ? trustFileReader(manifestPath, std::size_t{1024} * 1024)
+                                         : readWriterAuthFile(manifestPath);
     if (!manifestBytes) {
         return manifestBytes.error();
     }
@@ -242,8 +251,10 @@ loadWriterAuthenticator(const MemorySyncDaemonConfig& config) {
         auth.required = true;
         auth.localWriterId = config.nodeId;
         auth.localKeyId = local.at("key_id").get<std::string>();
-        auto privatePem = readWriterAuthFile(
-            resolve(local.at("private_key_path").get<std::string>()), std::size_t{64} * 1024);
+        const auto privateKeyPath = resolve(local.at("private_key_path").get<std::string>());
+        auto privatePem = privateKeyReader
+                              ? privateKeyReader(privateKeyPath)
+                              : readWriterAuthFile(privateKeyPath, std::size_t{64} * 1024);
         if (!privatePem) {
             return privatePem.error();
         }
@@ -257,8 +268,10 @@ loadWriterAuthenticator(const MemorySyncDaemonConfig& config) {
         }
         auth.trustedKeys.reserve(trusted.size());
         for (const auto& entry : trusted) {
-            auto publicPem = readWriterAuthFile(
-                resolve(entry.at("public_key_path").get<std::string>()), std::size_t{64} * 1024);
+            const auto publicKeyPath = resolve(entry.at("public_key_path").get<std::string>());
+            auto publicPem = trustFileReader
+                                 ? trustFileReader(publicKeyPath, std::size_t{64} * 1024)
+                                 : readWriterAuthFile(publicKeyPath, std::size_t{64} * 1024);
             if (!publicPem) {
                 return publicPem.error();
             }
@@ -278,7 +291,9 @@ loadWriterAuthenticator(const MemorySyncDaemonConfig& config) {
 inline Result<std::unique_ptr<MemorySyncService>>
 createMemorySyncService(const MemorySyncDaemonConfig& config,
                         std::optional<storage::BackendConfig> resolvedS3Config = std::nullopt,
-                        std::function<bool()> canAdmitRemoteWork = {}) {
+                        std::function<bool()> canAdmitRemoteWork = {},
+                        WriterPrivateKeyReader privateKeyReader = {},
+                        WriterTrustFileReader trustFileReader = {}) {
     if (!config.enabled) {
         return Error{ErrorCode::InvalidState, "memory_sync is disabled"};
     }
@@ -292,7 +307,7 @@ createMemorySyncService(const MemorySyncDaemonConfig& config,
                      "memory_sync.corpus_id and positive corpus_epoch are required"};
     }
 
-    auto writerAuth = loadWriterAuthenticator(config);
+    auto writerAuth = loadWriterAuthenticator(config, privateKeyReader, trustFileReader);
     if (!writerAuth) {
         return writerAuth.error();
     }
@@ -433,7 +448,8 @@ createMemorySyncService(const MemorySyncDaemonConfig& config,
     return std::make_unique<MemorySyncService>(
         std::move(backend),
         MemorySyncConfig{config.nodeId, config.syncIntervalMs, config.corpusId, config.corpusEpoch,
-                         config.limits, temporary, std::move(writerAuth.value())},
+                         config.limits, temporary, std::move(writerAuth.value()),
+                         config.controlScope},
         std::move(canAdmitRemoteWork), config.allowLegacyUnbound,
         std::move(sessionMaintenanceBackend), std::move(sessionLeaseKey));
 }

--- a/include/yams/memory_sync/memory_sync_service.h
+++ b/include/yams/memory_sync/memory_sync_service.h
@@ -34,15 +34,17 @@ struct MemorySyncConfig {
     MemorySyncLimits limits{};
     bool cleanupOwnedNamespaceOnStop{false};
     std::shared_ptr<const WriterAuthenticator> writerAuth; /// optional schema-v4 signer/verifier
+    std::string controlScope;                              /// authenticated local-store generation
 
     MemorySyncConfig() = default;
     explicit MemorySyncConfig(std::string writerId, std::uint32_t intervalMs = 5000,
                               std::string corpus = "local-test-corpus", std::uint64_t epoch = 1,
                               MemorySyncLimits resourceLimits = {}, bool cleanupOwned = false,
-                              std::shared_ptr<const WriterAuthenticator> auth = {})
+                              std::shared_ptr<const WriterAuthenticator> auth = {},
+                              std::string authenticatedControlScope = {})
         : nodeId(std::move(writerId)), syncIntervalMs(intervalMs), corpusId(std::move(corpus)),
           corpusEpoch(epoch), limits(resourceLimits), cleanupOwnedNamespaceOnStop(cleanupOwned),
-          writerAuth(std::move(auth)) {}
+          writerAuth(std::move(auth)), controlScope(std::move(authenticatedControlScope)) {}
 };
 
 /// Daemon-facing service that runs the memory-sync loop periodically and exposes
@@ -63,7 +65,7 @@ public:
                 MemorySyncControl{
                     .isCancelled = [this] { return stop_.load(std::memory_order_acquire); },
                     .canAdmitRemoteWork = std::move(canAdmitRemoteWork)},
-                {}, config_.writerAuth) {}
+                {}, config_.writerAuth, config_.controlScope) {}
 
     ~MemorySyncService() { stop(); }
 
@@ -134,6 +136,21 @@ public:
 
     bool stopRequested() const noexcept { return stop_.load(std::memory_order_acquire); }
     [[nodiscard]] const std::string& localNodeId() const noexcept { return config_.nodeId; }
+    [[nodiscard]] bool writerAuthenticationReady() const noexcept {
+        return config_.writerAuth && config_.writerAuth->required();
+    }
+    [[nodiscard]] bool directP2pReady(std::string_view nodeId, std::string_view corpusId,
+                                      std::uint64_t corpusEpoch) const noexcept {
+        return writerAuthenticationReady() && !config_.controlScope.empty() &&
+               fullRecoveryCompleted_.load(std::memory_order_acquire) &&
+               !legacyUnauthenticatedHistory_.load(std::memory_order_acquire) &&
+               config_.nodeId == nodeId && config_.corpusId == corpusId &&
+               config_.corpusEpoch == corpusEpoch;
+    }
+    [[nodiscard]] bool legacyUnauthenticatedHistoryObserved() const {
+        std::lock_guard<std::mutex> lock(loopMutex_);
+        return loop_.legacyUnauthenticatedHistoryObserved();
+    }
 
     /// Called after a successful periodic reconciliation and after releasing loopMutex_.
     /// The callback may safely use this service's public read/sync methods.
@@ -346,6 +363,10 @@ public:
             std::lock_guard<std::mutex> lock(loopMutex_);
             const auto generation = loop_.durableQuarantineGeneration();
             result = loop_.sync();
+            if (loop_.legacyUnauthenticatedHistoryObserved()) {
+                legacyUnauthenticatedHistory_.store(true, std::memory_order_release);
+                fullRecoveryCompleted_.store(false, std::memory_order_release);
+            }
             quarantineChanged = generation != loop_.durableQuarantineGeneration();
             if (result || quarantineChanged) {
                 refreshCommittedState();
@@ -364,6 +385,10 @@ public:
             std::lock_guard<std::mutex> lock(loopMutex_);
             const auto generation = loop_.durableQuarantineGeneration();
             result = loop_.syncFully();
+            const bool legacyHistory = loop_.legacyUnauthenticatedHistoryObserved();
+            legacyUnauthenticatedHistory_.store(legacyHistory, std::memory_order_release);
+            fullRecoveryCompleted_.store(result.has_value() && !legacyHistory,
+                                         std::memory_order_release);
             quarantineChanged = generation != loop_.durableQuarantineGeneration();
             if (result || quarantineChanged) {
                 refreshCommittedState();
@@ -546,6 +571,10 @@ private:
                     snapshot = Error{ErrorCode::InternalError,
                                      "memory sync reconciliation threw an unknown exception"};
                 }
+                if (loop_.legacyUnauthenticatedHistoryObserved()) {
+                    legacyUnauthenticatedHistory_.store(true, std::memory_order_release);
+                    fullRecoveryCompleted_.store(false, std::memory_order_release);
+                }
                 quarantineChanged = generation != loop_.durableQuarantineGeneration();
                 if (snapshot || quarantineChanged) {
                     refreshCommittedState();
@@ -632,6 +661,8 @@ private:
     std::atomic<std::uint64_t> failedSyncCycles_{0};
     std::atomic<std::int64_t> lastSuccessfulSyncSteadyMs_{0};
     std::atomic<bool> namespaceCleaned_{false};
+    std::atomic<bool> fullRecoveryCompleted_{false};
+    std::atomic<bool> legacyUnauthenticatedHistory_{false};
     mutable std::mutex snapshotMutex_;
     std::shared_ptr<const MemorySyncLoop::CommittedState> committed_;
 };

--- a/src/daemon/components/ConfigResolver.cpp
+++ b/src/daemon/components/ConfigResolver.cpp
@@ -1770,6 +1770,10 @@ bool ConfigResolver::applyMemorySync(const ConfigSections& sections, DaemonConfi
         } else if (policy.listen.empty()) {
             spdlog::warn("Config: disabling direct memory_sync with empty listen address");
             policy.enabled = false;
+        } else if (!policy.writerAuthRequired || policy.writerAuthManifestPath.empty()) {
+            spdlog::warn("Config: disabling direct memory_sync; writer_auth_required=true and "
+                         "writer_auth_manifest are required for authenticated cold bootstrap");
+            policy.enabled = false;
         }
     } else if (policy.writerAuthRequired && policy.mode == "persistent-migration") {
         spdlog::warn("Config: disabling memory_sync; legacy migration cannot run with writer "

--- a/src/daemon/components/ServiceManager.cpp
+++ b/src/daemon/components/ServiceManager.cpp
@@ -24,17 +24,21 @@
 #include <string>
 #include <system_error>
 #include <unordered_map>
+#include <vector>
+#include <openssl/rand.h>
 #include <yams/common/fs_utils.h>
 #include <yams/config/config_helpers.h>
 #include <yams/config/config_migration.h>
 #include <yams/core/assert.hpp>
 
 #ifdef _WIN32
+#include <aclapi.h>
 #include <io.h>
 #include <windows.h>
 #define getpid _getpid
 #else
 #include <unistd.h>
+#include <sys/stat.h>
 #endif
 
 // Platform-specific malloc pressure relief for macOS
@@ -193,42 +197,303 @@ inline void setOnnxShutdownMarker(bool enabled) {
     onnxShutdownMarker().store(enabled, std::memory_order_release);
 }
 
-yams::Result<std::string> readProtectedP2pPrivateKey(const std::filesystem::path& keyPath) {
-#ifndef _WIN32
-    std::error_code error;
-    const auto linkStatus = std::filesystem::symlink_status(keyPath, error);
-    if (error) {
-        return yams::Error{yams::ErrorCode::IOError,
-                           "cannot inspect P2P identity key: " + error.message()};
+constexpr std::size_t kMaxP2pPrivateKeyBytes = std::size_t{64} * 1024;
+
+#ifdef _WIN32
+class WindowsTokenUser {
+public:
+    ~WindowsTokenUser() {
+        if (token_ != nullptr) {
+            CloseHandle(token_);
+        }
     }
-    if (std::filesystem::is_symlink(linkStatus)) {
+
+    WindowsTokenUser(const WindowsTokenUser&) = delete;
+    WindowsTokenUser& operator=(const WindowsTokenUser&) = delete;
+    WindowsTokenUser() = default;
+
+    yams::Result<void> initialize() {
+        if (!OpenThreadToken(GetCurrentThread(), TOKEN_QUERY, TRUE, &token_)) {
+            if (GetLastError() != ERROR_NO_TOKEN ||
+                !OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token_)) {
+                return yams::Error{yams::ErrorCode::IOError,
+                                   "cannot open effective token for P2P identity key ACL"};
+            }
+        }
+        DWORD bytes = 0;
+        GetTokenInformation(token_, TokenUser, nullptr, 0, &bytes);
+        if (bytes == 0 || GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+            return yams::Error{yams::ErrorCode::IOError,
+                               "cannot size effective SID for P2P identity key ACL"};
+        }
+        user_.resize(bytes);
+        if (!GetTokenInformation(token_, TokenUser, user_.data(), bytes, &bytes)) {
+            return yams::Error{yams::ErrorCode::IOError,
+                               "cannot read effective SID for P2P identity key ACL"};
+        }
+        return {};
+    }
+
+    PSID sid() const { return reinterpret_cast<const TOKEN_USER*>(user_.data())->User.Sid; }
+
+private:
+    HANDLE token_{nullptr};
+    std::vector<std::byte> user_;
+};
+
+class WindowsOwnerOnlySecurity {
+public:
+    ~WindowsOwnerOnlySecurity() {
+        if (acl_ != nullptr) {
+            LocalFree(acl_);
+        }
+    }
+
+    WindowsOwnerOnlySecurity(const WindowsOwnerOnlySecurity&) = delete;
+    WindowsOwnerOnlySecurity& operator=(const WindowsOwnerOnlySecurity&) = delete;
+    WindowsOwnerOnlySecurity() = default;
+
+    yams::Result<SECURITY_ATTRIBUTES*> initialize() {
+        if (auto initialized = user_.initialize(); !initialized) {
+            return initialized.error();
+        }
+        EXPLICIT_ACCESSW access{};
+        access.grfAccessPermissions = GENERIC_ALL;
+        access.grfAccessMode = SET_ACCESS;
+        access.grfInheritance = NO_INHERITANCE;
+        BuildTrusteeWithSidW(&access.Trustee, user_.sid());
+        const auto aclResult = SetEntriesInAclW(1, &access, nullptr, &acl_);
+        if (aclResult != ERROR_SUCCESS) {
+            return yams::Error{yams::ErrorCode::IOError,
+                               "cannot build owner-only P2P identity key ACL"};
+        }
+        if (!InitializeSecurityDescriptor(&descriptor_, SECURITY_DESCRIPTOR_REVISION) ||
+            !SetSecurityDescriptorOwner(&descriptor_, user_.sid(), FALSE) ||
+            !SetSecurityDescriptorDacl(&descriptor_, TRUE, acl_, FALSE) ||
+            !SetSecurityDescriptorControl(&descriptor_, SE_DACL_PROTECTED, SE_DACL_PROTECTED)) {
+            return yams::Error{yams::ErrorCode::IOError,
+                               "cannot initialize owner-only P2P identity key ACL"};
+        }
+        attributes_.nLength = sizeof(attributes_);
+        attributes_.lpSecurityDescriptor = &descriptor_;
+        attributes_.bInheritHandle = FALSE;
+        return &attributes_;
+    }
+
+private:
+    WindowsTokenUser user_;
+    PACL acl_{nullptr};
+    SECURITY_DESCRIPTOR descriptor_{};
+    SECURITY_ATTRIBUTES attributes_{};
+};
+
+class WindowsHandle {
+public:
+    explicit WindowsHandle(HANDLE handle) : handle_(handle) {}
+    ~WindowsHandle() {
+        if (handle_ != INVALID_HANDLE_VALUE) {
+            CloseHandle(handle_);
+        }
+    }
+    WindowsHandle(const WindowsHandle&) = delete;
+    WindowsHandle& operator=(const WindowsHandle&) = delete;
+    HANDLE get() const { return handle_; }
+
+private:
+    HANDLE handle_{INVALID_HANDLE_VALUE};
+};
+
+yams::Result<std::string> readProtectedP2pFile(const std::filesystem::path& keyPath,
+                                               bool ownerOnlyRead, std::size_t maxBytes) {
+    WindowsHandle file(CreateFileW(keyPath.c_str(), GENERIC_READ | READ_CONTROL, 0, nullptr,
+                                   OPEN_EXISTING,
+                                   FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr));
+    if (file.get() == INVALID_HANDLE_VALUE) {
+        return yams::Error{yams::ErrorCode::IOError, "cannot open P2P identity key"};
+    }
+    FILE_ATTRIBUTE_TAG_INFO attributes{};
+    if (!GetFileInformationByHandleEx(file.get(), FileAttributeTagInfo, &attributes,
+                                      sizeof(attributes)) ||
+        (attributes.FileAttributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT)) !=
+            0 ||
+        GetFileType(file.get()) != FILE_TYPE_DISK) {
         return yams::Error{yams::ErrorCode::Unauthorized,
-                           "P2P identity key must not be a symbolic link"};
+                           "P2P identity key must be a non-reparse regular file"};
     }
-    if (!std::filesystem::is_regular_file(linkStatus)) {
+
+    WindowsTokenUser expectedUser;
+    if (auto initialized = expectedUser.initialize(); !initialized) {
+        return initialized.error();
+    }
+    PSID owner = nullptr;
+    PACL dacl = nullptr;
+    PSECURITY_DESCRIPTOR rawDescriptor = nullptr;
+    const auto status = GetSecurityInfo(file.get(), SE_FILE_OBJECT,
+                                        OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+                                        &owner, nullptr, &dacl, nullptr, &rawDescriptor);
+    std::unique_ptr<void, decltype(&LocalFree)> descriptor(rawDescriptor, LocalFree);
+    if (status != ERROR_SUCCESS || owner == nullptr || dacl == nullptr ||
+        !EqualSid(owner, expectedUser.sid())) {
         return yams::Error{yams::ErrorCode::Unauthorized,
-                           "P2P identity key must be a regular file"};
+                           "P2P identity key must have an explicit effective-user-only ACL"};
     }
-    const auto permissions = linkStatus.permissions();
-    if (error) {
-        return yams::Error{yams::ErrorCode::IOError,
-                           "cannot inspect P2P identity key permissions: " + error.message()};
-    }
-    constexpr auto insecure =
-        std::filesystem::perms::group_all | std::filesystem::perms::others_all;
-    if ((permissions & insecure) != std::filesystem::perms::none) {
+    SECURITY_DESCRIPTOR_CONTROL control{};
+    DWORD revision = 0;
+    if (!GetSecurityDescriptorControl(rawDescriptor, &control, &revision) ||
+        (control & SE_DACL_PROTECTED) == 0) {
         return yams::Error{yams::ErrorCode::Unauthorized,
-                           "P2P identity key must not be accessible by group or others"};
+                           "P2P identity key ACL must be protected from inheritance"};
     }
+    ACL_SIZE_INFORMATION info{};
+    if (!GetAclInformation(dacl, &info, sizeof(info), AclSizeInformation)) {
+        return yams::Error{yams::ErrorCode::IOError, "cannot inspect P2P identity key ACL"};
+    }
+    bool ownerAllowed = false;
+    for (DWORD index = 0; index < info.AceCount; ++index) {
+        void* rawAce = nullptr;
+        if (!GetAce(dacl, index, &rawAce) || rawAce == nullptr) {
+            return yams::Error{yams::ErrorCode::IOError,
+                               "cannot inspect P2P identity key ACL entry"};
+        }
+        const auto* header = static_cast<const ACE_HEADER*>(rawAce);
+        if (header->AceType == ACCESS_ALLOWED_ACE_TYPE) {
+            constexpr std::size_t sidOffset = offsetof(ACCESS_ALLOWED_ACE, SidStart);
+            if (header->AceSize < sidOffset + sizeof(DWORD) ||
+                (header->AceFlags & INHERITED_ACE) != 0) {
+                return yams::Error{yams::ErrorCode::Unauthorized,
+                                   "P2P identity key ACL contains an unsafe allow entry"};
+            }
+            const auto* ace = static_cast<const ACCESS_ALLOWED_ACE*>(rawAce);
+            auto* sid = const_cast<DWORD*>(&ace->SidStart);
+            if (!IsValidSid(sid) || GetLengthSid(sid) > header->AceSize - sidOffset) {
+                return yams::Error{yams::ErrorCode::Unauthorized,
+                                   "P2P trust file ACL contains an invalid SID"};
+            }
+            const bool ownerSid = EqualSid(expectedUser.sid(), sid);
+            constexpr ACCESS_MASK readable =
+                GENERIC_ALL | GENERIC_READ | FILE_GENERIC_READ | FILE_READ_DATA | FILE_EXECUTE;
+            constexpr ACCESS_MASK writable = GENERIC_ALL | GENERIC_WRITE | FILE_GENERIC_WRITE |
+                                             FILE_WRITE_DATA | FILE_APPEND_DATA | FILE_WRITE_EA |
+                                             FILE_WRITE_ATTRIBUTES | FILE_DELETE_CHILD | DELETE |
+                                             WRITE_DAC | WRITE_OWNER;
+            if ((!ownerSid && ownerOnlyRead && ace->Mask != 0) ||
+                (!ownerSid && (ace->Mask & writable) != 0)) {
+                return yams::Error{yams::ErrorCode::Unauthorized,
+                                   "P2P trust file ACL grants unsafe external access"};
+            }
+            ownerAllowed = ownerAllowed || (ownerSid && (ace->Mask & readable) != 0);
+        } else if (header->AceType != ACCESS_DENIED_ACE_TYPE &&
+                   header->AceType != ACCESS_DENIED_OBJECT_ACE_TYPE &&
+                   header->AceType != ACCESS_DENIED_CALLBACK_ACE_TYPE &&
+                   header->AceType != ACCESS_DENIED_CALLBACK_OBJECT_ACE_TYPE) {
+            return yams::Error{yams::ErrorCode::Unauthorized,
+                               "P2P identity key ACL contains an unsupported entry type"};
+        }
+    }
+    if (!ownerAllowed) {
+        return yams::Error{yams::ErrorCode::Unauthorized,
+                           "P2P identity key ACL does not grant effective-user read access"};
+    }
+
+    LARGE_INTEGER size{};
+    if (!GetFileSizeEx(file.get(), &size) || size.QuadPart <= 0 ||
+        static_cast<unsigned long long>(size.QuadPart) > maxBytes) {
+        return yams::Error{yams::ErrorCode::InvalidArgument,
+                           "P2P identity key is empty or oversized"};
+    }
+    std::string content(static_cast<std::size_t>(size.QuadPart), '\0');
+    std::size_t offset = 0;
+    while (offset < content.size()) {
+        DWORD read = 0;
+        const auto remaining =
+            std::min<std::size_t>(content.size() - offset, std::numeric_limits<DWORD>::max());
+        if (!ReadFile(file.get(), content.data() + offset, static_cast<DWORD>(remaining), &read,
+                      nullptr) ||
+            read == 0) {
+            return yams::Error{yams::ErrorCode::IOError, "cannot read complete P2P identity key"};
+        }
+        offset += read;
+    }
+    return content;
+}
+#else
+yams::Result<std::string> readProtectedP2pFile(const std::filesystem::path& keyPath,
+                                               bool ownerOnlyRead, std::size_t maxBytes) {
+    int flags = O_RDONLY;
+#ifdef O_CLOEXEC
+    flags |= O_CLOEXEC;
 #endif
-    return yams::memory_sync::readWriterAuthFile(keyPath, std::size_t{64} * 1024);
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+    const int file = ::open(keyPath.c_str(), flags);
+    if (file < 0) {
+        const auto openError = errno;
+        return yams::Error{
+            openError == ELOOP ? yams::ErrorCode::Unauthorized : yams::ErrorCode::IOError,
+            openError == ELOOP ? "P2P identity key must not be a symbolic link"
+                               : "cannot open P2P identity key: " + systemErrorMessage(openError)};
+    }
+    const auto closeFile = [&] { (void)::close(file); };
+    struct stat info{};
+    if (::fstat(file, &info) != 0) {
+        const auto message = systemErrorMessage(errno);
+        closeFile();
+        return yams::Error{yams::ErrorCode::IOError, "cannot inspect P2P identity key: " + message};
+    }
+    const mode_t unsafePermissions = ownerOnlyRead ? mode_t{0077} : mode_t{0022};
+    if (!S_ISREG(info.st_mode) || info.st_uid != ::geteuid() ||
+        (info.st_mode & unsafePermissions) != 0) {
+        closeFile();
+        return yams::Error{yams::ErrorCode::Unauthorized,
+                           "P2P trust file must be an effective-user-owned regular file without "
+                           "unsafe permissions"};
+    }
+    if (info.st_size <= 0 ||
+        static_cast<std::uintmax_t>(info.st_size) > static_cast<std::uintmax_t>(maxBytes)) {
+        closeFile();
+        return yams::Error{yams::ErrorCode::InvalidArgument,
+                           "P2P identity key is empty or oversized"};
+    }
+    std::string content(static_cast<std::size_t>(info.st_size), '\0');
+    std::size_t offset = 0;
+    while (offset < content.size()) {
+        const auto read = ::read(file, content.data() + offset, content.size() - offset);
+        if (read < 0 && errno == EINTR) {
+            continue;
+        }
+        if (read <= 0) {
+            const auto message = systemErrorMessage(errno);
+            closeFile();
+            return yams::Error{yams::ErrorCode::IOError,
+                               "cannot read complete P2P identity key: " + message};
+        }
+        offset += static_cast<std::size_t>(read);
+    }
+    closeFile();
+    return content;
+}
+#endif
+
+yams::Result<std::string> readProtectedP2pPrivateKey(const std::filesystem::path& keyPath) {
+    return readProtectedP2pFile(keyPath, true, kMaxP2pPrivateKeyBytes);
+}
+
+yams::Result<std::string> readProtectedP2pTrustFile(const std::filesystem::path& path,
+                                                    std::size_t maxBytes) {
+    return readProtectedP2pFile(path, false, maxBytes);
 }
 
 yams::Result<void> writeExclusiveP2pPrivateKey(const std::filesystem::path& path,
                                                std::string_view contents) {
 #ifdef _WIN32
-    HANDLE file = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW,
-                              FILE_ATTRIBUTE_NORMAL, nullptr);
+    WindowsOwnerOnlySecurity security;
+    auto securityAttributes = security.initialize();
+    if (!securityAttributes) {
+        return securityAttributes.error();
+    }
+    HANDLE file = CreateFileW(path.c_str(), GENERIC_WRITE, 0, securityAttributes.value(),
+                              CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (file == INVALID_HANDLE_VALUE) {
         const auto code = GetLastError();
         return yams::Error{code == ERROR_FILE_EXISTS || code == ERROR_ALREADY_EXISTS
@@ -373,7 +638,7 @@ loadP2pPrivateKey(const yams::daemon::DaemonConfig::MemorySyncPolicy& policy,
     }
     if (!policy.writerAuthManifestPath.empty()) {
         const std::filesystem::path manifestPath(policy.writerAuthManifestPath);
-        auto bytes = yams::memory_sync::readWriterAuthFile(manifestPath);
+        auto bytes = readProtectedP2pTrustFile(manifestPath, std::size_t{1024} * 1024);
         if (!bytes) {
             return bytes.error();
         }
@@ -403,6 +668,114 @@ loadP2pPrivateKey(const yams::daemon::DaemonConfig::MemorySyncPolicy& policy,
     return loadOrCreateP2pPrivateKey(dataDir / "p2p" / "identity.pem");
 }
 
+yams::Result<std::string> ensureAuthenticatedDirectStore(const std::filesystem::path& dataDir,
+                                                         std::string_view corpusId,
+                                                         std::uint64_t corpusEpoch) {
+    const auto p2pDirectory = dataDir / "p2p";
+    const auto operationStore = p2pDirectory / "op-store";
+    const auto marker = p2pDirectory / "authenticated-store-v1.json";
+    std::error_code error;
+    if (std::filesystem::exists(marker, error)) {
+        if (error) {
+            return yams::Error{yams::ErrorCode::IOError,
+                               "cannot inspect direct P2P authentication marker: " +
+                                   error.message()};
+        }
+        auto encoded = readProtectedP2pPrivateKey(marker);
+        if (!encoded) {
+            return encoded.error();
+        }
+        try {
+            const auto parsed = nlohmann::json::parse(encoded.value());
+            const auto storeGeneration = parsed.at("store_generation").get<std::string>();
+            const bool validGeneration =
+                storeGeneration.size() == 64 &&
+                std::ranges::all_of(storeGeneration, [](unsigned char ch) {
+                    return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f');
+                });
+            if (parsed.at("schema_version").get<std::uint32_t>() != 1 ||
+                parsed.at("corpus_id").get<std::string>() != corpusId ||
+                parsed.at("corpus_epoch").get<std::uint64_t>() != corpusEpoch || !validGeneration) {
+                return yams::Error{
+                    yams::ErrorCode::InvalidState,
+                    "direct P2P operation store authentication marker does not match corpus "
+                    "identity"};
+            }
+            return storeGeneration;
+        } catch (const std::exception&) {
+            return yams::Error{yams::ErrorCode::DataCorruption,
+                               "direct P2P operation store authentication marker is malformed"};
+        }
+    }
+    if (error) {
+        return yams::Error{yams::ErrorCode::IOError,
+                           "cannot inspect direct P2P authentication marker: " + error.message()};
+    }
+
+    if (std::filesystem::exists(operationStore, error)) {
+        if (error) {
+            return yams::Error{yams::ErrorCode::IOError,
+                               "cannot inspect direct P2P operation store: " + error.message()};
+        }
+        const auto operationStoreStatus = std::filesystem::symlink_status(operationStore, error);
+        if (error || !std::filesystem::is_directory(operationStoreStatus)) {
+            return yams::Error{yams::ErrorCode::InvalidState,
+                               "direct P2P operation store is not a trusted directory"};
+        }
+        std::filesystem::recursive_directory_iterator entry(operationStore, error);
+        const std::filesystem::recursive_directory_iterator end;
+        for (; !error && entry != end; entry.increment(error)) {
+            const auto status = entry->symlink_status(error);
+            if (error || !std::filesystem::is_directory(status)) {
+                return yams::Error{
+                    yams::ErrorCode::InvalidState,
+                    "direct P2P operation store has unsigned or provenance-unknown history; "
+                    "preserve it for audit, advance corpus_epoch, and bootstrap a fresh store"};
+            }
+        }
+        if (error) {
+            return yams::Error{yams::ErrorCode::IOError,
+                               "cannot scan direct P2P operation store: " + error.message()};
+        }
+    } else if (error) {
+        return yams::Error{yams::ErrorCode::IOError,
+                           "cannot inspect direct P2P operation store: " + error.message()};
+    }
+
+    std::filesystem::create_directories(p2pDirectory, error);
+    if (error) {
+        return yams::Error{yams::ErrorCode::IOError,
+                           "cannot create direct P2P state directory: " + error.message()};
+    }
+    std::array<unsigned char, 32> generationBytes{};
+    if (RAND_bytes(generationBytes.data(), static_cast<int>(generationBytes.size())) != 1) {
+        return yams::Error{yams::ErrorCode::InternalError,
+                           "cannot generate direct P2P store identity"};
+    }
+    static constexpr char kHex[] = "0123456789abcdef";
+    std::string storeGeneration;
+    storeGeneration.reserve(generationBytes.size() * 2);
+    for (const auto byte : generationBytes) {
+        storeGeneration.push_back(kHex[byte >> 4]);
+        storeGeneration.push_back(kHex[byte & 0x0f]);
+    }
+    const nlohmann::json content{{"schema_version", 1},
+                                 {"corpus_id", corpusId},
+                                 {"corpus_epoch", corpusEpoch},
+                                 {"store_generation", storeGeneration}};
+    const auto temporary = marker.string() + ".tmp-" + std::to_string(::getpid());
+    if (auto written = writeExclusiveP2pPrivateKey(temporary, content.dump()); !written) {
+        return written.error();
+    }
+    std::filesystem::rename(temporary, marker, error);
+    if (error) {
+        std::filesystem::remove(temporary, error);
+        return yams::Error{yams::ErrorCode::WriteError,
+                           "cannot install direct P2P authentication marker"};
+    }
+    return storeGeneration;
+}
+
 std::uint64_t nowUnixMillis() {
     return static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
                                           std::chrono::system_clock::now().time_since_epoch())
@@ -415,6 +788,17 @@ std::uint64_t nowUnixMillis() {
 #undef YAMS_DAEMON_TEST_HOOKS_IMPL
 
 namespace yams::daemon {
+
+Result<std::string>
+ServiceManager::__test_loadOrCreateP2pPrivateKey(const std::filesystem::path& keyPath) {
+    return loadOrCreateP2pPrivateKey(keyPath);
+}
+
+Result<void>
+ServiceManager::__test_writeProtectedP2pPrivateKey(const std::filesystem::path& keyPath,
+                                                   std::string_view contents) {
+    return writeExclusiveP2pPrivateKey(keyPath, contents);
+}
 
 namespace {
 constexpr auto kTopologyOverlayRebuildMinAge = std::chrono::minutes(5);
@@ -1286,6 +1670,7 @@ void ServiceManager::startAsyncInit(std::promise<void>* barrierPromise,
     }
 
     if (!workCoordinator_ || !workCoordinator_->isRunning()) {
+        asyncInit_.markFutureNotExpected();
         spdlog::error("ServiceManager: WorkCoordinator not ready, cannot start async init");
         if (barrierPromise) {
             barrierPromise->set_value();
@@ -1298,6 +1683,7 @@ void ServiceManager::startAsyncInit(std::promise<void>* barrierPromise,
     try {
         self = shared_from_this();
     } catch (const std::bad_weak_ptr& e) {
+        asyncInit_.markFutureNotExpected();
         spdlog::error(
             "ServiceManager: shared_from_this() failed - object not managed by shared_ptr: {}",
             e.what());
@@ -1308,63 +1694,83 @@ void ServiceManager::startAsyncInit(std::promise<void>* barrierPromise,
         return;
     }
 
-    boost::asio::post(
-        workCoordinator_->getExecutor(), [self, barrierPromise, signalBarrierOnStart]() {
-            spdlog::debug("ServiceManager: Async init sync point reached, spawning coroutine");
+    spdlog::debug("ServiceManager: Async init sync point reached, spawning coroutine");
 
-            self->asyncInit_.setFuture(boost::asio::co_spawn(
-                self->workCoordinator_->getExecutor(),
-                [self, barrierPromise, signalBarrierOnStart]() -> boost::asio::awaitable<void> {
-                    auto localSelf = self;
-                    auto localBarrierPromise = barrierPromise;
-                    const auto signalCompletion = [&]() {
-                        if (signalBarrierOnStart || !localBarrierPromise) {
-                            return;
-                        }
-                        try {
-                            localBarrierPromise->set_value();
-                        } catch (...) {
-                            spdlog::debug("ServiceManager: async init completion signal failed");
-                        }
-                    };
-
-                    spdlog::info("Starting async resource initialization (coroutine)...");
-
-                    if (signalBarrierOnStart && localBarrierPromise) {
-                        try {
-                            localBarrierPromise->set_value();
-                            spdlog::debug("ServiceManager: Async init barrier signaled");
-                        } catch (...) {
-                            spdlog::debug("ServiceManager: async init barrier signal failed");
-                        }
+    try {
+        self->asyncInit_.setFuture(boost::asio::co_spawn(
+            self->workCoordinator_->getExecutor(),
+            [self, barrierPromise, signalBarrierOnStart]() -> boost::asio::awaitable<void> {
+                auto localSelf = self;
+                auto localBarrierPromise = barrierPromise;
+                const auto signalCompletion = [&]() {
+                    if (signalBarrierOnStart || !localBarrierPromise) {
+                        return;
                     }
-
-                    auto token = localSelf->asyncInit_.getStopToken();
-
                     try {
-                        auto result = co_await localSelf->initializeAsyncAwaitable(token);
-
-                        if (!result) {
-                            spdlog::error("Async resource initialization failed: {}",
-                                          result.error().message);
-                            if (!token.stop_requested()) {
-                                localSelf->serviceFsm_.dispatch(
-                                    InitializationFailedEvent{result.error().message});
-                            }
-                        } else {
-                            spdlog::info("All daemon services initialized successfully");
-                        }
-                    } catch (const std::exception& e) {
-                        spdlog::error("Async resource initialization exception: {}", e.what());
-                        if (!token.stop_requested()) {
-                            localSelf->serviceFsm_.dispatch(InitializationFailedEvent{e.what()});
-                        }
+                        localBarrierPromise->set_value();
+                    } catch (...) {
+                        spdlog::debug("ServiceManager: async init completion signal failed");
                     }
+                };
 
-                    signalCompletion();
-                },
-                boost::asio::use_future));
-        });
+                spdlog::info("Starting async resource initialization (coroutine)...");
+
+                if (signalBarrierOnStart && localBarrierPromise) {
+                    try {
+                        localBarrierPromise->set_value();
+                        spdlog::debug("ServiceManager: Async init barrier signaled");
+                    } catch (...) {
+                        spdlog::debug("ServiceManager: async init barrier signal failed");
+                    }
+                }
+
+                auto token = localSelf->asyncInit_.getStopToken();
+
+                try {
+                    auto result = co_await localSelf->initializeAsyncAwaitable(token);
+
+                    if (!result) {
+                        spdlog::error("Async resource initialization failed: {}",
+                                      result.error().message);
+                        if (!token.stop_requested()) {
+                            localSelf->serviceFsm_.dispatch(
+                                InitializationFailedEvent{result.error().message});
+                        }
+                    } else {
+                        spdlog::info("All daemon services initialized successfully");
+                    }
+                } catch (const std::exception& e) {
+                    spdlog::error("Async resource initialization exception: {}", e.what());
+                    if (!token.stop_requested()) {
+                        localSelf->serviceFsm_.dispatch(InitializationFailedEvent{e.what()});
+                    }
+                }
+
+                signalCompletion();
+            },
+            boost::asio::use_future));
+    } catch (const std::exception& error) {
+        self->asyncInit_.markFutureNotExpected();
+        spdlog::error("Failed to spawn async resource initialization: {}", error.what());
+        if (barrierPromise) {
+            try {
+                barrierPromise->set_value();
+            } catch (...) {
+            }
+        }
+        self->serviceFsm_.dispatch(InitializationFailedEvent{error.what()});
+    } catch (...) {
+        self->asyncInit_.markFutureNotExpected();
+        spdlog::error("Failed to spawn async resource initialization");
+        if (barrierPromise) {
+            try {
+                barrierPromise->set_value();
+            } catch (...) {
+            }
+        }
+        self->serviceFsm_.dispatch(
+            InitializationFailedEvent{"failed to spawn async resource initialization"});
+    }
 }
 
 void ServiceManager::stopBackgroundTaskManagerForShutdown() {
@@ -3012,6 +3418,12 @@ Result<void> ServiceManager::initializeMemorySync(const std::filesystem::path& d
     if (!policy.enabled) {
         return Result<void>();
     }
+    if (policy.transport == "direct" &&
+        (!policy.writerAuthRequired || policy.writerAuthManifestPath.empty())) {
+        return Error{ErrorCode::InvalidArgument,
+                     "direct memory_sync requires writer_auth_required=true and a usable "
+                     "writer_auth_manifest for authenticated cold bootstrap"};
+    }
 
     try {
         yams::memory_sync::MemorySyncDaemonConfig cfg;
@@ -3035,6 +3447,15 @@ Result<void> ServiceManager::initializeMemorySync(const std::filesystem::path& d
             cfg.path = (dataDir / cfg.path).string();
         }
 
+        if (policy.transport == "direct") {
+            auto trustedStore =
+                ensureAuthenticatedDirectStore(dataDir, cfg.corpusId, cfg.corpusEpoch);
+            if (!trustedStore) {
+                return trustedStore.error();
+            }
+            cfg.controlScope = std::move(trustedStore.value());
+        }
+
         std::optional<yams::storage::BackendConfig> resolvedS3Config;
         if (policy.transport == "shared-store" && cfg.backend == "s3") {
             auto storageDecision = yams::storage::resolveStorageBootstrapDecision(
@@ -3051,9 +3472,15 @@ Result<void> ServiceManager::initializeMemorySync(const std::filesystem::path& d
             resolvedS3Config = *storageDecision.value().backendConfig;
         }
 
-        auto svc = yams::memory_sync::createMemorySyncService(cfg, std::move(resolvedS3Config), [] {
-            return ResourceGovernor::instance().canAdmitWork();
-        });
+        auto svc = yams::memory_sync::createMemorySyncService(
+            cfg, std::move(resolvedS3Config),
+            [] { return ResourceGovernor::instance().canAdmitWork(); },
+            policy.transport == "direct"
+                ? yams::memory_sync::WriterPrivateKeyReader{readProtectedP2pPrivateKey}
+                : yams::memory_sync::WriterPrivateKeyReader{},
+            policy.transport == "direct"
+                ? yams::memory_sync::WriterTrustFileReader{readProtectedP2pTrustFile}
+                : yams::memory_sync::WriterTrustFileReader{});
         if (!svc) {
             return Error{svc.error().code,
                          "memory_sync service creation failed: " + svc.error().message};
@@ -3099,6 +3526,11 @@ Result<void> ServiceManager::initializeDirectP2p(const std::filesystem::path& da
     if (!synchronized) {
         return Error{synchronized.error().code,
                      "direct P2P local op-store recovery failed: " + synchronized.error().message};
+    }
+    if (memorySync_->legacyUnauthenticatedHistoryObserved()) {
+        return Error{ErrorCode::InvalidState,
+                     "direct P2P operation store contains unsigned legacy history; preserve it "
+                     "for audit, advance corpus_epoch, and bootstrap a fresh store"};
     }
     if (policy.allowFirstContact) {
         spdlog::warn("[ServiceManager] memory_sync.allow_first_contact=true permits unsolicited "

--- a/src/daemon/meson.build
+++ b/src/daemon/meson.build
@@ -55,6 +55,11 @@ if tracy_enabled
   message('Tracy profiling enabled for daemon')
 endif
 
+daemon_platform_deps = []
+if host_machine.system() == 'windows'
+  daemon_platform_deps += cpp.find_library('advapi32', required: true)
+endif
+
 daemon_testing_cpp_args = []
 if get_option('build-tests') or get_option('build-benchmarks')
   daemon_testing_cpp_args += [
@@ -181,7 +186,7 @@ yams_daemon_lib = static_library('yams_daemon',
     nlohmann_json_dep,
     protobuf_dep,
     version_generated_dep,
-  ] + tracy_deps,
+  ] + tracy_deps + daemon_platform_deps,
   cpp_args: tracy_args + daemon_testing_cpp_args + (cpp.get_id() == 'msvc' ? ['/wd4100'] : ['-Wno-unused-parameter']),
   include_directories: [
     include_directories('../../include'),
@@ -194,7 +199,7 @@ yams_daemon_lib = static_library('yams_daemon',
 yams_daemon_dep = declare_dependency(
   link_with: yams_daemon_lib,
   include_directories: [include_directories('../../include'), generated_inc],
-  dependencies: [yams_daemon_client_dep, version_generated_dep],
+  dependencies: [yams_daemon_client_dep, version_generated_dep] + daemon_platform_deps,
 )
 
 meson.override_dependency('yams_daemon', yams_daemon_dep)

--- a/src/daemon/p2p/p2p_delta.cpp
+++ b/src/daemon/p2p/p2p_delta.cpp
@@ -321,9 +321,9 @@ Result<BootstrapPhaseResult> sendBootstrapPhase(P2pConnection& connection,
     if (!offer) {
         return result;
     }
-    if (handshake.firstContactPinned) {
+    if (!handshake.pinnedByOperator) {
         return Error{ErrorCode::Unauthorized,
-                     "cold bootstrap requires a previously operator-pinned peer"};
+                     "cold bootstrap requires explicit operator enrollment"};
     }
     const auto current = service.replicationState();
     memory_sync::ReplicationState frozen{.version = handshake.localVersion,
@@ -422,9 +422,10 @@ Result<BootstrapPhaseResult> receiveBootstrapPhase(P2pConnection& connection,
                      std::string("invalid p2p replication mode: ") + error.what()};
     }
     if (!handshake.localVersion.empty() || !service.currentVersion().empty() ||
-        handshake.firstContactPinned) {
+        !handshake.pinnedByOperator) {
         return Error{ErrorCode::Unauthorized,
-                     "cold bootstrap requires a durable zero state and prior peer pin"};
+                     "cold bootstrap requires a durable zero state and explicit operator "
+                     "enrollment"};
     }
     auto begin = readJson(connection, options.timeout);
     if (!begin) {

--- a/src/daemon/p2p/p2p_manager.cpp
+++ b/src/daemon/p2p/p2p_manager.cpp
@@ -280,7 +280,7 @@ public:
                 }
                 return registry_->updatePeerState(peer.nodeId, peer.corpusId, peer.corpusEpoch,
                                                   peer.lastSeenVersion, peer.lastConnectedMs,
-                                                  peer.endpoint, false, peer.pinnedByOperator);
+                                                  peer.endpoint, false);
             }
         }
         return Error{ErrorCode::NotFound, "P2P peer is not registered"};
@@ -411,8 +411,7 @@ private:
         }
         auto persisted = registry_->updatePeerState(handshake.value().peerNodeId, options_.corpusId,
                                                     options_.corpusEpoch, service_.currentVersion(),
-                                                    unixTimeMs(), spec.endpoint(), spec.remember,
-                                                    spec.peerPin.has_value());
+                                                    unixTimeMs(), spec.endpoint(), spec.remember);
         if (!persisted) {
             return persisted.error();
         }
@@ -444,21 +443,19 @@ private:
         }
         std::string endpoint;
         bool remembered = false;
-        bool operatorPin = false;
         auto records = registry_->listPeers();
         if (records) {
             for (const auto& peer : records.value()) {
                 if (peer.nodeId == handshake.value().peerNodeId) {
                     endpoint = peer.endpoint;
                     remembered = peer.remembered;
-                    operatorPin = peer.pinnedByOperator;
                     break;
                 }
             }
         }
         (void)registry_->updatePeerState(handshake.value().peerNodeId, options_.corpusId,
                                          options_.corpusEpoch, service_.currentVersion(),
-                                         unixTimeMs(), endpoint, remembered, operatorPin);
+                                         unixTimeMs(), endpoint, remembered);
     }
 
     void reconnectLoop() {
@@ -544,6 +541,11 @@ Result<std::unique_ptr<P2pManager>> P2pManager::create(P2pManagerOptions options
         options.sessionTimeout <= std::chrono::milliseconds::zero() ||
         options.sessionTimeout > kP2pMaxSessionTimeout) {
         return Error{ErrorCode::InvalidArgument, "invalid P2P manager configuration"};
+    }
+    if (!service.directP2pReady(options.nodeId, options.corpusId, options.corpusEpoch)) {
+        return Error{ErrorCode::InvalidArgument,
+                     "direct P2P requires a fully recovered writer-authenticated service with "
+                     "matching node, corpus, and epoch"};
     }
     auto identity = TlsIdentity::fromPrivateKeyPem(options.nodeId, options.privateKeyPem);
     if (!identity) {

--- a/src/daemon/p2p/p2p_protocol.cpp
+++ b/src/daemon/p2p/p2p_protocol.cpp
@@ -379,11 +379,11 @@ Result<WireState> validatePeerWindowFrontier(const PeerHandshakeConfig& config,
     return replaceWriterFrontier(peerState, frontier);
 }
 
-Result<bool> preflightTrust(IPeerTrustStore& trustStore, std::string_view nodeId,
-                            std::string_view spkiPin, bool allowFirstContact) {
+Result<PeerTrustDecision> preflightTrust(IPeerTrustStore& trustStore, std::string_view nodeId,
+                                         std::string_view spkiPin, bool allowFirstContact) {
     auto verified = trustStore.verifyOrPin(nodeId, spkiPin, false);
     if (verified) {
-        return false;
+        return verified.value();
     }
     if (verified.error().code != ErrorCode::Unauthorized) {
         return verified.error(); // Storage/config failures always fail closed.
@@ -392,13 +392,14 @@ Result<bool> preflightTrust(IPeerTrustStore& trustStore, std::string_view nodeId
     if (pinned || !allowFirstContact) {
         return verified.error(); // Existing mismatch or unknown peer without TOFU.
     }
-    return true; // Defer first-contact pin commit until state validation succeeds.
+    // Defer first-contact pin commit until state validation succeeds.
+    return PeerTrustDecision{.firstContactPinned = true, .pinnedByOperator = false};
 }
 
-Result<bool> validatePeerAndPreflightTrust(IPeerTrustStore& trustStore,
-                                           const P2pConnection& connection,
-                                           const PeerHandshakeConfig& local,
-                                           const WireHello& peer) {
+Result<PeerTrustDecision> validatePeerAndPreflightTrust(IPeerTrustStore& trustStore,
+                                                        const P2pConnection& connection,
+                                                        const PeerHandshakeConfig& local,
+                                                        const WireHello& peer) {
     if (auto valid = validatePeerHello(peer, local, connection); !valid) {
         return valid.error();
     }
@@ -407,9 +408,10 @@ Result<bool> validatePeerAndPreflightTrust(IPeerTrustStore& trustStore,
 }
 
 Result<PeerTrustDecision> commitTrust(IPeerTrustStore& trustStore, std::string_view nodeId,
-                                      std::string_view spkiPin, bool pendingFirstContact) {
-    if (!pendingFirstContact) {
-        return PeerTrustDecision{};
+                                      std::string_view spkiPin,
+                                      PeerTrustDecision preflightDecision) {
+    if (!preflightDecision.firstContactPinned) {
+        return preflightDecision;
     }
     return trustStore.verifyOrPin(nodeId, spkiPin, true);
 }
@@ -428,7 +430,8 @@ Result<PeerHandshakeResult> makeHandshakeResult(const P2pConnection& connection,
                                .peerPrefixCounter = proof.proof.counter,
                                .peerPrefixVerified = true,
                                .peerPrefixMatches = proof.matchesLocalPrefix,
-                               .firstContactPinned = trust.firstContactPinned};
+                               .firstContactPinned = trust.firstContactPinned,
+                               .pinnedByOperator = trust.pinnedByOperator};
 }
 
 Result<void> validateLocalHandshake(const P2pConnection& connection,
@@ -452,8 +455,9 @@ Result<WireState> readStateFrame(P2pConnection& connection, std::chrono::millise
 
 Result<PeerTrustDecision> finalizeTrust(IPeerTrustStore& trustStore,
                                         const P2pConnection& connection,
-                                        std::string_view peerNodeId, bool pendingFirstContact) {
-    return commitTrust(trustStore, peerNodeId, connection.peerSpkiPin(), pendingFirstContact);
+                                        std::string_view peerNodeId,
+                                        PeerTrustDecision preflightDecision) {
+    return commitTrust(trustStore, peerNodeId, connection.peerSpkiPin(), preflightDecision);
 }
 
 Json historyProofJson(const WireHistoryProof& proof) {
@@ -592,10 +596,34 @@ Result<PeerTrustDecision> InMemoryPeerTrustStore::verifyOrPin(std::string_view n
     const std::optional<std::string> existing =
         found == pins_.end() ? std::nullopt : std::optional<std::string>{found->second};
     auto decision = evaluatePeerPin(existing, normalizedPin, allowFirstContact);
-    if (decision && decision.value().firstContactPinned) {
+    if (!decision) {
+        return decision.error();
+    }
+    if (decision.value().firstContactPinned) {
         pins_.emplace(nodeId, normalizedPin);
+    } else {
+        decision.value().pinnedByOperator = operatorPinnedNodes_.contains(std::string(nodeId));
     }
     return decision;
+}
+
+Result<void> InMemoryPeerTrustStore::enrollOperatorPeer(std::string_view nodeId,
+                                                        std::string_view spkiPin) {
+    if (nodeId.empty()) {
+        return Error{ErrorCode::InvalidArgument, "p2p enrollment node id is empty"};
+    }
+    auto normalized = normalizePeerSpkiPin(spkiPin);
+    if (!normalized) {
+        return normalized.error();
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto found = pins_.find(std::string(nodeId));
+    if (found != pins_.end() && found->second != normalized.value()) {
+        return Error{ErrorCode::Unauthorized, "P2P peer pin replacement requires explicit removal"};
+    }
+    pins_.insert_or_assign(std::string(nodeId), normalized.value());
+    operatorPinnedNodes_.insert(std::string(nodeId));
+    return {};
 }
 
 std::optional<std::string> InMemoryPeerTrustStore::pinnedPin(std::string_view nodeId) const {
@@ -731,7 +759,7 @@ Result<PeerHandshakeResult> initiatePeerHandshake(P2pConnection& connection,
     if (!peerProof) {
         return fail(peerProof.error());
     }
-    if (!peerProof.value().matchesLocalPrefix && pendingTrust.value()) {
+    if (!peerProof.value().matchesLocalPrefix && pendingTrust.value().firstContactPinned) {
         return fail(
             Error{ErrorCode::Unauthorized, "first-contact peer failed writer prefix verification"});
     }
@@ -814,7 +842,7 @@ Result<PeerHandshakeResult> acceptPeerHandshake(P2pConnection& connection,
     if (!peerProof) {
         return fail(peerProof.error());
     }
-    if (!peerProof.value().matchesLocalPrefix && pendingTrust.value()) {
+    if (!peerProof.value().matchesLocalPrefix && pendingTrust.value().firstContactPinned) {
         return fail(
             Error{ErrorCode::Unauthorized, "first-contact peer failed writer prefix verification"});
     }

--- a/src/daemon/p2p/peer_registry.cpp
+++ b/src/daemon/p2p/peer_registry.cpp
@@ -24,7 +24,8 @@ CREATE TABLE IF NOT EXISTS p2p_peers (
     last_connected_ms INTEGER NOT NULL DEFAULT 0,
     endpoint TEXT NOT NULL DEFAULT '',
     remembered INTEGER NOT NULL DEFAULT 0 CHECK(remembered IN (0, 1)),
-    pinned_by_operator INTEGER NOT NULL DEFAULT 0 CHECK(pinned_by_operator IN (0, 1))
+    pinned_by_operator INTEGER NOT NULL DEFAULT 0 CHECK(pinned_by_operator IN (0, 1)),
+    operator_enrollment_generation INTEGER NOT NULL DEFAULT 0
 )
 )sql";
 
@@ -143,6 +144,18 @@ Result<void> PeerRegistry::initializeSchema() {
             return migrated.error();
         }
     }
+    auto hasEnrollmentGeneration = hasPeerColumn(*database_, "operator_enrollment_generation");
+    if (!hasEnrollmentGeneration) {
+        return hasEnrollmentGeneration.error();
+    }
+    if (!hasEnrollmentGeneration.value()) {
+        if (auto migrated = database_->execute(
+                "ALTER TABLE p2p_peers ADD COLUMN operator_enrollment_generation INTEGER NOT "
+                "NULL DEFAULT 0");
+            !migrated) {
+            return migrated.error();
+        }
+    }
     return Result<void>();
 }
 
@@ -159,6 +172,23 @@ Result<std::optional<std::string>> PeerRegistry::findPinLocked(std::string_view 
     }
     return row.value() ? std::optional<std::string>{statement.getString(0)}
                        : std::optional<std::string>{};
+}
+
+Result<bool> PeerRegistry::operatorPinnedLocked(std::string_view nodeId) const {
+    auto prepared = prepareNodeStatement(
+        *database_,
+        "SELECT pinned_by_operator, operator_enrollment_generation FROM p2p_peers WHERE node_id = "
+        "?",
+        nodeId);
+    if (!prepared) {
+        return prepared.error();
+    }
+    auto statement = std::move(prepared.value());
+    auto row = statement.step();
+    if (!row) {
+        return row.error();
+    }
+    return row.value() && statement.getInt(0) != 0 && statement.getInt64(1) == 1;
 }
 
 Result<std::size_t> PeerRegistry::peerCountLocked() const {
@@ -197,7 +227,15 @@ Result<PeerTrustDecision> PeerRegistry::verifyOrPin(std::string_view nodeId,
         return existing.error();
     }
     auto decision = evaluatePeerPin(existing.value(), normalized.value(), allowFirstContact);
-    if (!decision || !decision.value().firstContactPinned) {
+    if (!decision) {
+        return decision.error();
+    }
+    if (!decision.value().firstContactPinned) {
+        auto operatorPinned = operatorPinnedLocked(nodeId);
+        if (!operatorPinned) {
+            return operatorPinned.error();
+        }
+        decision.value().pinnedByOperator = operatorPinned.value();
         return decision;
     }
     auto count = peerCountLocked();
@@ -218,7 +256,7 @@ Result<PeerTrustDecision> PeerRegistry::verifyOrPin(std::string_view nodeId,
     if (auto inserted = statement.execute(); !inserted) {
         return inserted.error();
     }
-    return PeerTrustDecision{.firstContactPinned = true};
+    return PeerTrustDecision{.firstContactPinned = true, .pinnedByOperator = false};
 }
 
 Result<void> PeerRegistry::enrollOperatorPeer(std::string_view nodeId, std::string_view spkiPin) {
@@ -239,8 +277,9 @@ Result<void> PeerRegistry::enrollOperatorPeer(std::string_view nodeId, std::stri
             return Error{ErrorCode::Unauthorized,
                          "P2P peer pin replacement requires explicit removal"};
         }
-        auto promoted =
-            database_->prepare("UPDATE p2p_peers SET pinned_by_operator = 1 WHERE node_id = ?");
+        auto promoted = database_->prepare(
+            "UPDATE p2p_peers SET pinned_by_operator = 1, operator_enrollment_generation = 1 "
+            "WHERE node_id = ?");
         if (!promoted) {
             return promoted.error();
         }
@@ -257,8 +296,9 @@ Result<void> PeerRegistry::enrollOperatorPeer(std::string_view nodeId, std::stri
     if (count.value() >= maxPeers_) {
         return Error{ErrorCode::ResourceExhausted, "p2p peer registry capacity reached"};
     }
-    auto inserted = database_->prepare(
-        "INSERT INTO p2p_peers(node_id, spki_hash, pinned_by_operator) VALUES(?, ?, 1)");
+    auto inserted =
+        database_->prepare("INSERT INTO p2p_peers(node_id, spki_hash, pinned_by_operator, "
+                           "operator_enrollment_generation) VALUES(?, ?, 1, 1)");
     if (!inserted) {
         return inserted.error();
     }
@@ -273,7 +313,7 @@ Result<void> PeerRegistry::updatePeerState(std::string_view nodeId, std::string_
                                            std::uint64_t corpusEpoch,
                                            const memory_sync::VersionVector& lastSeenVersion,
                                            std::int64_t lastConnectedMs, std::string_view endpoint,
-                                           bool remembered, bool pinnedByOperator) {
+                                           bool remembered) {
     if (nodeId.empty() || corpusId.empty() || corpusEpoch == 0 ||
         corpusEpoch > static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) ||
         lastConnectedMs < 0) {
@@ -294,7 +334,7 @@ Result<void> PeerRegistry::updatePeerState(std::string_view nodeId, std::string_
     auto prepared = database_->prepare(R"sql(
 UPDATE p2p_peers
 SET corpus_id = ?, corpus_epoch = ?, last_seen_vv = ?, last_connected_ms = ?,
-    endpoint = ?, remembered = ?, pinned_by_operator = MAX(pinned_by_operator, ?)
+    endpoint = ?, remembered = ?
 WHERE node_id = ?
 )sql");
     if (!prepared) {
@@ -304,7 +344,7 @@ WHERE node_id = ?
     const std::string endpointValue(endpoint);
     if (auto bound = statement.bindAll(corpusId, static_cast<std::int64_t>(corpusEpoch),
                                        encodedVersion.value(), lastConnectedMs, endpointValue,
-                                       remembered ? 1 : 0, pinnedByOperator ? 1 : 0, nodeId);
+                                       remembered ? 1 : 0, nodeId);
         !bound) {
         return bound.error();
     }
@@ -315,7 +355,8 @@ Result<std::vector<PeerRegistryRecord>> PeerRegistry::listPeers() const {
     std::lock_guard<std::mutex> lock(mutex_);
     auto prepared = database_->prepare(R"sql(
 SELECT node_id, spki_hash, corpus_id, corpus_epoch, last_seen_vv,
-       last_connected_ms, endpoint, remembered, pinned_by_operator
+       last_connected_ms, endpoint, remembered, pinned_by_operator,
+       operator_enrollment_generation
 FROM p2p_peers
 ORDER BY node_id
 )sql");
@@ -348,7 +389,8 @@ ORDER BY node_id
                                            .lastConnectedMs = statement.getInt64(5),
                                            .endpoint = statement.getString(6),
                                            .remembered = statement.getInt(7) != 0,
-                                           .pinnedByOperator = statement.getInt(8) != 0});
+                                           .pinnedByOperator = statement.getInt(8) != 0 &&
+                                                               statement.getInt64(9) == 1});
     }
 }
 

--- a/tests/unit/daemon/components/config_resolver_test.cpp
+++ b/tests/unit/daemon/components/config_resolver_test.cpp
@@ -1569,8 +1569,8 @@ TEST_CASE("Direct P2P defaults to operator-approved first contact",
     CHECK_FALSE(config.memorySync.allowFirstContact);
 }
 
-TEST_CASE("ConfigResolver accepts direct P2P without a shared path",
-          "[daemon][config][memory-sync][p2p]") {
+TEST_CASE("ConfigResolver rejects direct P2P without usable writer authentication",
+          "[daemon][config][memory-sync][p2p][security]") {
     ConfigResolver::ConfigSections sections = {
         {"memory_sync",
          {{"enabled", "true"},
@@ -1585,14 +1585,36 @@ TEST_CASE("ConfigResolver accepts direct P2P without a shared path",
     };
     DaemonConfig config;
 
+    CHECK_FALSE(ConfigResolver::applyMemorySync(sections, config));
+    CHECK_FALSE(config.memorySync.enabled);
+}
+
+TEST_CASE("ConfigResolver accepts authenticated direct P2P without a shared path",
+          "[daemon][config][memory-sync][p2p][security]") {
+    ConfigResolver::ConfigSections sections = {
+        {"memory_sync",
+         {{"enabled", "true"},
+          {"node_id", "123e4567-e89b-42d3-a456-426614174000"},
+          {"corpus_id", "corpus-a"},
+          {"corpus_epoch", "9"},
+          {"transport", "direct"},
+          {"listen", "0.0.0.0:9721"},
+          {"allow_first_contact", "false"},
+          {"max_peers", "12"},
+          {"writer_auth_required", "true"},
+          {"writer_auth_manifest", "/secure/writers.json"}}},
+    };
+    DaemonConfig config;
+
     REQUIRE(ConfigResolver::applyMemorySync(sections, config));
     CHECK(config.memorySync.enabled);
     CHECK(config.memorySync.transport == "direct");
     CHECK(config.memorySync.listen == "0.0.0.0:9721");
-    CHECK(config.memorySync.identityKeyPath == "/secure/p2p.pem");
     CHECK_FALSE(config.memorySync.allowFirstContact);
     CHECK(config.memorySync.maxPeers == 12);
     CHECK(config.memorySync.path.empty());
+    CHECK(config.memorySync.writerAuthRequired);
+    CHECK(config.memorySync.writerAuthManifestPath == "/secure/writers.json");
 }
 
 TEST_CASE("ConfigResolver infers shared-store for legacy backend path",

--- a/tests/unit/daemon/p2p_delta_catch2_test.cpp
+++ b/tests/unit/daemon/p2p_delta_catch2_test.cpp
@@ -322,14 +322,23 @@ TEST_CASE("direct P2P cold bootstrap installs an authenticated multiwriter snaps
     CHECK_FALSE((refused.client.has_value() && refused.server.has_value()));
     CHECK(clientService.currentVersion().empty());
 
-    // The failed TOFU session persisted pins. A fresh handshake can now use those explicit
-    // identities, but same-session first contact was never allowed to carry a snapshot.
+    // A prior TOFU session remains legacy first-contact trust and must never become operator
+    // enrollment merely because a later handshake recognizes the same pin.
     const auto exchange = runExchange(clientService, serverService, clientKey.value(),
                                       serverKey.value(), clientTrust, serverTrust, false);
-    REQUIRE(exchange.client.has_value());
-    REQUIRE(exchange.server.has_value());
-    CHECK(exchange.client.value().snapshotsReceived == 1);
-    CHECK(exchange.server.value().snapshotsSent == 1);
+    CHECK_FALSE((exchange.client.has_value() && exchange.server.has_value()));
+    CHECK(clientService.currentVersion().empty());
+
+    const auto serverPin = identity("server-node", serverKey.value()).spkiPin();
+    const auto clientPin = identity("client-node", clientKey.value()).spkiPin();
+    REQUIRE(clientTrust.enrollOperatorPeer("server-node", serverPin).has_value());
+    REQUIRE(serverTrust.enrollOperatorPeer("client-node", clientPin).has_value());
+    const auto enrolled = runExchange(clientService, serverService, clientKey.value(),
+                                      serverKey.value(), clientTrust, serverTrust, false);
+    REQUIRE(enrolled.client.has_value());
+    REQUIRE(enrolled.server.has_value());
+    CHECK(enrolled.client.value().snapshotsReceived == 1);
+    CHECK(enrolled.server.value().snapshotsSent == 1);
     REQUIRE(clientService.readCached("user/foreign").has_value());
     REQUIRE(clientService.readCached("user/server").has_value());
     CHECK(text(clientService.readCached("user/foreign").value()) == "foreign-value");

--- a/tests/unit/daemon/p2p_manager_catch2_test.cpp
+++ b/tests/unit/daemon/p2p_manager_catch2_test.cpp
@@ -11,6 +11,8 @@
 #include <yams/memory_sync/writer_auth.h>
 #include <yams/storage/storage_backend.h>
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstring>
@@ -25,10 +27,49 @@
 using namespace std::chrono_literals;
 using yams::daemon::p2p::P2pManager;
 using yams::daemon::p2p::P2pManagerOptions;
-using yams::memory_sync::MemorySyncConfig;
 using yams::memory_sync::MemorySyncService;
 
 namespace {
+
+std::shared_ptr<const yams::memory_sync::WriterAuthenticator>
+testWriterAuthenticator(const std::string& writerId, const std::string& corpusId,
+                        std::uint64_t corpusEpoch) {
+    static const auto keys = [] {
+        auto generated = yams::memory_sync::generateWriterKeyPair();
+        if (!generated) {
+            throw std::runtime_error(generated.error().message);
+        }
+        return generated.value();
+    }();
+    yams::memory_sync::WriterAuthConfig config;
+    config.required = true;
+    config.localWriterId = writerId;
+    config.localKeyId = "manager-test-v1";
+    config.localPrivateKeyPem = keys.privateKeyPem;
+    for (const auto& trustedId :
+         std::array<std::string, 4>{"node", "client-node", "server-node", writerId}) {
+        if (std::ranges::none_of(config.trustedKeys, [&](const auto& trusted) {
+                return trusted.writerId == trustedId;
+            })) {
+            config.trustedKeys.push_back(yams::memory_sync::TrustedWriterKey{
+                trustedId, config.localKeyId, keys.publicKeyPem, false});
+        }
+    }
+    auto authenticator =
+        yams::memory_sync::WriterAuthenticator::create(std::move(config), corpusId, corpusEpoch);
+    if (!authenticator) {
+        throw std::runtime_error(authenticator.error().message);
+    }
+    return authenticator.value();
+}
+
+struct MemorySyncConfig : yams::memory_sync::MemorySyncConfig {
+    explicit MemorySyncConfig(std::string writerId, std::uint32_t intervalMs = 5000,
+                              std::string corpus = "local-test-corpus", std::uint64_t epoch = 1)
+        : yams::memory_sync::MemorySyncConfig(writerId, intervalMs, corpus, epoch, {}, false,
+                                              testWriterAuthenticator(writerId, corpus, epoch),
+                                              "manager-test-control-scope") {}
+};
 
 struct TempDir {
     explicit TempDir(std::string_view label) {
@@ -114,6 +155,37 @@ TEST_CASE("P2P connection strings are strict and IPv6 aware", "[daemon][p2p][man
 TEST_CASE("P2P manager defaults to rejecting first contact", "[daemon][p2p][security]") {
     CHECK_FALSE(P2pManagerOptions{}.allowFirstContact);
     CHECK(P2pManagerOptions{}.sessionTimeout > P2pManagerOptions{}.timeout);
+}
+
+TEST_CASE("P2P manager rejects unauthenticated memory sync services",
+          "[daemon][p2p][manager][security]") {
+    TempDir dir{"unauthenticated"};
+    MemorySyncService service{backend(dir.path / "ops"), yams::memory_sync::MemorySyncConfig{
+                                                             "node", 60'000, "manager-corpus", 1}};
+    REQUIRE(service.syncFully().has_value());
+    auto key = yams::memory_sync::generateWriterKeyPair();
+    REQUIRE(key.has_value());
+    auto manager =
+        P2pManager::create(options("node", dir.path, key.value().privateKeyPem), service);
+    REQUIRE_FALSE(manager.has_value());
+    CHECK(manager.error().code == yams::ErrorCode::InvalidArgument);
+}
+
+TEST_CASE("P2P manager requires full recovery and exact memory sync identity",
+          "[daemon][p2p][manager][security]") {
+    TempDir dir{"readiness"};
+    MemorySyncService service{backend(dir.path / "ops"),
+                              MemorySyncConfig{"node", 60'000, "manager-corpus", 1}};
+    auto key = yams::memory_sync::generateWriterKeyPair();
+    REQUIRE(key.has_value());
+    auto managerOptions = options("node", dir.path, key.value().privateKeyPem);
+    auto unrecovered = P2pManager::create(managerOptions, service);
+    REQUIRE_FALSE(unrecovered.has_value());
+    REQUIRE(service.syncFully().has_value());
+    managerOptions.corpusId = "different-corpus";
+    auto mismatched = P2pManager::create(managerOptions, service);
+    REQUIRE_FALSE(mismatched.has_value());
+    CHECK(mismatched.error().code == yams::ErrorCode::InvalidArgument);
 }
 
 TEST_CASE("P2P manager rejects reconnect intervals above the hard ceiling",

--- a/tests/unit/daemon/p2p_protocol_catch2_test.cpp
+++ b/tests/unit/daemon/p2p_protocol_catch2_test.cpp
@@ -167,11 +167,19 @@ TEST_CASE("P2P peer trust store pins first contact and rejects key changes",
     auto first = trust.verifyOrPin("peer", firstPin, true);
     REQUIRE(first.has_value());
     CHECK(first.value().firstContactPinned);
+    CHECK_FALSE(first.value().pinnedByOperator);
     CHECK(trust.pinnedPin("peer") == firstPin);
 
     auto known = trust.verifyOrPin("peer", firstPin, false);
     REQUIRE(known.has_value());
     CHECK_FALSE(known.value().firstContactPinned);
+    CHECK_FALSE(known.value().pinnedByOperator);
+
+    REQUIRE(trust.enrollOperatorPeer("peer", firstPin).has_value());
+    auto enrolled = trust.verifyOrPin("peer", firstPin, false);
+    REQUIRE(enrolled.has_value());
+    CHECK_FALSE(enrolled.value().firstContactPinned);
+    CHECK(enrolled.value().pinnedByOperator);
 
     auto changed = trust.verifyOrPin("peer", changedPin, true);
     REQUIRE_FALSE(changed.has_value());
@@ -204,6 +212,8 @@ TEST_CASE("P2P hello binds TLS identities and exchanges causal watermarks",
     CHECK(pair.server.value().peerNodeId == "client-node");
     CHECK(pair.client.value().firstContactPinned);
     CHECK(pair.server.value().firstContactPinned);
+    CHECK_FALSE(pair.client.value().pinnedByOperator);
+    CHECK_FALSE(pair.server.value().pinnedByOperator);
     CHECK(pair.client.value().peerWatermark("server-node") == 3);
     CHECK(pair.server.value().peerWatermark("client-node") == 2);
     CHECK(pair.client.value().peerVersion.get("server-node") == 3);

--- a/tests/unit/daemon/peer_registry_catch2_test.cpp
+++ b/tests/unit/daemon/peer_registry_catch2_test.cpp
@@ -51,12 +51,14 @@ CREATE TABLE p2p_peers (
     corpus_id TEXT NOT NULL DEFAULT '',
     corpus_epoch INTEGER NOT NULL DEFAULT 0,
     last_seen_vv TEXT NOT NULL DEFAULT '{"counters_":{}}',
-    last_connected_ms INTEGER NOT NULL DEFAULT 0
+    last_connected_ms INTEGER NOT NULL DEFAULT 0,
+    pinned_by_operator INTEGER NOT NULL DEFAULT 0
 )
 )sql")
                     .has_value());
         auto insert =
-            legacy.prepare("INSERT INTO p2p_peers(node_id, spki_hash) VALUES('legacy-peer', ?)");
+            legacy.prepare("INSERT INTO p2p_peers(node_id, spki_hash, pinned_by_operator) "
+                           "VALUES('legacy-peer', ?, 1)");
         REQUIRE(insert.has_value());
         auto statement = std::move(insert.value());
         REQUIRE(statement.bind(1, std::string(64, 'a')).has_value());
@@ -71,6 +73,14 @@ CREATE TABLE p2p_peers (
     CHECK(peers.value().front().endpoint.empty());
     CHECK_FALSE(peers.value().front().remembered);
     CHECK_FALSE(peers.value().front().pinnedByOperator);
+    auto legacyTrust = opened.value()->verifyOrPin("legacy-peer", std::string(64, 'a'), false);
+    REQUIRE(legacyTrust.has_value());
+    CHECK_FALSE(legacyTrust.value().firstContactPinned);
+    CHECK_FALSE(legacyTrust.value().pinnedByOperator);
+    REQUIRE(opened.value()->enrollOperatorPeer("legacy-peer", std::string(64, 'a')).has_value());
+    auto reenrolled = opened.value()->verifyOrPin("legacy-peer", std::string(64, 'a'), false);
+    REQUIRE(reenrolled.has_value());
+    CHECK(reenrolled.value().pinnedByOperator);
     yams::memory_sync::VersionVector version;
     REQUIRE(opened.value()
                 ->updatePeerState("legacy-peer", "corpus", 1, version, 7, "host:9721", true)
@@ -101,6 +111,9 @@ TEST_CASE("P2P peer registry persists operator enrollment",
     CHECK(peers.value().front().spkiPin == pin);
     CHECK(peers.value().front().pinnedByOperator);
     CHECK_FALSE(peers.value().front().remembered);
+    auto trusted = registry.verifyOrPin("peer-node", pin, false);
+    REQUIRE(trusted.has_value());
+    CHECK(trusted.value().pinnedByOperator);
 }
 
 TEST_CASE("P2P peer registry persists trust and causal state across restart",
@@ -121,8 +134,13 @@ TEST_CASE("P2P peer registry persists trust and causal state across restart",
         auto first = registry.verifyOrPin("peer-node", std::string(64, 'A'), true);
         REQUIRE(first.has_value());
         CHECK(first.value().firstContactPinned);
+        CHECK_FALSE(first.value().pinnedByOperator);
+        REQUIRE(registry.enrollOperatorPeer("peer-node", pin).has_value());
+        auto promoted = registry.verifyOrPin("peer-node", pin, false);
+        REQUIRE(promoted.has_value());
+        CHECK(promoted.value().pinnedByOperator);
         auto firstUpdate =
-            registry.updatePeerState("peer-node", "corpus", 7, version, 123456, {}, false, true);
+            registry.updatePeerState("peer-node", "corpus", 7, version, 123456, {}, false);
         const std::string firstUpdateError =
             firstUpdate ? std::string{} : firstUpdate.error().message;
         INFO(firstUpdateError);
@@ -130,7 +148,7 @@ TEST_CASE("P2P peer registry persists trust and causal state across restart",
         // A later non-operator update must not downgrade the pin source.
         REQUIRE(registry
                     .updatePeerState("peer-node", "corpus", 7, version, 123999,
-                                     "ghost.example:9721", true, false)
+                                     "ghost.example:9721", true)
                     .has_value());
     }
 
@@ -141,6 +159,7 @@ TEST_CASE("P2P peer registry persists trust and causal state across restart",
     auto known = registry.verifyOrPin("peer-node", pin, false);
     REQUIRE(known.has_value());
     CHECK_FALSE(known.value().firstContactPinned);
+    CHECK(known.value().pinnedByOperator);
     auto changed = registry.verifyOrPin("peer-node", std::string(64, 'b'), true);
     REQUIRE_FALSE(changed.has_value());
     CHECK(changed.error().code == yams::ErrorCode::Unauthorized);

--- a/tests/unit/daemon/service_manager_catch2_test.cpp
+++ b/tests/unit/daemon/service_manager_catch2_test.cpp
@@ -5,6 +5,7 @@
 // pi-lens-ignore: fatal error
 #include <catch2/catch_test_macros.hpp>
 
+#include <nlohmann/json.hpp>
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/use_future.hpp>
@@ -19,6 +20,11 @@
 #include <stdexcept>
 #include <system_error>
 #include <thread>
+
+#ifdef _WIN32
+#include <aclapi.h>
+#include <windows.h>
+#endif
 
 #include "../../common/test_helpers_catch2.h"
 
@@ -227,6 +233,62 @@ private:
     std::shared_ptr<PluginHostLifecycleCounters> counters_;
 };
 
+fs::path writeProtectedWriterManifest(const fs::path& directory, std::string_view nodeId,
+                                      std::string_view corpusId, std::uint64_t corpusEpoch) {
+    auto keys = memory_sync::generateWriterKeyPair();
+    REQUIRE(keys.has_value());
+    const auto privateKey = directory / "writer-private.pem";
+    const auto publicKey = directory / "writer-public.pem";
+    REQUIRE(
+        ServiceManager::__test_writeProtectedP2pPrivateKey(privateKey, keys.value().privateKeyPem)
+            .has_value());
+    REQUIRE(ServiceManager::__test_writeProtectedP2pPrivateKey(publicKey, keys.value().publicKeyPem)
+                .has_value());
+    const auto manifest = directory / "writers.json";
+    const nlohmann::json content{
+        {"schema_version", 1},
+        {"corpus_id", corpusId},
+        {"corpus_epoch", corpusEpoch},
+        {"local_key",
+         {{"writer_id", nodeId},
+          {"key_id", "local-v1"},
+          {"private_key_path", privateKey.string()}}},
+        {"trusted_writers", nlohmann::json::array({{{"writer_id", nodeId},
+                                                    {"key_id", "local-v1"},
+                                                    {"public_key_path", publicKey.string()}}})}};
+    REQUIRE(
+        ServiceManager::__test_writeProtectedP2pPrivateKey(manifest, content.dump()).has_value());
+    return manifest;
+}
+
+void grantUntrustedKeyAccess(const fs::path& keyPath, bool writable) {
+#ifdef _WIN32
+    BYTE worldSid[SECURITY_MAX_SID_SIZE];
+    DWORD worldSidBytes = sizeof(worldSid);
+    REQUIRE(CreateWellKnownSid(WinWorldSid, nullptr, worldSid, &worldSidBytes));
+    PACL currentAcl = nullptr;
+    PSECURITY_DESCRIPTOR descriptor = nullptr;
+    REQUIRE(GetNamedSecurityInfoW(const_cast<wchar_t*>(keyPath.c_str()), SE_FILE_OBJECT,
+                                  DACL_SECURITY_INFORMATION, nullptr, nullptr, &currentAcl, nullptr,
+                                  &descriptor) == ERROR_SUCCESS);
+    EXPLICIT_ACCESSW access{};
+    access.grfAccessPermissions = writable ? GENERIC_WRITE : GENERIC_READ;
+    access.grfAccessMode = GRANT_ACCESS;
+    access.grfInheritance = NO_INHERITANCE;
+    BuildTrusteeWithSidW(&access.Trustee, worldSid);
+    PACL broadenedAcl = nullptr;
+    REQUIRE(SetEntriesInAclW(1, &access, currentAcl, &broadenedAcl) == ERROR_SUCCESS);
+    REQUIRE(SetNamedSecurityInfoW(const_cast<wchar_t*>(keyPath.c_str()), SE_FILE_OBJECT,
+                                  DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                                  nullptr, nullptr, broadenedAcl, nullptr) == ERROR_SUCCESS);
+    LocalFree(broadenedAcl);
+    LocalFree(descriptor);
+#else
+    fs::permissions(keyPath, writable ? fs::perms::group_write : fs::perms::group_read,
+                    fs::perm_options::add);
+#endif
+}
+
 } // namespace
 
 // Test fixture for ServiceManager tests
@@ -351,6 +413,60 @@ TEST_CASE_METHOD(ServiceManagerFixture,
     CHECK((result.error().message.find(config_.dataDir.string()) != std::string::npos));
 }
 
+TEST_CASE_METHOD(ServiceManagerFixture,
+                 "ServiceManager rejects direct P2P without usable writer authentication",
+                 "[daemon][service_manager][p2p][security][config]") {
+    config_.memorySync.enabled = true;
+    config_.memorySync.transport = "direct";
+    config_.memorySync.nodeId = "123e4567-e89b-42d3-a456-42661417400a";
+    config_.memorySync.corpusId = "missing-writer-auth";
+    config_.memorySync.corpusEpoch = 1;
+
+    ServiceManager manager(config_, state_, lifecycleFsm_);
+    REQUIRE(manager.initialize().has_value());
+    boost::asio::io_context io;
+    compat::stop_source stopSource;
+    auto future = boost::asio::co_spawn(
+        io, manager.initializeAsyncAwaitable(stopSource.get_token()), boost::asio::use_future);
+    io.run();
+    const auto initialized = future.get();
+    REQUIRE_FALSE(initialized.has_value());
+    CHECK(initialized.error().code == ErrorCode::InvalidArgument);
+    CHECK(initialized.error().message.find("writer_auth_required=true") != std::string::npos);
+}
+
+TEST_CASE_METHOD(ServiceManagerFixture,
+                 "ServiceManager rejects provenance-unknown direct operation stores",
+                 "[daemon][service_manager][p2p][security][migration]") {
+    const std::string nodeId = "123e4567-e89b-42d3-a456-42661417400a";
+    const std::string corpusId = "legacy-direct-store";
+    const auto manifest = writeProtectedWriterManifest(testDir_, nodeId, corpusId, 2);
+    const auto legacyObject = config_.dataDir / "p2p" / "op-store" / "legacy" / "record.json";
+    fs::create_directories(legacyObject.parent_path());
+    std::ofstream(legacyObject) << "unsigned-history";
+
+    config_.memorySync.enabled = true;
+    config_.memorySync.transport = "direct";
+    config_.memorySync.nodeId = nodeId;
+    config_.memorySync.corpusId = corpusId;
+    config_.memorySync.corpusEpoch = 2;
+    config_.memorySync.writerAuthRequired = true;
+    config_.memorySync.writerAuthManifestPath = manifest.string();
+
+    ServiceManager manager(config_, state_, lifecycleFsm_);
+    REQUIRE(manager.initialize().has_value());
+    boost::asio::io_context io;
+    compat::stop_source stopSource;
+    auto future = boost::asio::co_spawn(
+        io, manager.initializeAsyncAwaitable(stopSource.get_token()), boost::asio::use_future);
+    io.run();
+    const auto initialized = future.get();
+    REQUIRE_FALSE(initialized.has_value());
+    CHECK(initialized.error().code == ErrorCode::InvalidState);
+    CHECK(initialized.error().message.find("provenance-unknown") != std::string::npos);
+    CHECK(fs::exists(legacyObject));
+}
+
 TEST_CASE_METHOD(ServiceManagerFixture, "ServiceManager rejects symbolic-link P2P identity keys",
                  "[daemon][service_manager][p2p][security]") {
 #ifdef _WIN32
@@ -366,6 +482,30 @@ TEST_CASE_METHOD(ServiceManagerFixture, "ServiceManager rejects symbolic-link P2
     }
     fs::permissions(victim, fs::perms::owner_read | fs::perms::owner_write,
                     fs::perm_options::replace);
+    const auto publicKey = testDir_ / "identity.pub.pem";
+    {
+        std::ofstream output(publicKey, std::ios::binary | std::ios::trunc);
+        REQUIRE(output.good());
+        output << generated.value().publicKeyPem;
+    }
+    const auto manifest = testDir_ / "writers.json";
+    {
+        nlohmann::json content{
+            {"schema_version", 1},
+            {"corpus_id", "identity-security-test"},
+            {"corpus_epoch", 1},
+            {"local_key",
+             {{"writer_id", "123e4567-e89b-42d3-a456-42661417400a"},
+              {"key_id", "local-v1"},
+              {"private_key_path", victim.string()}}},
+            {"trusted_writers",
+             nlohmann::json::array({{{"writer_id", "123e4567-e89b-42d3-a456-42661417400a"},
+                                     {"key_id", "local-v1"},
+                                     {"public_key_path", publicKey.string()}}})}};
+        std::ofstream output(manifest, std::ios::binary | std::ios::trunc);
+        REQUIRE(output.good());
+        output << content.dump();
+    }
     const auto identity = testDir_ / "identity.pem";
     fs::create_symlink(victim, identity);
 
@@ -375,6 +515,8 @@ TEST_CASE_METHOD(ServiceManagerFixture, "ServiceManager rejects symbolic-link P2
     config_.memorySync.corpusId = "identity-security-test";
     config_.memorySync.corpusEpoch = 1;
     config_.memorySync.identityKeyPath = identity.string();
+    config_.memorySync.writerAuthRequired = true;
+    config_.memorySync.writerAuthManifestPath = manifest.string();
 
     ServiceManager manager(config_, state_, lifecycleFsm_);
     REQUIRE(manager.initialize().has_value());
@@ -388,6 +530,112 @@ TEST_CASE_METHOD(ServiceManagerFixture, "ServiceManager rejects symbolic-link P2
     CHECK(initialized.error().code == ErrorCode::Unauthorized);
     CHECK(initialized.error().message.find("symbolic link") != std::string::npos);
     CHECK(fs::is_symlink(fs::symlink_status(identity)));
+#endif
+}
+
+TEST_CASE_METHOD(ServiceManagerFixture,
+                 "ServiceManager rejects broadly accessible direct writer private keys",
+                 "[daemon][service_manager][p2p][security][platform]") {
+    const std::string nodeId = "123e4567-e89b-42d3-a456-42661417400a";
+    const std::string corpusId = "writer-key-security";
+    const auto manifest = writeProtectedWriterManifest(testDir_, nodeId, corpusId, 1);
+    const auto identity = testDir_ / "separate-identity.pem";
+    REQUIRE(ServiceManager::__test_loadOrCreateP2pPrivateKey(identity).has_value());
+    grantUntrustedKeyAccess(testDir_ / "writer-private.pem", false);
+
+    config_.memorySync.enabled = true;
+    config_.memorySync.transport = "direct";
+    config_.memorySync.nodeId = nodeId;
+    config_.memorySync.corpusId = corpusId;
+    config_.memorySync.corpusEpoch = 1;
+    config_.memorySync.identityKeyPath = identity.string();
+    config_.memorySync.writerAuthRequired = true;
+    config_.memorySync.writerAuthManifestPath = manifest.string();
+
+    ServiceManager manager(config_, state_, lifecycleFsm_);
+    REQUIRE(manager.initialize().has_value());
+    boost::asio::io_context io;
+    compat::stop_source stopSource;
+    auto future = boost::asio::co_spawn(
+        io, manager.initializeAsyncAwaitable(stopSource.get_token()), boost::asio::use_future);
+    io.run();
+    const auto initialized = future.get();
+    REQUIRE_FALSE(initialized.has_value());
+    CHECK(initialized.error().code == ErrorCode::Unauthorized);
+}
+
+TEST_CASE_METHOD(ServiceManagerFixture, "ServiceManager rejects writable direct writer trust files",
+                 "[daemon][service_manager][p2p][security][platform]") {
+    const std::string nodeId = "123e4567-e89b-42d3-a456-42661417400a";
+    const std::string corpusId = "writer-trust-security";
+    const auto manifest = writeProtectedWriterManifest(testDir_, nodeId, corpusId, 1);
+    const auto identity = testDir_ / "trust-test-identity.pem";
+    REQUIRE(ServiceManager::__test_loadOrCreateP2pPrivateKey(identity).has_value());
+
+    SECTION("writable manifest") {
+        grantUntrustedKeyAccess(manifest, true);
+    }
+    SECTION("writable public key") {
+        grantUntrustedKeyAccess(testDir_ / "writer-public.pem", true);
+    }
+
+    config_.memorySync.enabled = true;
+    config_.memorySync.transport = "direct";
+    config_.memorySync.nodeId = nodeId;
+    config_.memorySync.corpusId = corpusId;
+    config_.memorySync.corpusEpoch = 1;
+    config_.memorySync.identityKeyPath = identity.string();
+    config_.memorySync.writerAuthRequired = true;
+    config_.memorySync.writerAuthManifestPath = manifest.string();
+
+    ServiceManager manager(config_, state_, lifecycleFsm_);
+    REQUIRE(manager.initialize().has_value());
+    boost::asio::io_context io;
+    compat::stop_source stopSource;
+    auto future = boost::asio::co_spawn(
+        io, manager.initializeAsyncAwaitable(stopSource.get_token()), boost::asio::use_future);
+    io.run();
+    const auto initialized = future.get();
+    REQUIRE_FALSE(initialized.has_value());
+    CHECK(initialized.error().code == ErrorCode::Unauthorized);
+}
+
+TEST_CASE_METHOD(ServiceManagerFixture,
+                 "ServiceManager creates owner-only P2P identity keys and rejects broad access",
+                 "[daemon][service_manager][p2p][security][platform]") {
+    const auto identity = testDir_ / "generated-identity.pem";
+    auto created = ServiceManager::__test_loadOrCreateP2pPrivateKey(identity);
+    REQUIRE(created.has_value());
+    REQUIRE_FALSE(created.value().empty());
+    REQUIRE(ServiceManager::__test_loadOrCreateP2pPrivateKey(identity).has_value());
+
+    grantUntrustedKeyAccess(identity, false);
+
+    auto rejected = ServiceManager::__test_loadOrCreateP2pPrivateKey(identity);
+    REQUIRE_FALSE(rejected.has_value());
+    CHECK(rejected.error().code == ErrorCode::Unauthorized);
+}
+
+TEST_CASE_METHOD(ServiceManagerFixture,
+                 "ServiceManager rejects inherited Windows P2P identity ACLs",
+                 "[daemon][service_manager][p2p][security][platform]") {
+#ifndef _WIN32
+    SKIP("Windows ACL-specific coverage");
+#else
+    const auto identity = testDir_ / "inherited-identity.pem";
+    REQUIRE(ServiceManager::__test_loadOrCreateP2pPrivateKey(identity).has_value());
+    PACL currentAcl = nullptr;
+    PSECURITY_DESCRIPTOR descriptor = nullptr;
+    REQUIRE(GetNamedSecurityInfoW(const_cast<wchar_t*>(identity.c_str()), SE_FILE_OBJECT,
+                                  DACL_SECURITY_INFORMATION, nullptr, nullptr, &currentAcl, nullptr,
+                                  &descriptor) == ERROR_SUCCESS);
+    REQUIRE(SetNamedSecurityInfoW(const_cast<wchar_t*>(identity.c_str()), SE_FILE_OBJECT,
+                                  DACL_SECURITY_INFORMATION | UNPROTECTED_DACL_SECURITY_INFORMATION,
+                                  nullptr, nullptr, currentAcl, nullptr) == ERROR_SUCCESS);
+    LocalFree(descriptor);
+    auto rejected = ServiceManager::__test_loadOrCreateP2pPrivateKey(identity);
+    REQUIRE_FALSE(rejected.has_value());
+    CHECK(rejected.error().code == ErrorCode::Unauthorized);
 #endif
 }
 

--- a/tests/unit/memory_sync/memory_sync_config_catch2_test.cpp
+++ b/tests/unit/memory_sync/memory_sync_config_catch2_test.cpp
@@ -188,7 +188,96 @@ TEST_CASE("authenticated writer manifest produces schema-v4 envelopes",
     CHECK(envelope.at("signingKeyId") == "writer-v1");
     CHECK(envelope.at("signature").get<std::string>().size() == 128);
 
-    service.value()->stop();
+    service.value().reset();
+    const auto checkpoints = inspect.list("checkpoint/");
+    REQUIRE(checkpoints.has_value());
+    REQUIRE(checkpoints.value().size() == 1);
+    auto checkpoint = inspect.retrieve(checkpoints.value().front());
+    REQUIRE(checkpoint.has_value());
+    auto forged = nlohmann::json::parse(text(checkpoint.value()));
+    forged["commitments"] = nlohmann::json::array();
+    REQUIRE(inspect.remove(checkpoints.value().front()).has_value());
+    REQUIRE(inspect.store(checkpoints.value().front(), bytes(forged.dump())).has_value());
+    auto rejected = createMemorySyncService(cfg);
+    REQUIRE(rejected.has_value());
+    auto recovered = rejected.value()->syncFully();
+    REQUIRE_FALSE(recovered.has_value());
+    CHECK(recovered.error().code == yams::ErrorCode::Unauthorized);
+
+    rejected.value().reset();
+    std::error_code error;
+    std::filesystem::remove_all(dir, error);
+}
+
+TEST_CASE("authenticated writer recovery reports legacy unsigned history",
+          "[memory-sync][config][auth][migration]") {
+    const auto dir = std::filesystem::temp_directory_path() /
+                     ("yams-memory-sync-auth-migration-" +
+                      std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+    std::filesystem::create_directories(dir);
+    writeWriterKeyPair(dir, "writer-v1");
+    constexpr std::string_view writerId = "123e4567-e89b-42d3-a456-426614174000";
+
+    MemorySyncDaemonConfig unsignedConfig;
+    unsignedConfig.enabled = true;
+    unsignedConfig.nodeId = std::string(writerId);
+    unsignedConfig.corpusId = "corpus-a";
+    unsignedConfig.corpusEpoch = 7;
+    unsignedConfig.path = (dir / "store").string();
+    auto unsignedService = createMemorySyncService(unsignedConfig);
+    REQUIRE(unsignedService.has_value());
+    REQUIRE(unsignedService.value()->publish("legacy", bytes("payload")).has_value());
+    unsignedService.value().reset();
+
+    yams::storage::FilesystemBackend inspect;
+    yams::storage::BackendConfig inspectConfig;
+    inspectConfig.type = "filesystem";
+    inspectConfig.localPath = unsignedConfig.path;
+    REQUIRE(inspect.initialize(inspectConfig).has_value());
+    auto checkpoints = inspect.list("checkpoint/");
+    REQUIRE(checkpoints.has_value());
+    REQUIRE_FALSE(checkpoints.value().empty());
+    const auto checkpoint = inspect.retrieve(checkpoints.value().front());
+    REQUIRE(checkpoint.has_value());
+    auto forgedCheckpoint = nlohmann::json::parse(text(checkpoint.value()));
+    forgedCheckpoint["authenticated_writers"] = true;
+    REQUIRE(inspect.remove(checkpoints.value().front()).has_value());
+    REQUIRE(inspect.store(checkpoints.value().front(), bytes(forgedCheckpoint.dump())).has_value());
+
+    const nlohmann::json manifest = {
+        {"schema_version", 1},
+        {"corpus_id", "corpus-a"},
+        {"corpus_epoch", 7},
+        {"local_key",
+         {{"writer_id", writerId}, {"key_id", "writer-v1"}, {"private_key_path", "writer-v1.pem"}}},
+        {"trusted_writers",
+         {{{"writer_id", writerId},
+           {"key_id", "writer-v1"},
+           {"public_key_path", "writer-v1.pub"},
+           {"revoked", false}}}},
+    };
+    const auto manifestPath = dir / "writers.json";
+    std::ofstream(manifestPath) << manifest.dump();
+
+    auto authenticatedConfig = unsignedConfig;
+    authenticatedConfig.writerAuthRequired = true;
+    authenticatedConfig.writerAuthManifestPath = manifestPath.string();
+    auto authenticatedService = createMemorySyncService(authenticatedConfig);
+    REQUIRE(authenticatedService.has_value());
+    const auto recovered = authenticatedService.value()->syncFully();
+    REQUIRE_FALSE(recovered.has_value());
+    CHECK(recovered.error().code == yams::ErrorCode::InvalidData);
+    CHECK_FALSE(authenticatedService.value()->directP2pReady(writerId, "corpus-a", 7));
+
+    for (const auto& key : checkpoints.value()) {
+        REQUIRE(inspect.remove(key).has_value());
+    }
+    REQUIRE(authenticatedService.value()->syncFully().has_value());
+    CHECK(authenticatedService.value()->legacyUnauthenticatedHistoryObserved());
+    CHECK_FALSE(authenticatedService.value()->directP2pReady(writerId, "corpus-a", 7));
+    CHECK_FALSE(authenticatedService.value()->readCached("legacy").has_value());
+
+    authenticatedService.value().reset();
     std::error_code error;
     std::filesystem::remove_all(dir, error);
 }

--- a/tools/fuzzing/meson.build
+++ b/tools/fuzzing/meson.build
@@ -36,6 +36,9 @@ fuzz_deps = [
   dependency('protobuf'),
   dependency('nlohmann_json'),
 ]
+if host_machine.system() == 'windows'
+  fuzz_deps += cpp.find_library('advapi32', required: true)
+endif
 
 # Seed generator (non-fuzzer utility)
 seedgen = executable('seedgen',


### PR DESCRIPTION
## Summary

Stacked draft child of #71. This change closes the disclosed direct-P2P bootstrap-trust and private-key protection blockers without merging or deploying anything.

- requires a usable schema-v4 writer-authentication manifest for direct transport and rejects unauthenticated embedded `P2pManager` construction
- requires explicit operator enrollment on both sides of cold bootstrap; legacy TOFU and connection pins remain non-authoritative
- migrates peer trust with a new enrollment-provenance generation, invalidating legacy `pinned_by_operator` bits until explicit re-enrollment
- fails closed on unsigned/provenance-unknown direct operation stores and documents the fresh-epoch migration procedure
- verifies direct writer private keys even when TLS uses a separate identity key
- creates and reads identity/writer keys through same-object owner-only checks: `open`/`fstat`/`O_NOFOLLOW` on Unix and handle-based reparse, owner SID, protected-DACL, and ACE validation on Windows
- propagates Windows `advapi32` linkage to daemon and fuzz consumers

Before the fix:

- direct configuration without writer authentication was accepted
- a peer remembered through legacy TOFU could satisfy cold-bootstrap transport trust
- pre-upgrade `connect ?pin=` rows could retain false operator authority
- embedded callers could construct direct `P2pManager` instances over unsigned schema-v3 services
- existing unsigned stores were quarantined silently instead of producing an actionable upgrade failure
- separate writer signing keys bypassed the TLS identity key's owner-only permission checks
- Windows key creation inherited ambient ACL authority and pathname validation raced the later read

## Known stack blockers

This draft child is **not independently mergeable or deployable**. The umbrella still has separately tracked replicated-apply serialization, operator-status semantics, fuzzing, and final live gates.

## AI disclosure

Extensive AI assistance was used for implementation, test generation, and adversarial review. All changes were locally inspected and validated; remaining stack blockers are disclosed above.

## Stack

- Base: `fix/p2p-transport-availability` / #71
- Head: `fix/p2p-bootstrap-trust` at `435ff22518f206bb77617e312d1962cb573eec38`
- Umbrella: #68

Do not merge or deploy this child independently.
