### PR TITLE
fix(p2p): serialize sync application

### DIFF
--- a/include/yams/daemon/components/ServiceManager.h
+++ b/include/yams/daemon/components/ServiceManager.h
@@ -453,7 +453,22 @@ public:
     void testingApplyMemorySyncWinners() { applyMemorySyncWinners(); }
     void testingPublishMemorySyncBackfill() { publishMemorySyncBackfill(); }
     void testingSetMemorySyncBackfillItemBudget(std::size_t budget) {
+        std::lock_guard<std::mutex> lock(memorySyncBackfillMutex_);
         memorySyncBackfillState_.itemBudgetPerCycle = std::max<std::size_t>(budget, 1);
+    }
+    bool testingMemorySyncApplyLockHeld() {
+        std::unique_lock<std::mutex> lock(memorySyncApplyMutex_, std::try_to_lock);
+        return !lock.owns_lock();
+    }
+    std::uint64_t testingMemorySyncApplyAttempts() const noexcept {
+        return memorySyncApplyAttempts_.load(std::memory_order_acquire);
+    }
+    bool testingMemorySyncBackfillLockHeld() {
+        std::unique_lock<std::mutex> lock(memorySyncBackfillMutex_, std::try_to_lock);
+        return !lock.owns_lock();
+    }
+    std::uint64_t testingMemorySyncBackfillAttempts() const noexcept {
+        return memorySyncBackfillAttempts_.load(std::memory_order_acquire);
     }
     static bool __test_shouldStartSessionWatcher(std::string_view disableValue) {
         return shouldStartSessionWatcher(disableValue);
@@ -951,6 +966,12 @@ private:
     std::function<void(std::string_view)> memorySyncDeleteOutboxObserver_;
     mutable std::mutex memorySyncStageObserverMutex_;
     std::function<void(std::string_view)> memorySyncStageObserver_;
+    // Direct sessions may finish concurrently. Serialize the daemon adapter pipeline and its
+    // vector rebuild state; backfill has a separate lock so focused maintenance calls are safe.
+    mutable std::mutex memorySyncApplyMutex_;
+    mutable std::mutex memorySyncBackfillMutex_;
+    std::atomic<std::uint64_t> memorySyncApplyAttempts_{0};
+    std::atomic<std::uint64_t> memorySyncBackfillAttempts_{0};
     bool memorySyncVectorRebuildDirty_{false};
     struct MemorySyncBackfillState {
         enum class Domain { Documents, Vectors, Topology };

--- a/include/yams/memory_sync/memory_sync_service.h
+++ b/include/yams/memory_sync/memory_sync_service.h
@@ -74,23 +74,43 @@ public:
 
     /// Start the periodic sync worker (idempotent).
     Result<void> start() {
+        if (activeCallbackSnapshot() != nullptr) {
+            return Error{ErrorCode::InvalidState,
+                         "memory sync cannot restart from its active callback"};
+        }
         std::lock_guard<std::mutex> lifecycleLock(lifecycleMutex_);
+        const bool restarting = stop_.load(std::memory_order_acquire);
         if (worker_.joinable()) {
-            return {};
+            if (!stop_.load(std::memory_order_acquire)) {
+                return {};
+            }
+            try {
+                worker_.join();
+            } catch (const std::exception& e) {
+                return Error{ErrorCode::InternalError, e.what()};
+            }
+        }
+        std::unique_lock<std::recursive_mutex> callbackDrain(callbackExecutionMutex_,
+                                                             std::defer_lock);
+        if (restarting) {
+            callbackDrain.lock();
         }
         if (config_.syncIntervalMs == 0) {
             return Error{ErrorCode::InvalidArgument,
                          "memory_sync.syncIntervalMs must be greater than zero"};
         }
         backend_->resetCancel(); // A restarted worker receives a fresh cancellation generation.
+        callbackGeneration_.fetch_add(1, std::memory_order_acq_rel);
         stop_.store(false, std::memory_order_release);
         if (auto lease = refreshSessionLease(); !lease) {
             return lease.error();
         }
         namespaceCleaned_.store(false, std::memory_order_release);
+        workerRunning_.store(true, std::memory_order_release);
         try {
             worker_ = std::thread([this] { workerLoop(); });
         } catch (const std::exception& e) {
+            workerRunning_.store(false, std::memory_order_release);
             return Error{ErrorCode::InternalError, e.what()};
         }
         return {};
@@ -99,11 +119,15 @@ public:
     /// Stop the periodic worker and join (idempotent, noexcept).
     void stop() noexcept {
         stop_.store(true, std::memory_order_release);
+        callbackGeneration_.fetch_add(1, std::memory_order_acq_rel);
         backend_->requestCancel();
         sleepCv_.notify_all();
-        if (std::hash<std::thread::id>{}(std::this_thread::get_id()) ==
-            workerIdHash_.load(std::memory_order_acquire)) {
-            return; // The worker exits after the callback; a non-worker owner performs the join.
+        if (activeCallbackSnapshot() != nullptr ||
+            std::hash<std::thread::id>{}(std::this_thread::get_id()) ==
+                workerIdHash_.load(std::memory_order_acquire)) {
+            // A callback may own callbackExecutionMutex_ while the worker is waiting for it.
+            // Leave joining to a non-callback owner to avoid a stop/join lock cycle.
+            return;
         }
         std::lock_guard<std::mutex> lifecycleLock(lifecycleMutex_);
         // A concurrent start may have acquired the lifecycle lock after the first request.
@@ -117,6 +141,9 @@ public:
                 shutdownFailures_.fetch_add(1, std::memory_order_relaxed);
             }
         }
+        // Direct-session callbacks do not belong to worker_. Drain the active callback before
+        // releasing lifecycleMutex_. Generation checks discard callbacks queued before stop().
+        std::lock_guard<std::recursive_mutex> callbackDrain(callbackExecutionMutex_);
         if (config_.cleanupOwnedNamespaceOnStop && !namespaceCleaned_.exchange(true)) {
             backend_->resetCancel();
             if (!backend_->clear()) {
@@ -130,8 +157,8 @@ public:
     }
 
     bool started() const noexcept {
-        std::lock_guard<std::mutex> lifecycleLock(lifecycleMutex_);
-        return worker_.joinable() && !stop_.load(std::memory_order_acquire);
+        return workerRunning_.load(std::memory_order_acquire) &&
+               !stop_.load(std::memory_order_acquire);
     }
 
     bool stopRequested() const noexcept { return stop_.load(std::memory_order_acquire); }
@@ -354,8 +381,8 @@ public:
     }
 
     Result<std::map<std::string, MemoryIndexRecord>> syncOnce() {
-        if (callbackOwner_ == this && callbackSnapshot_ != nullptr) {
-            return *callbackSnapshot_;
+        if (const auto* callbackSnapshot = activeCallbackSnapshot()) {
+            return *callbackSnapshot;
         }
         Result<std::map<std::string, MemoryIndexRecord>> result;
         bool quarantineChanged = false;
@@ -500,6 +527,21 @@ public:
 #endif
 
 private:
+    struct CallbackContext {
+        const MemorySyncService* owner;
+        const std::map<std::string, MemoryIndexRecord>* snapshot;
+        CallbackContext* previous;
+    };
+
+    const std::map<std::string, MemoryIndexRecord>* activeCallbackSnapshot() const noexcept {
+        for (auto* context = callbackContext_; context != nullptr; context = context->previous) {
+            if (context->owner == this) {
+                return context->snapshot;
+            }
+        }
+        return nullptr;
+    }
+
     /// Immutable state published for IPC readers. Readers never take loopMutex_
     /// (held for the whole reconciliation on slow backends), so a slow sync can
     /// not stall status or cached reads; they consume this snapshot instead.
@@ -516,32 +558,53 @@ private:
         committed_ = std::move(state);
     }
 
-    void invokeAfterSyncCallback(
-        const std::map<std::string, MemoryIndexRecord>* snapshot = nullptr) noexcept {
-        std::map<std::string, MemoryIndexRecord> adapterSnapshot;
-        if (snapshot == nullptr) {
-            std::lock_guard<std::mutex> lock(loopMutex_);
-            adapterSnapshot = loop_.adapterState();
-            snapshot = &adapterSnapshot;
+    void invokeAfterSyncCallback() noexcept {
+        if (activeCallbackSnapshot() != nullptr) {
+            callbackPending_.store(true, std::memory_order_release);
+            return; // The outer callback coalesces recursive callback-side publications.
         }
-        std::function<void()> callback;
-        {
-            std::lock_guard<std::mutex> lock(callbackMutex_);
-            callback = afterSyncCallback_;
+        const auto callbackGeneration = callbackGeneration_.load(std::memory_order_acquire);
+        while (!callbackExecutionMutex_.try_lock()) {
+            if (stop_.load(std::memory_order_acquire) ||
+                callbackGeneration != callbackGeneration_.load(std::memory_order_acquire)) {
+                return;
+            }
+            std::this_thread::yield();
         }
-        if (!callback || stop_.load(std::memory_order_acquire)) {
+        std::unique_lock<std::recursive_mutex> executionLock(callbackExecutionMutex_,
+                                                             std::adopt_lock);
+        if (callbackGeneration != callbackGeneration_.load(std::memory_order_acquire)) {
             return;
         }
-        callbackOwner_ = snapshot != nullptr ? this : nullptr;
-        callbackSnapshot_ = snapshot;
-        try {
-            callback();
-        } catch (...) {
-            // Adapter failures are isolated from the convergence/session worker.
-            callbackFailures_.fetch_add(1, std::memory_order_relaxed);
+        for (;;) {
+            callbackPending_.store(false, std::memory_order_release);
+            std::function<void()> callback;
+            {
+                std::lock_guard<std::mutex> lock(callbackMutex_);
+                callback = afterSyncCallback_;
+            }
+            if (!callback || stop_.load(std::memory_order_acquire)) {
+                return;
+            }
+            std::map<std::string, MemoryIndexRecord> adapterSnapshot;
+            {
+                std::lock_guard<std::mutex> lock(loopMutex_);
+                adapterSnapshot = loop_.adapterState();
+            }
+            CallbackContext context{this, &adapterSnapshot, callbackContext_};
+            callbackContext_ = &context;
+            try {
+                callback();
+            } catch (...) {
+                // Adapter failures are isolated from the convergence/session worker.
+                callbackFailures_.fetch_add(1, std::memory_order_relaxed);
+            }
+            callbackContext_ = context.previous;
+            if (!callbackPending_.exchange(false, std::memory_order_acq_rel) ||
+                stop_.load(std::memory_order_acquire)) {
+                return;
+            }
         }
-        callbackSnapshot_ = nullptr;
-        callbackOwner_ = nullptr;
     }
 
     void workerLoop() {
@@ -594,11 +657,7 @@ private:
                             std::chrono::steady_clock::now().time_since_epoch())
                             .count(),
                         std::memory_order_release);
-                    if (quarantineChanged) {
-                        invokeAfterSyncCallback();
-                    } else {
-                        invokeAfterSyncCallback(&snapshot.value());
-                    }
+                    invokeAfterSyncCallback();
                     callbackInvoked = true;
                 }
             } else {
@@ -611,6 +670,7 @@ private:
             sleepCv_.wait_for(sleepLock, std::chrono::milliseconds(config_.syncIntervalMs),
                               [this] { return stop_.load(std::memory_order_acquire); });
         }
+        workerRunning_.store(false, std::memory_order_release);
         workerIdHash_.store(0, std::memory_order_release);
     }
 
@@ -643,17 +703,22 @@ private:
     MemorySyncLoop loop_;
     std::atomic<bool> stop_{false};
     std::thread worker_;
+    std::atomic<bool> workerRunning_{false};
     std::atomic<std::size_t> workerIdHash_{0};
     mutable std::mutex lifecycleMutex_;
     std::mutex sleepMutex_;
     std::condition_variable sleepCv_;
-    inline static thread_local const MemorySyncService* callbackOwner_{nullptr};
-    inline static thread_local const std::map<std::string, MemoryIndexRecord>* callbackSnapshot_{
-        nullptr};
+    inline static thread_local CallbackContext* callbackContext_{nullptr};
     // Serializes all MemorySyncLoop access (worker sync vs publish/read/syncOnce);
     // the loop keeps mutable version-vector/logical-clock/merged state.
     mutable std::mutex loopMutex_;
     mutable std::mutex callbackMutex_;
+    // Serialize adapter callbacks process-wide: callbacks are arbitrary and can call between
+    // services, so per-service locks permit an A↔B ABBA deadlock. Recursive acquisition permits
+    // same-thread A→B nesting while CallbackContext coalesces A→B→A re-entry.
+    inline static std::recursive_mutex callbackExecutionMutex_;
+    std::atomic<std::uint64_t> callbackGeneration_{0};
+    std::atomic<bool> callbackPending_{false};
     std::function<void()> afterSyncCallback_;
     std::atomic<std::uint64_t> callbackFailures_{0};
     std::atomic<std::uint64_t> shutdownFailures_{0};

--- a/src/daemon/components/ServiceManager.cpp
+++ b/src/daemon/components/ServiceManager.cpp
@@ -3004,6 +3004,8 @@ bool ServiceManager::drainMemorySyncDocumentDeleteOutbox() noexcept {
 }
 
 void ServiceManager::applyMemorySyncWinners() noexcept {
+    memorySyncApplyAttempts_.fetch_add(1, std::memory_order_acq_rel);
+    std::lock_guard<std::mutex> applyLock(memorySyncApplyMutex_);
     if (!memorySync_ || memorySync_->stopRequested()) {
         return;
     }
@@ -3137,6 +3139,8 @@ void ServiceManager::applyMemorySyncWinners() noexcept {
 }
 
 void ServiceManager::publishMemorySyncBackfill() noexcept try {
+    memorySyncBackfillAttempts_.fetch_add(1, std::memory_order_acq_rel);
+    std::lock_guard<std::mutex> backfillLock(memorySyncBackfillMutex_);
     if (!memorySync_) {
         return;
     }

--- a/tests/integration/daemon/memory_sync_service_integration_test.cpp
+++ b/tests/integration/daemon/memory_sync_service_integration_test.cpp
@@ -721,6 +721,139 @@ TEST_CASE("Daemon memory sync stop during production apply prevents later adapte
     CHECK(harness.shutdownSucceeded());
 }
 
+TEST_CASE("Daemon serializes concurrent memory sync apply callbacks",
+          "[integration][daemon][memory-sync][apply-serialization]") {
+    auto options = makeMemorySyncHarnessOptions("123e4567-e89b-42d3-a456-426614174021",
+                                                "apply-serialization-corpus");
+    yams::test::DaemonHarness harness{std::move(options)};
+    REQUIRE(harness.start(30s));
+
+    auto* serviceManager = harness.daemon()->getServiceManager();
+    REQUIRE(serviceManager != nullptr);
+    auto* daemonSync = serviceManager->testingMemorySyncService();
+    REQUIRE(daemonSync != nullptr);
+    std::atomic<std::size_t> contentStages{0};
+    std::promise<void> firstEnteredPromise;
+    auto firstEntered = firstEnteredPromise.get_future();
+    std::promise<void> secondEnteredPromise;
+    auto secondEntered = secondEnteredPromise.get_future();
+    std::promise<void> releaseFirstPromise;
+    auto releaseFirst = releaseFirstPromise.get_future().share();
+    serviceManager->testingSetMemorySyncStageObserver([&](std::string_view stage) {
+        if (stage != "apply.after_content") {
+            return;
+        }
+        if (contentStages.fetch_add(1, std::memory_order_acq_rel) == 0) {
+            firstEnteredPromise.set_value();
+            releaseFirst.wait();
+        } else {
+            secondEnteredPromise.set_value();
+        }
+    });
+
+    const auto applyAttemptsBefore = serviceManager->testingMemorySyncApplyAttempts();
+    auto first = std::async(std::launch::async,
+                            [serviceManager] { serviceManager->testingApplyMemorySyncWinners(); });
+    REQUIRE(firstEntered.wait_for(5s) == std::future_status::ready);
+    CHECK(serviceManager->testingMemorySyncApplyLockHeld());
+    auto second = std::async(std::launch::async,
+                             [serviceManager] { serviceManager->testingApplyMemorySyncWinners(); });
+    const auto secondApplyDeadline = std::chrono::steady_clock::now() + 5s;
+    while (serviceManager->testingMemorySyncApplyAttempts() < applyAttemptsBefore + 2 &&
+           std::chrono::steady_clock::now() < secondApplyDeadline) {
+        std::this_thread::yield();
+    }
+    REQUIRE(serviceManager->testingMemorySyncApplyAttempts() == applyAttemptsBefore + 2);
+    CHECK(contentStages.load(std::memory_order_acquire) == 1);
+
+    releaseFirstPromise.set_value();
+    first.get();
+    second.get();
+    CHECK(secondEntered.wait_for(5s) == std::future_status::ready);
+    CHECK(contentStages.load(std::memory_order_acquire) == 2);
+
+    auto repository = serviceManager->getMetadataRepo();
+    auto contentStore = serviceManager->getContentStore();
+    REQUIRE(repository != nullptr);
+    REQUIRE(contentStore != nullptr);
+    std::vector<std::string> hashes;
+    std::vector<yams::metadata::BatchDocumentInsert> inserts;
+    for (int index = 0; index < 2; ++index) {
+        const auto payload = bytes("serialized-backfill-" + std::to_string(index));
+        auto stored = contentStore->storeBytes(payload);
+        REQUIRE(stored.has_value());
+        hashes.push_back(stored.value().contentHash);
+        yams::metadata::BatchDocumentInsert item;
+        item.info.filePath = "/local/serialized-" + std::to_string(index) + ".md";
+        item.info.fileName = "serialized-" + std::to_string(index) + ".md";
+        item.info.fileExtension = ".md";
+        item.info.fileSize = static_cast<std::int64_t>(payload.size());
+        item.info.sha256Hash = stored.value().contentHash;
+        item.info.mimeType = "text/markdown";
+        inserts.push_back(std::move(item));
+    }
+    REQUIRE(repository->batchInsertDocumentsWithMetadata(inserts).has_value());
+    const auto writerCounterBeforeBackfill =
+        daemonSync->currentVersion().get("123e4567-e89b-42d3-a456-426614174021");
+    serviceManager->testingSetMemorySyncBackfillItemBudget(1);
+
+    std::atomic<std::size_t> backfillStages{0};
+    std::promise<void> firstBackfillEnteredPromise;
+    auto firstBackfillEntered = firstBackfillEnteredPromise.get_future();
+    std::promise<void> secondBackfillEnteredPromise;
+    auto secondBackfillEntered = secondBackfillEnteredPromise.get_future();
+    std::promise<void> releaseFirstBackfillPromise;
+    auto releaseFirstBackfill = releaseFirstBackfillPromise.get_future().share();
+    serviceManager->testingSetMemorySyncStageObserver([&](std::string_view stage) {
+        if (!stage.starts_with("backfill.")) {
+            return;
+        }
+        if (backfillStages.fetch_add(1, std::memory_order_acq_rel) == 0) {
+            firstBackfillEnteredPromise.set_value();
+            releaseFirstBackfill.wait();
+        } else {
+            secondBackfillEnteredPromise.set_value();
+        }
+    });
+    const auto backfillAttemptsBefore = serviceManager->testingMemorySyncBackfillAttempts();
+    auto firstBackfill = std::async(std::launch::async, [serviceManager] {
+        serviceManager->testingPublishMemorySyncBackfill();
+    });
+    REQUIRE(firstBackfillEntered.wait_for(5s) == std::future_status::ready);
+    CHECK(serviceManager->testingMemorySyncBackfillLockHeld());
+    auto secondBackfill = std::async(std::launch::async, [serviceManager] {
+        serviceManager->testingPublishMemorySyncBackfill();
+    });
+    const auto secondBackfillDeadline = std::chrono::steady_clock::now() + 5s;
+    while (serviceManager->testingMemorySyncBackfillAttempts() < backfillAttemptsBefore + 2 &&
+           std::chrono::steady_clock::now() < secondBackfillDeadline) {
+        std::this_thread::yield();
+    }
+    REQUIRE(serviceManager->testingMemorySyncBackfillAttempts() == backfillAttemptsBefore + 2);
+    CHECK(backfillStages.load(std::memory_order_acquire) == 1);
+
+    releaseFirstBackfillPromise.set_value();
+    firstBackfill.get();
+    secondBackfill.get();
+    CHECK(secondBackfillEntered.wait_for(5s) == std::future_status::ready);
+    CHECK(backfillStages.load(std::memory_order_acquire) == 2);
+    serviceManager->testingSetMemorySyncStageObserver({});
+
+    yams::memory_sync::MemorySyncService peer{
+        makeFilesystemBackend(harness.dataDir() / "shared-memory"),
+        yams::memory_sync::MemorySyncConfig{"serialization-peer", 60'000,
+                                            "apply-serialization-corpus", 1}};
+    REQUIRE(peer.syncFully().has_value());
+    for (const auto& hash : hashes) {
+        CHECK(peer.readCached("document/" + hash).has_value());
+    }
+    CHECK(peer.currentVersion().get("123e4567-e89b-42d3-a456-426614174021") ==
+          writerCounterBeforeBackfill + 4);
+
+    harness.stop();
+    CHECK(harness.shutdownSucceeded());
+}
+
 TEST_CASE("Daemon memory sync prerequisite failures stop dependent adapters and retry",
           "[integration][daemon][memory-sync][prerequisite]") {
     auto options = makeMemorySyncHarnessOptions("123e4567-e89b-42d3-a456-426614174012",

--- a/tests/integration/daemon/meson.build
+++ b/tests/integration/daemon/meson.build
@@ -628,6 +628,14 @@ else
       timeout: 60,
       args: ['Daemon memory sync stop during production apply prevents later adapters', '--allow-running-no-tests'],
     )
+    test('daemon_memory_sync_apply_serialization',
+      memory_sync_service_integration_exe,
+      suite: ['integration', 'daemon', 'catch2', 'memory-sync'],
+      env: _daemon_test_env,
+      is_parallel: false,
+      timeout: 60,
+      args: ['Daemon serializes concurrent memory sync apply callbacks', '--allow-running-no-tests'],
+    )
     test('daemon_memory_sync_prerequisites',
       memory_sync_service_integration_exe,
       suite: ['integration', 'daemon', 'catch2', 'memory-sync'],

--- a/tests/unit/memory_sync/memory_sync_service_catch2_test.cpp
+++ b/tests/unit/memory_sync/memory_sync_service_catch2_test.cpp
@@ -614,6 +614,422 @@ TEST_CASE("MemorySyncService direct delta apply invokes adapter callback after l
     CHECK(reader.readCached("user/key").has_value());
 }
 
+TEST_CASE("MemorySyncService serializes concurrent post-sync callbacks",
+          "[memory-sync][service][direct-delta][concurrency]") {
+    TempDirGuard writerADir;
+    TempDirGuard writerBDir;
+    TempDirGuard readerDir;
+    MemorySyncService writerA{makeBackend(writerADir.path),
+                              MemorySyncConfig{"writer-a", 60'000, "callback-corpus", 1}};
+    MemorySyncService writerB{makeBackend(writerBDir.path),
+                              MemorySyncConfig{"writer-b", 60'000, "callback-corpus", 1}};
+    MemorySyncService reader{makeBackend(readerDir.path),
+                             MemorySyncConfig{"reader", 60'000, "callback-corpus", 1}};
+    REQUIRE(writerA.publish("user/a", bytes("a")).has_value());
+    REQUIRE(writerB.publish("user/b", bytes("b")).has_value());
+    auto deltaA = writerA.exportLocalDeltasAfter({});
+    auto deltaB = writerB.exportLocalDeltasAfter({});
+    REQUIRE(deltaA.has_value());
+    REQUIRE(deltaB.has_value());
+
+    std::atomic<std::size_t> active{0};
+    std::atomic<std::size_t> maximumActive{0};
+    std::atomic<std::size_t> callbacks{0};
+    std::promise<void> firstEnteredPromise;
+    auto firstEntered = firstEnteredPromise.get_future();
+    std::promise<void> releaseFirstPromise;
+    auto releaseFirst = releaseFirstPromise.get_future().share();
+    reader.setAfterSyncCallback([&] {
+        const auto nowActive = active.fetch_add(1, std::memory_order_acq_rel) + 1;
+        auto observed = maximumActive.load(std::memory_order_acquire);
+        while (observed < nowActive && !maximumActive.compare_exchange_weak(
+                                           observed, nowActive, std::memory_order_acq_rel)) {
+        }
+        if (callbacks.fetch_add(1, std::memory_order_acq_rel) == 0) {
+            firstEnteredPromise.set_value();
+            releaseFirst.wait();
+        }
+        active.fetch_sub(1, std::memory_order_acq_rel);
+    });
+
+    auto first =
+        std::async(std::launch::async, [&] { return reader.applyDeltas(deltaA.value().deltas); });
+    REQUIRE(firstEntered.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+    auto second =
+        std::async(std::launch::async, [&] { return reader.applyDeltas(deltaB.value().deltas); });
+
+    const auto mergedDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (reader.replicationState().version.get("writer-b") == 0 &&
+           std::chrono::steady_clock::now() < mergedDeadline) {
+        std::this_thread::yield();
+    }
+    REQUIRE(reader.replicationState().version.get("writer-b") == 1);
+    CHECK(second.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout);
+    CHECK(maximumActive.load(std::memory_order_acquire) == 1);
+
+    releaseFirstPromise.set_value();
+    REQUIRE(first.get().has_value());
+    REQUIRE(second.get().has_value());
+    CHECK(callbacks.load(std::memory_order_acquire) == 2);
+    CHECK(maximumActive.load(std::memory_order_acquire) == 1);
+}
+
+TEST_CASE("MemorySyncService callback stop does not join a worker waiting for serialization",
+          "[memory-sync][service][direct-delta][concurrency][stop]") {
+    TempDirGuard writerDir;
+    TempDirGuard readerDir;
+    MemorySyncService writer{makeBackend(writerDir.path),
+                             MemorySyncConfig{"writer", 60'000, "callback-stop-corpus", 1}};
+    MemorySyncService reader{makeBackend(readerDir.path),
+                             MemorySyncConfig{"reader", 1, "callback-stop-corpus", 1}};
+    REQUIRE(writer.publish("user/key", bytes("value")).has_value());
+    auto deltas = writer.exportLocalDeltasAfter({});
+    REQUIRE(deltas.has_value());
+
+    std::promise<void> callbackEnteredPromise;
+    auto callbackEntered = callbackEnteredPromise.get_future();
+    std::promise<void> allowStopPromise;
+    auto allowStop = allowStopPromise.get_future().share();
+    std::atomic<bool> first{true};
+    reader.setAfterSyncCallback([&] {
+        if (first.exchange(false, std::memory_order_acq_rel)) {
+            callbackEnteredPromise.set_value();
+            allowStop.wait();
+            reader.stop();
+        }
+    });
+
+    auto directApply =
+        std::async(std::launch::async, [&] { return reader.applyDeltas(deltas.value().deltas); });
+    REQUIRE(callbackEntered.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+    REQUIRE(reader.start().has_value());
+    const auto workerDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (reader.successfulSyncCycles() == 0 &&
+           std::chrono::steady_clock::now() < workerDeadline) {
+        std::this_thread::yield();
+    }
+    REQUIRE(reader.successfulSyncCycles() > 0);
+
+    allowStopPromise.set_value();
+    REQUIRE(directApply.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+    REQUIRE(directApply.get().has_value());
+    reader.stop();
+    CHECK_FALSE(reader.started());
+    REQUIRE(reader.start().has_value());
+    CHECK(reader.started());
+    reader.stop();
+    CHECK_FALSE(reader.started());
+}
+
+TEST_CASE("MemorySyncService serializes callbacks across service instances",
+          "[memory-sync][service][direct-delta][concurrency][cross-service]") {
+    TempDirGuard writerADir;
+    TempDirGuard writerBDir;
+    TempDirGuard readerADir;
+    TempDirGuard readerBDir;
+    MemorySyncService writerA{makeBackend(writerADir.path),
+                              MemorySyncConfig{"writer-a", 60'000, "global-callback-a", 1}};
+    MemorySyncService writerB{makeBackend(writerBDir.path),
+                              MemorySyncConfig{"writer-b", 60'000, "global-callback-b", 1}};
+    MemorySyncService readerA{makeBackend(readerADir.path),
+                              MemorySyncConfig{"reader-a", 60'000, "global-callback-a", 1}};
+    MemorySyncService readerB{makeBackend(readerBDir.path),
+                              MemorySyncConfig{"reader-b", 60'000, "global-callback-b", 1}};
+    REQUIRE(writerA.publish("user/a", bytes("a")).has_value());
+    REQUIRE(writerB.publish("user/b", bytes("b")).has_value());
+    auto deltaA = writerA.exportLocalDeltasAfter({});
+    auto deltaB = writerB.exportLocalDeltasAfter({});
+    REQUIRE(deltaA.has_value());
+    REQUIRE(deltaB.has_value());
+
+    std::atomic<std::size_t> active{0};
+    std::atomic<std::size_t> maximumActive{0};
+    std::atomic<std::size_t> callbacks{0};
+    std::promise<void> firstEnteredPromise;
+    auto firstEntered = firstEnteredPromise.get_future();
+    std::promise<void> releaseFirstPromise;
+    auto releaseFirst = releaseFirstPromise.get_future().share();
+    const auto callback = [&] {
+        const auto nowActive = active.fetch_add(1, std::memory_order_acq_rel) + 1;
+        auto observed = maximumActive.load(std::memory_order_acquire);
+        while (observed < nowActive && !maximumActive.compare_exchange_weak(
+                                           observed, nowActive, std::memory_order_acq_rel)) {
+        }
+        if (callbacks.fetch_add(1, std::memory_order_acq_rel) == 0) {
+            firstEnteredPromise.set_value();
+            releaseFirst.wait();
+        }
+        active.fetch_sub(1, std::memory_order_acq_rel);
+    };
+    readerA.setAfterSyncCallback(callback);
+    readerB.setAfterSyncCallback(callback);
+
+    auto first =
+        std::async(std::launch::async, [&] { return readerA.applyDeltas(deltaA.value().deltas); });
+    REQUIRE(firstEntered.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+    auto second =
+        std::async(std::launch::async, [&] { return readerB.applyDeltas(deltaB.value().deltas); });
+    const auto mergedDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (readerB.replicationState().version.get("writer-b") == 0 &&
+           std::chrono::steady_clock::now() < mergedDeadline) {
+        std::this_thread::yield();
+    }
+    REQUIRE(readerB.replicationState().version.get("writer-b") == 1);
+    CHECK(second.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout);
+    CHECK(maximumActive.load(std::memory_order_acquire) == 1);
+
+    releaseFirstPromise.set_value();
+    REQUIRE(first.get().has_value());
+    REQUIRE(second.get().has_value());
+    CHECK(callbacks.load(std::memory_order_acquire) == 2);
+    CHECK(maximumActive.load(std::memory_order_acquire) == 1);
+}
+
+TEST_CASE("MemorySyncService refreshes queued callback snapshots after serialization",
+          "[memory-sync][service][direct-delta][concurrency][snapshot]") {
+    TempDirGuard writerADir;
+    TempDirGuard writerBDir;
+    TempDirGuard readerDir;
+    MemorySyncService writerA{makeBackend(writerADir.path),
+                              MemorySyncConfig{"writer-a", 60'000, "callback-snapshot", 1}};
+    MemorySyncService writerB{makeBackend(writerBDir.path),
+                              MemorySyncConfig{"writer-b", 60'000, "callback-snapshot", 1}};
+    MemorySyncService reader{makeBackend(readerDir.path),
+                             MemorySyncConfig{"reader", 1, "callback-snapshot", 1}};
+    REQUIRE(writerA.publish("user/a", bytes("a")).has_value());
+    REQUIRE(writerB.publish("user/b", bytes("b")).has_value());
+    auto deltaA = writerA.exportLocalDeltasAfter({});
+    auto deltaB = writerB.exportLocalDeltasAfter({});
+    REQUIRE(deltaA.has_value());
+    REQUIRE(deltaB.has_value());
+
+    std::atomic<std::size_t> callbacks{0};
+    std::atomic<bool> staleSnapshot{false};
+    std::promise<void> firstEnteredPromise;
+    auto firstEntered = firstEnteredPromise.get_future();
+    std::promise<void> releaseFirstPromise;
+    auto releaseFirst = releaseFirstPromise.get_future().share();
+    reader.setAfterSyncCallback([&] {
+        if (callbacks.fetch_add(1, std::memory_order_acq_rel) == 0) {
+            firstEnteredPromise.set_value();
+            releaseFirst.wait();
+            return;
+        }
+        auto snapshot = reader.syncOnce();
+        if (!snapshot || !snapshot.value().contains("user/b")) {
+            staleSnapshot.store(true, std::memory_order_release);
+        }
+    });
+
+    auto first =
+        std::async(std::launch::async, [&] { return reader.applyDeltas(deltaA.value().deltas); });
+    REQUIRE(firstEntered.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+    REQUIRE(reader.start().has_value());
+    const auto workerDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (reader.successfulSyncCycles() == 0 &&
+           std::chrono::steady_clock::now() < workerDeadline) {
+        std::this_thread::yield();
+    }
+    REQUIRE(reader.successfulSyncCycles() > 0);
+
+    auto second =
+        std::async(std::launch::async, [&] { return reader.applyDeltas(deltaB.value().deltas); });
+    const auto mergeDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (reader.replicationState().version.get("writer-b") == 0 &&
+           std::chrono::steady_clock::now() < mergeDeadline) {
+        std::this_thread::yield();
+    }
+    REQUIRE(reader.replicationState().version.get("writer-b") == 1);
+    releaseFirstPromise.set_value();
+    REQUIRE(first.get().has_value());
+    REQUIRE(second.get().has_value());
+    const auto callbackDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (callbacks.load(std::memory_order_acquire) < 3 &&
+           std::chrono::steady_clock::now() < callbackDeadline) {
+        std::this_thread::yield();
+    }
+    REQUIRE(callbacks.load(std::memory_order_acquire) >= 3);
+    reader.stop();
+
+    CHECK(callbacks.load(std::memory_order_acquire) >= 3);
+    CHECK_FALSE(staleSnapshot.load(std::memory_order_acquire));
+}
+
+TEST_CASE("MemorySyncService stop drains an active direct-session callback",
+          "[memory-sync][service][direct-delta][concurrency][stop]") {
+    TempDirGuard writerDir;
+    TempDirGuard readerDir;
+    MemorySyncService writer{makeBackend(writerDir.path),
+                             MemorySyncConfig{"writer", 60'000, "callback-drain-corpus", 1}};
+    MemorySyncService reader{makeBackend(readerDir.path),
+                             MemorySyncConfig{"reader", 60'000, "callback-drain-corpus", 1}};
+    REQUIRE(writer.publish("user/key", bytes("value")).has_value());
+    auto deltas = writer.exportLocalDeltasAfter({});
+    REQUIRE(deltas.has_value());
+
+    std::promise<void> callbackEnteredPromise;
+    auto callbackEntered = callbackEnteredPromise.get_future();
+    std::promise<void> releaseCallbackPromise;
+    auto releaseCallback = releaseCallbackPromise.get_future().share();
+    std::atomic<bool> callbackObservedStopped{false};
+    reader.setAfterSyncCallback([&] {
+        callbackEnteredPromise.set_value();
+        releaseCallback.wait();
+        callbackObservedStopped.store(!reader.started(), std::memory_order_release);
+    });
+    auto directApply =
+        std::async(std::launch::async, [&] { return reader.applyDeltas(deltas.value().deltas); });
+    REQUIRE(callbackEntered.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+    std::promise<void> stopStartedPromise;
+    auto stopStarted = stopStartedPromise.get_future();
+    auto stopped = std::async(std::launch::async, [&] {
+        stopStartedPromise.set_value();
+        reader.stop();
+    });
+    REQUIRE(stopStarted.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+    CHECK(stopped.wait_for(std::chrono::milliseconds(100)) == std::future_status::timeout);
+
+    releaseCallbackPromise.set_value();
+    REQUIRE(directApply.get().has_value());
+    stopped.get();
+    CHECK(callbackObservedStopped.load(std::memory_order_acquire));
+    CHECK_FALSE(reader.started());
+}
+
+TEST_CASE("MemorySyncService can destroy another service from a callback",
+          "[memory-sync][service][direct-delta][concurrency][destruction]") {
+    TempDirGuard writerDir;
+    TempDirGuard readerADir;
+    TempDirGuard readerBDir;
+    MemorySyncService writer{makeBackend(writerDir.path),
+                             MemorySyncConfig{"writer", 60'000, "callback-destroy-a", 1}};
+    MemorySyncService readerA{makeBackend(readerADir.path),
+                              MemorySyncConfig{"reader-a", 60'000, "callback-destroy-a", 1}};
+    auto readerB = std::make_unique<MemorySyncService>(
+        makeBackend(readerBDir.path), MemorySyncConfig{"reader-b", 1, "callback-destroy-b", 1});
+    REQUIRE(writer.publish("user/key", bytes("value")).has_value());
+    auto deltas = writer.exportLocalDeltasAfter({});
+    REQUIRE(deltas.has_value());
+
+    std::promise<void> callbackEnteredPromise;
+    auto callbackEntered = callbackEnteredPromise.get_future();
+    std::promise<void> allowDestroyPromise;
+    auto allowDestroy = allowDestroyPromise.get_future().share();
+    readerA.setAfterSyncCallback([&] {
+        callbackEnteredPromise.set_value();
+        allowDestroy.wait();
+        readerB.reset();
+    });
+    auto apply =
+        std::async(std::launch::async, [&] { return readerA.applyDeltas(deltas.value().deltas); });
+    REQUIRE(callbackEntered.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+    REQUIRE(readerB->start().has_value());
+    const auto workerDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (readerB->successfulSyncCycles() == 0 &&
+           std::chrono::steady_clock::now() < workerDeadline) {
+        std::this_thread::yield();
+    }
+    REQUIRE(readerB->successfulSyncCycles() > 0);
+
+    allowDestroyPromise.set_value();
+    REQUIRE(apply.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+    REQUIRE(apply.get().has_value());
+    CHECK(readerB == nullptr);
+}
+
+TEST_CASE("MemorySyncService coalesces recursive post-sync callbacks",
+          "[memory-sync][service][direct-delta][concurrency][recursive]") {
+    TempDirGuard writerADir;
+    TempDirGuard writerBDir;
+    TempDirGuard readerDir;
+    MemorySyncService writerA{makeBackend(writerADir.path),
+                              MemorySyncConfig{"writer-a", 60'000, "recursive-corpus", 1}};
+    MemorySyncService writerB{makeBackend(writerBDir.path),
+                              MemorySyncConfig{"writer-b", 60'000, "recursive-corpus", 1}};
+    MemorySyncService reader{makeBackend(readerDir.path),
+                             MemorySyncConfig{"reader", 60'000, "recursive-corpus", 1}};
+    REQUIRE(writerA.publish("user/a", bytes("a")).has_value());
+    REQUIRE(writerB.publish("user/b", bytes("b")).has_value());
+    auto deltaA = writerA.exportLocalDeltasAfter({});
+    auto deltaB = writerB.exportLocalDeltasAfter({});
+    REQUIRE(deltaA.has_value());
+    REQUIRE(deltaB.has_value());
+    REQUIRE(reader.applyDeltas(deltaA.value().deltas).has_value());
+    REQUIRE(reader.applyDeltas(deltaB.value().deltas).has_value());
+
+    std::atomic<std::size_t> callbacks{0};
+    std::atomic<bool> nestedQuarantineSucceeded{false};
+    reader.setAfterSyncCallback([&] {
+        if (callbacks.fetch_add(1, std::memory_order_acq_rel) == 0) {
+            auto nested = reader.quarantineWriter("writer-b", "reader");
+            nestedQuarantineSucceeded.store(nested && nested.value(), std::memory_order_release);
+        }
+    });
+    auto quarantined = reader.quarantineWriter("writer-a", "reader");
+    REQUIRE(quarantined.has_value());
+    CHECK(quarantined.value());
+    CHECK(nestedQuarantineSucceeded.load(std::memory_order_acquire));
+    CHECK(callbacks.load(std::memory_order_acquire) == 2);
+    CHECK(reader.replicationState().quarantinedWriters.contains("writer-a"));
+    CHECK(reader.replicationState().quarantinedWriters.contains("writer-b"));
+}
+
+TEST_CASE("MemorySyncService preserves callback ownership across services",
+          "[memory-sync][service][direct-delta][concurrency][recursive]") {
+    TempDirGuard writerA1Dir;
+    TempDirGuard writerA2Dir;
+    TempDirGuard writerBDir;
+    TempDirGuard readerADir;
+    TempDirGuard readerBDir;
+    MemorySyncService writerA1{makeBackend(writerA1Dir.path),
+                               MemorySyncConfig{"writer-a1", 60'000, "cross-callback-a", 1}};
+    MemorySyncService writerA2{makeBackend(writerA2Dir.path),
+                               MemorySyncConfig{"writer-a2", 60'000, "cross-callback-a", 1}};
+    MemorySyncService writerB{makeBackend(writerBDir.path),
+                              MemorySyncConfig{"writer-b", 60'000, "cross-callback-b", 1}};
+    MemorySyncService readerA{makeBackend(readerADir.path),
+                              MemorySyncConfig{"reader-a", 60'000, "cross-callback-a", 1}};
+    MemorySyncService readerB{makeBackend(readerBDir.path),
+                              MemorySyncConfig{"reader-b", 60'000, "cross-callback-b", 1}};
+    REQUIRE(writerA1.publish("user/a1", bytes("a1")).has_value());
+    REQUIRE(writerA2.publish("user/a2", bytes("a2")).has_value());
+    REQUIRE(writerB.publish("user/b", bytes("b")).has_value());
+    auto deltaA1 = writerA1.exportLocalDeltasAfter({});
+    auto deltaA2 = writerA2.exportLocalDeltasAfter({});
+    auto deltaB = writerB.exportLocalDeltasAfter({});
+    REQUIRE(deltaA1.has_value());
+    REQUIRE(deltaA2.has_value());
+    REQUIRE(deltaB.has_value());
+    REQUIRE(readerA.applyDeltas(deltaA1.value().deltas).has_value());
+    REQUIRE(readerA.applyDeltas(deltaA2.value().deltas).has_value());
+    REQUIRE(readerB.applyDeltas(deltaB.value().deltas).has_value());
+
+    std::atomic<std::size_t> callbacksA{0};
+    std::atomic<std::size_t> callbacksB{0};
+    std::atomic<bool> nestedB{false};
+    std::atomic<bool> nestedA{false};
+    readerB.setAfterSyncCallback([&] {
+        if (callbacksB.fetch_add(1, std::memory_order_acq_rel) == 0) {
+            auto quarantineA = readerA.quarantineWriter("writer-a2", "reader-a");
+            nestedA.store(quarantineA && quarantineA.value(), std::memory_order_release);
+        }
+    });
+    readerA.setAfterSyncCallback([&] {
+        if (callbacksA.fetch_add(1, std::memory_order_acq_rel) == 0) {
+            auto quarantineB = readerB.quarantineWriter("writer-b", "reader-b");
+            nestedB.store(quarantineB && quarantineB.value(), std::memory_order_release);
+        }
+    });
+
+    auto quarantineA1 = readerA.quarantineWriter("writer-a1", "reader-a");
+    REQUIRE(quarantineA1.has_value());
+    CHECK(quarantineA1.value());
+    CHECK(nestedA.load(std::memory_order_acquire));
+    CHECK(nestedB.load(std::memory_order_acquire));
+    CHECK(callbacksA.load(std::memory_order_acquire) == 2);
+    CHECK(callbacksB.load(std::memory_order_acquire) == 1);
+}
+
 TEST_CASE("MemorySyncService publishes quarantine snapshot before adapter invalidation",
           "[memory-sync][service][direct-delta][quarantine]") {
     TempDirGuard writerDir;


### PR DESCRIPTION
## Summary

Stacked draft child of #72. This change closes the disclosed direct-P2P replicated-apply serialization blocker without merging or deploying anything.

- serializes post-sync callbacks from periodic reconciliation and concurrent direct-P2P sessions process-wide, preventing cross-service ABBA cycles
- keeps memory-sync loop locks released before adapter callbacks, preserving safe callback re-entry
- coalesces callback-side recursive publications and refreshes queued snapshots instead of deadlocking, regressing state, or dropping follow-up work
- invalidates pre-stop queued callbacks and safely drains direct-session callbacks across stop/restart and cross-service destruction
- serializes the daemon content/metadata/vector/topology apply pipeline and vector rebuild state
- separately serializes bounded daemon backfill cursor/domain state

Before the fix:

- two concurrent direct-delta applies entered the post-sync callback simultaneously (`maximumActive == 2`)
- two concurrent daemon apply calls both reached `apply.after_content` while the first callback remained blocked

## Known stack blockers

This draft child is **not independently mergeable or deployable**. The umbrella still has separately tracked operator-status semantics, fuzzing, and final live/release gates.

## AI disclosure

Extensive AI assistance was used for implementation, test generation, and adversarial review. All changes were locally inspected and validated; remaining stack blockers are disclosed above.

## Stack

- Base: `fix/p2p-bootstrap-trust` / #72 at `435ff22518f206bb77617e312d1962cb573eec38`
- Head: `fix/p2p-apply-serialization` at `ed7b09a23cf1bfb5cb6be0bcfc769d826f9e82b4`
- Umbrella: #68

Do not merge or deploy this child independently.
