### PR TITLE
test(p2p): add direct control fuzz harnesses

### DIFF
--- a/docs/p2p.md
+++ b/docs/p2p.md
@@ -81,7 +81,11 @@ Restart both daemons after changing configuration, then confirm the compact stat
 yams daemon status
 ```
 
-Use `yams daemon status -d` for corpus, identity, peer, counter, and failure details.
+Use `yams daemon status -d` for corpus, identity, peer, counter, and failure details. Status is
+local activity and health telemetry, not a global convergence claim: `peer_count` includes the
+local peer registry, `successful_cycles` counts completed local reconciliation cycles, and a recent
+success does not prove that every enrolled peer is reachable or has the same frontier. Confirm
+convergence with explicit per-node corpus/frontier checks after the required full-mesh sessions.
 
 ## Enroll and connect peers
 
@@ -202,6 +206,26 @@ wrangler r2 bucket delete "$BUCKET"
 ```
 
 The smoke performs PUT, GET, HEAD, LIST, and DELETE. Do not put credentials or generated test configuration in git.
+
+## Fuzz direct protocol controls
+
+The direct-P2P fuzz targets exercise the production protocol-v4 handshake/state/history control
+parsers and bounded delta/bootstrap control parsers. Their deterministic seed corpus retains a protocol-v3 hello specifically
+to verify fail-closed exact-version rejection after the v4 upgrade:
+
+```bash
+tools/fuzzing/generate_corpus.sh
+tools/fuzzing/fuzz.sh build
+AFL_FUZZ_SECONDS=60 tools/fuzzing/fuzz.sh fuzz p2p_protocol
+AFL_FUZZ_SECONDS=60 tools/fuzzing/fuzz.sh fuzz p2p_delta
+```
+
+These parser harnesses do not replace deterministic TLS/session, payload-accounting, authenticated
+application, or restart tests. Bounded local fuzz runs are regression evidence, not
+release-readiness evidence. Promotion still requires exact protocol-v4 binaries on every endpoint; at least three isolated cold, warm,
+reconnect, and restart repeats; exact pre/post corpus equality; and captured latency, CPU, RSS,
+logical/wire-byte, and disk-I/O measurements. Existing protocol-v3 or host-contended profiles must
+not be reused for that gate.
 
 ## Troubleshooting
 

--- a/src/daemon/p2p/p2p_delta.cpp
+++ b/src/daemon/p2p/p2p_delta.cpp
@@ -4,7 +4,11 @@
 // pi-lens-ignore: fatal error
 #include <yams/daemon/p2p/p2p_delta.h>
 
+#include "p2p_fuzz.h"
 #include "p2p_json.h"
+
+// pi-lens-ignore: fatal error
+#include <yams/memory_sync/key_policy.h>
 
 #include <limits>
 #include <string_view>
@@ -139,6 +143,34 @@ Result<BatchHeader> parseBatchHeader(const Json& control, const DeltaExchangeOpt
     }
 }
 
+struct DeltaRecordControl {
+    memory_sync::MemoryDelta delta;
+    std::size_t payloadSize{0};
+};
+
+Result<DeltaRecordControl> parseDeltaRecordControl(const Json& control) {
+    try {
+        if (!control.is_object() || control.value("type", std::string{}) != "delta_record") {
+            return Error{ErrorCode::ValidationError, "unexpected p2p delta record message"};
+        }
+        DeltaRecordControl parsed;
+        parsed.delta.logicalKey = control.at("logical_key").get<std::string>();
+        parsed.delta.record = control.at("record").get<memory_sync::MemoryIndexRecord>();
+        parsed.payloadSize = control.at("payload_size").get<std::size_t>();
+        if (parsed.delta.logicalKey.empty() ||
+            parsed.delta.logicalKey.size() > memory_sync::kMaxLogicalKeyBytes ||
+            parsed.payloadSize > kP2pMaxValuePayloadBytes ||
+            (parsed.delta.record.isTombstone() && parsed.payloadSize != 0)) {
+            return Error{ErrorCode::ValidationError,
+                         "p2p delta record control violates protocol bounds"};
+        }
+        return parsed;
+    } catch (const std::exception& error) {
+        return Error{ErrorCode::ValidationError,
+                     std::string("invalid p2p delta record: ") + error.what()};
+    }
+}
+
 struct ReceivedDelta {
     memory_sync::MemoryDelta delta;
     std::size_t wireBytes{0};
@@ -152,24 +184,12 @@ Result<ReceivedDelta> receiveDeltaRecord(P2pConnection& connection,
     if (!control) {
         return control.error();
     }
-    memory_sync::MemoryDelta delta;
-    std::size_t payloadSize = 0;
-    try {
-        if (!control.value().is_object() ||
-            control.value().value("type", std::string{}) != "delta_record") {
-            return Error{ErrorCode::ValidationError, "unexpected p2p delta record message"};
-        }
-        delta.logicalKey = control.value().at("logical_key").get<std::string>();
-        delta.record = control.value().at("record").get<memory_sync::MemoryIndexRecord>();
-        payloadSize = control.value().at("payload_size").get<std::size_t>();
-    } catch (const std::exception& error) {
-        return Error{ErrorCode::ValidationError,
-                     std::string("invalid p2p delta record: ") + error.what()};
+    auto parsed = parseDeltaRecordControl(control.value());
+    if (!parsed) {
+        return parsed.error();
     }
-    if (payloadSize > kP2pMaxValuePayloadBytes ||
-        (delta.record.isTombstone() && payloadSize != 0)) {
-        return Error{ErrorCode::ValidationError, "p2p delta payload size is invalid"};
-    }
+    auto delta = std::move(parsed.value().delta);
+    const auto payloadSize = parsed.value().payloadSize;
     const auto controlBytes = control.value().dump().size() + kFramePrefixBytes;
     const auto payloadBytes = payloadSize == 0 ? 0 : payloadSize + kFramePrefixBytes;
     if (controlBytes > remainingBytes || payloadBytes > remainingBytes - controlBytes) {
@@ -239,25 +259,41 @@ Json acknowledgementJson(const memory_sync::DeltaApplyResult& result) {
             {"vv", result.version}};
 }
 
+Result<DeltaAcknowledgement> parseAcknowledgement(const Json& json) {
+    try {
+        if (!json.is_object() || json.value("type", std::string{}) != "delta_ack") {
+            return Error{ErrorCode::ValidationError, "unexpected p2p delta acknowledgement"};
+        }
+        const auto version = json.at("vv").get<memory_sync::VersionVector>();
+        const auto quarantined = json.at("quarantined").get<std::map<std::string, std::string>>();
+        if (version.counters().size() > kMaxP2pReplicationWriters ||
+            quarantined.size() > kMaxP2pReplicationWriters ||
+            std::ranges::any_of(version.counters(),
+                                [](const auto& entry) {
+                                    return entry.first.empty() ||
+                                           entry.first.size() > kMaxP2pIdentityBytes;
+                                }) ||
+            std::ranges::any_of(quarantined, [](const auto& entry) {
+                return entry.first.empty() || entry.first.size() > kMaxP2pIdentityBytes ||
+                       entry.second.size() > kMaxP2pIdentityBytes;
+            })) {
+            return Error{ErrorCode::ValidationError,
+                         "p2p delta acknowledgement violates writer bounds"};
+        }
+        return DeltaAcknowledgement{.version = version, .quarantined = quarantined.size()};
+    } catch (const std::exception& error) {
+        return Error{ErrorCode::ValidationError,
+                     std::string("invalid p2p delta acknowledgement: ") + error.what()};
+    }
+}
+
 Result<DeltaAcknowledgement> receiveAcknowledgement(P2pConnection& connection,
                                                     std::chrono::milliseconds timeout) {
     auto json = readJson(connection, timeout);
     if (!json) {
         return json.error();
     }
-    try {
-        if (!json.value().is_object() || json.value().value("type", std::string{}) != "delta_ack") {
-            return Error{ErrorCode::ValidationError, "unexpected p2p delta acknowledgement"};
-        }
-        const auto quarantined =
-            json.value().at("quarantined").get<std::map<std::string, std::string>>();
-        return DeltaAcknowledgement{.version =
-                                        json.value().at("vv").get<memory_sync::VersionVector>(),
-                                    .quarantined = quarantined.size()};
-    } catch (const std::exception& error) {
-        return Error{ErrorCode::ValidationError,
-                     std::string("invalid p2p delta acknowledgement: ") + error.what()};
-    }
+    return parseAcknowledgement(json.value());
 }
 
 struct BootstrapPhaseResult {
@@ -299,6 +335,114 @@ parseCommitments(const Json& entries) {
     } catch (const std::exception& error) {
         return Error{ErrorCode::ValidationError,
                      std::string("invalid cold bootstrap commitments: ") + error.what()};
+    }
+}
+
+Result<std::string> parseReplicationMode(const Json& json) {
+    try {
+        if (!json.is_object() || json.value("type", std::string{}) != "replication_mode") {
+            return Error{ErrorCode::ValidationError, "missing p2p replication mode"};
+        }
+        auto mode = json.at("mode").get<std::string>();
+        if (mode != "delta" && mode != "snapshot") {
+            return Error{ErrorCode::ValidationError, "unknown p2p replication mode"};
+        }
+        return mode;
+    } catch (const std::exception& error) {
+        return Error{ErrorCode::ValidationError,
+                     std::string("invalid p2p replication mode: ") + error.what()};
+    }
+}
+
+struct SnapshotBeginControl {
+    std::string witness;
+    memory_sync::VersionVector frontier;
+    std::map<memory_sync::NodeId, memory_sync::WriterHistoryCommitment> commitments;
+    std::size_t recordCount{0};
+    std::size_t payloadBytes{0};
+    std::string rootDigest;
+    memory_sync::DetachedWriterSignature witnessSignature;
+};
+
+Result<SnapshotBeginControl> parseSnapshotBegin(const Json& json,
+                                                const DeltaExchangeOptions& options) {
+    try {
+        if (!json.is_object() || json.value("type", std::string{}) != "snapshot_begin") {
+            return Error{ErrorCode::ValidationError, "missing cold bootstrap manifest"};
+        }
+        SnapshotBeginControl control;
+        control.witness = json.at("witness").get<std::string>();
+        control.frontier = json.at("frontier").get<memory_sync::VersionVector>();
+        auto commitments = parseCommitments(json.at("commitments"));
+        if (!commitments) {
+            return commitments.error();
+        }
+        control.commitments = std::move(commitments.value());
+        control.recordCount = json.at("record_count").get<std::size_t>();
+        control.payloadBytes = json.at("payload_bytes").get<std::size_t>();
+        control.rootDigest = json.at("root_digest").get<std::string>();
+        control.witnessSignature = memory_sync::DetachedWriterSignature{
+            .writerId = control.witness,
+            .keyId = json.at("witness_key_id").get<std::string>(),
+            .algorithm = json.at("witness_algorithm").get<std::string>(),
+            .signature = json.at("witness_signature").get<std::string>()};
+        if (control.witness.empty() || control.witness.size() > kMaxP2pIdentityBytes ||
+            control.frontier.counters().size() > kMaxP2pReplicationWriters ||
+            std::ranges::any_of(control.frontier.counters(),
+                                [](const auto& entry) {
+                                    return entry.first.empty() ||
+                                           entry.first.size() > kMaxP2pIdentityBytes;
+                                }) ||
+            control.recordCount > options.maxSnapshotRecords ||
+            control.payloadBytes > options.maxSnapshotWireBytes ||
+            !memory_sync::isSha256Digest(control.rootDigest) ||
+            control.witnessSignature.keyId.empty() ||
+            control.witnessSignature.keyId.size() > kMaxP2pIdentityBytes ||
+            control.witnessSignature.algorithm.empty() ||
+            control.witnessSignature.algorithm.size() > kMaxP2pIdentityBytes ||
+            control.witnessSignature.signature.empty() ||
+            control.witnessSignature.signature.size() > kMaxP2pIdentityBytes * 4) {
+            return Error{ErrorCode::ValidationError,
+                         "cold bootstrap manifest violates protocol bounds"};
+        }
+        for (const auto& [writer, commitment] : control.commitments) {
+            if (control.frontier.get(writer) != commitment.counter) {
+                return Error{ErrorCode::ValidationError,
+                             "cold bootstrap commitment differs from frontier"};
+            }
+        }
+        return control;
+    } catch (const std::exception& error) {
+        return Error{ErrorCode::ValidationError,
+                     std::string("invalid cold bootstrap manifest: ") + error.what()};
+    }
+}
+
+struct SnapshotAcknowledgement {
+    std::string rootDigest;
+    memory_sync::VersionVector version;
+};
+
+Result<SnapshotAcknowledgement> parseSnapshotAcknowledgement(const Json& json) {
+    try {
+        if (!json.is_object() || json.value("type", std::string{}) != "snapshot_ack") {
+            return Error{ErrorCode::ValidationError, "unexpected cold bootstrap acknowledgement"};
+        }
+        SnapshotAcknowledgement acknowledgement{
+            .rootDigest = json.at("root_digest").get<std::string>(),
+            .version = json.at("vv").get<memory_sync::VersionVector>()};
+        if (!memory_sync::isSha256Digest(acknowledgement.rootDigest) ||
+            acknowledgement.version.counters().size() > kMaxP2pReplicationWriters ||
+            std::ranges::any_of(acknowledgement.version.counters(), [](const auto& entry) {
+                return entry.first.empty() || entry.first.size() > kMaxP2pIdentityBytes;
+            })) {
+            return Error{ErrorCode::ValidationError,
+                         "cold bootstrap acknowledgement violates protocol bounds"};
+        }
+        return acknowledgement;
+    } catch (const std::exception& error) {
+        return Error{ErrorCode::ValidationError,
+                     std::string("invalid cold bootstrap acknowledgement: ") + error.what()};
     }
 }
 
@@ -376,24 +520,20 @@ Result<BootstrapPhaseResult> sendBootstrapPhase(P2pConnection& connection,
     if (!ack) {
         return ack.error();
     }
-    try {
-        if (!ack.value().is_object() ||
-            ack.value().value("type", std::string{}) != "snapshot_ack" ||
-            ack.value().at("root_digest").get<std::string>() != snapshot.value().rootDigest) {
-            return Error{ErrorCode::ValidationError, "cold bootstrap acknowledgement mismatch"};
-        }
-        const auto acknowledged = ack.value().at("vv").get<memory_sync::VersionVector>();
-        if (acknowledged.counters() != snapshot.value().frontier.counters()) {
-            return Error{ErrorCode::ValidationError,
-                         "cold bootstrap acknowledgement frontier mismatch"};
-        }
-        result.peerVersion = std::move(acknowledged);
-        result.stats.snapshotsSent = 1;
-        return result;
-    } catch (const std::exception& error) {
-        return Error{ErrorCode::ValidationError,
-                     std::string("invalid cold bootstrap acknowledgement: ") + error.what()};
+    auto acknowledged = parseSnapshotAcknowledgement(ack.value());
+    if (!acknowledged) {
+        return acknowledged.error();
     }
+    if (acknowledged.value().rootDigest != snapshot.value().rootDigest) {
+        return Error{ErrorCode::ValidationError, "cold bootstrap acknowledgement mismatch"};
+    }
+    if (acknowledged.value().version.counters() != snapshot.value().frontier.counters()) {
+        return Error{ErrorCode::ValidationError,
+                     "cold bootstrap acknowledgement frontier mismatch"};
+    }
+    result.peerVersion = std::move(acknowledged.value().version);
+    result.stats.snapshotsSent = 1;
+    return result;
 }
 
 Result<BootstrapPhaseResult> receiveBootstrapPhase(P2pConnection& connection,
@@ -405,21 +545,12 @@ Result<BootstrapPhaseResult> receiveBootstrapPhase(P2pConnection& connection,
     if (!mode) {
         return mode.error();
     }
-    try {
-        if (!mode.value().is_object() ||
-            mode.value().value("type", std::string{}) != "replication_mode") {
-            return Error{ErrorCode::ValidationError, "missing p2p replication mode"};
-        }
-        const auto selected = mode.value().at("mode").get<std::string>();
-        if (selected == "delta") {
-            return result;
-        }
-        if (selected != "snapshot") {
-            return Error{ErrorCode::ValidationError, "unknown p2p replication mode"};
-        }
-    } catch (const std::exception& error) {
-        return Error{ErrorCode::ValidationError,
-                     std::string("invalid p2p replication mode: ") + error.what()};
+    auto selectedMode = parseReplicationMode(mode.value());
+    if (!selectedMode) {
+        return selectedMode.error();
+    }
+    if (selectedMode.value() == "delta") {
+        return result;
     }
     if (!handshake.localVersion.empty() || !service.currentVersion().empty() ||
         !handshake.pinnedByOperator) {
@@ -431,36 +562,27 @@ Result<BootstrapPhaseResult> receiveBootstrapPhase(P2pConnection& connection,
     if (!begin) {
         return begin.error();
     }
+    auto manifest = parseSnapshotBegin(begin.value(), options);
+    if (!manifest) {
+        return manifest.error();
+    }
+    if (manifest.value().witness != handshake.peerNodeId) {
+        return Error{ErrorCode::Unauthorized, "cold bootstrap witness mismatch"};
+    }
+    if (manifest.value().frontier.counters() != handshake.peerVersion.counters() ||
+        manifest.value().commitments != handshake.peerCommitments) {
+        return Error{ErrorCode::ValidationError,
+                     "cold bootstrap manifest differs from authenticated frontier"};
+    }
     try {
-        if (!begin.value().is_object() ||
-            begin.value().value("type", std::string{}) != "snapshot_begin" ||
-            begin.value().at("witness").get<std::string>() != handshake.peerNodeId) {
-            return Error{ErrorCode::Unauthorized, "cold bootstrap witness mismatch"};
-        }
-        auto frontier = begin.value().at("frontier").get<memory_sync::VersionVector>();
-        auto commitments = parseCommitments(begin.value().at("commitments"));
-        if (!commitments) {
-            return commitments.error();
-        }
-        const auto count = begin.value().at("record_count").get<std::size_t>();
-        const auto declaredPayload = begin.value().at("payload_bytes").get<std::size_t>();
-        const auto root = begin.value().at("root_digest").get<std::string>();
-        if (frontier.counters() != handshake.peerVersion.counters() ||
-            commitments.value() != handshake.peerCommitments ||
-            count > options.maxSnapshotRecords || declaredPayload > options.maxSnapshotWireBytes ||
-            !memory_sync::isSha256Digest(root)) {
-            return Error{ErrorCode::ValidationError,
-                         "cold bootstrap manifest differs from authenticated frontier"};
-        }
+        const auto count = manifest.value().recordCount;
+        const auto declaredPayload = manifest.value().payloadBytes;
+        const auto root = manifest.value().rootDigest;
         memory_sync::ColdBootstrapSnapshot snapshot{
-            .frontier = std::move(frontier),
-            .commitments = std::move(commitments.value()),
+            .frontier = std::move(manifest.value().frontier),
+            .commitments = std::move(manifest.value().commitments),
             .rootDigest = root,
-            .witnessSignature = memory_sync::DetachedWriterSignature{
-                .writerId = handshake.peerNodeId,
-                .keyId = begin.value().at("witness_key_id").get<std::string>(),
-                .algorithm = begin.value().at("witness_algorithm").get<std::string>(),
-                .signature = begin.value().at("witness_signature").get<std::string>()}};
+            .witnessSignature = std::move(manifest.value().witnessSignature)};
         snapshot.winners.reserve(count);
         constexpr std::size_t kFramePrefixBytes = 4;
         std::size_t wireBytes = begin.value().dump().size() + kFramePrefixBytes;
@@ -753,6 +875,48 @@ Result<DeltaExchangeStats> runDeltaExchange(P2pConnection& connection,
 }
 
 } // namespace
+
+Result<void> detail::validateDeltaControlFrame(std::span<const std::byte> frame,
+                                               const DeltaExchangeOptions& options) {
+    if (auto validOptions = validateOptions(options); !validOptions) {
+        return validOptions.error();
+    }
+    auto parsed = parseJsonFrame(frame);
+    if (!parsed) {
+        return parsed.error();
+    }
+    try {
+        const auto type = parsed.value().value("type", std::string{});
+        if (type == "delta_batch") {
+            auto batch = parseBatchHeader(parsed.value(), options);
+            return batch ? Result<void>{} : Result<void>{batch.error()};
+        }
+        if (type == "delta_record") {
+            auto record = parseDeltaRecordControl(parsed.value());
+            return record ? Result<void>{} : Result<void>{record.error()};
+        }
+        if (type == "delta_ack") {
+            auto acknowledgement = parseAcknowledgement(parsed.value());
+            return acknowledgement ? Result<void>{} : Result<void>{acknowledgement.error()};
+        }
+        if (type == "replication_mode") {
+            auto mode = parseReplicationMode(parsed.value());
+            return mode ? Result<void>{} : Result<void>{mode.error()};
+        }
+        if (type == "snapshot_begin") {
+            auto manifest = parseSnapshotBegin(parsed.value(), options);
+            return manifest ? Result<void>{} : Result<void>{manifest.error()};
+        }
+        if (type == "snapshot_ack") {
+            auto acknowledgement = parseSnapshotAcknowledgement(parsed.value());
+            return acknowledgement ? Result<void>{} : Result<void>{acknowledgement.error()};
+        }
+        return Error{ErrorCode::ValidationError, "unknown p2p delta control message"};
+    } catch (const std::exception& error) {
+        return Error{ErrorCode::ValidationError,
+                     std::string("invalid p2p delta control message: ") + error.what()};
+    }
+}
 
 Result<DeltaExchangeStats> initiateDeltaExchange(P2pConnection& connection,
                                                  memory_sync::MemorySyncService& service,

--- a/src/daemon/p2p/p2p_fuzz.h
+++ b/src/daemon/p2p/p2p_fuzz.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2026 YAMS Contributors
+#pragma once
+
+// Internal parser seams shared by the direct-P2P fuzz harnesses and focused tests.
+
+// pi-lens-ignore: fatal error
+#include <yams/core/types.h>
+
+#include <cstddef>
+#include <span>
+
+namespace yams::daemon::p2p {
+
+struct DeltaExchangeOptions;
+
+namespace detail {
+
+Result<void> validateHandshakeControlFrame(std::span<const std::byte> frame);
+Result<void> validateDeltaControlFrame(std::span<const std::byte> frame,
+                                       const DeltaExchangeOptions& options);
+
+} // namespace detail
+} // namespace yams::daemon::p2p

--- a/src/daemon/p2p/p2p_json.h
+++ b/src/daemon/p2p/p2p_json.h
@@ -28,19 +28,22 @@ inline Result<void> writeJson(P2pConnection& connection, const Json& json,
     }
 }
 
-inline Result<Json> readJson(P2pConnection& connection, std::chrono::milliseconds timeout) {
-    auto frame = connection.readFrame(timeout);
-    if (!frame) {
-        return frame.error();
-    }
+inline Result<Json> parseJsonFrame(std::span<const std::byte> frame) {
     try {
-        const std::string_view text(reinterpret_cast<const char*>(frame.value().data()),
-                                    frame.value().size());
+        const std::string_view text(reinterpret_cast<const char*>(frame.data()), frame.size());
         return Json::parse(text);
     } catch (const std::exception& error) {
         return Error{ErrorCode::SerializationError,
                      std::string("invalid p2p JSON: ") + error.what()};
     }
+}
+
+inline Result<Json> readJson(P2pConnection& connection, std::chrono::milliseconds timeout) {
+    auto frame = connection.readFrame(timeout);
+    if (!frame) {
+        return frame.error();
+    }
+    return parseJsonFrame(frame.value());
 }
 
 } // namespace yams::daemon::p2p::detail

--- a/src/daemon/p2p/p2p_protocol.cpp
+++ b/src/daemon/p2p/p2p_protocol.cpp
@@ -4,6 +4,7 @@
 // pi-lens-ignore: fatal error
 #include <yams/daemon/p2p/p2p_protocol.h>
 
+#include "p2p_fuzz.h"
 #include "p2p_json.h"
 
 #include <algorithm>
@@ -554,6 +555,60 @@ Result<ValidatedHistoryProof> readAndValidatePeerHistoryProof(P2pConnection& con
 }
 
 } // namespace
+
+Result<void> detail::validateHandshakeControlFrame(std::span<const std::byte> frame) {
+    auto parsed = parseJsonFrame(frame);
+    if (!parsed) {
+        return parsed.error();
+    }
+    try {
+        const auto type = parsed.value().value("type", std::string{});
+        if (type == "hello" || type == "hello_ack") {
+            auto hello = parseHello(parsed.value(), type);
+            if (!hello) {
+                return hello.error();
+            }
+            if (hello.value().protocol != kP2pProtocolVersion ||
+                hello.value().schemaVersion != kP2pEnvelopeSchemaVersion) {
+                return Error{ErrorCode::NotSupported, "p2p protocol or schema version mismatch"};
+            }
+            if (hello.value().nodeId.empty() || hello.value().corpusId.empty() ||
+                hello.value().nodeId.size() > kMaxP2pIdentityBytes ||
+                hello.value().corpusId.size() > kMaxP2pIdentityBytes ||
+                hello.value().corpusEpoch == 0 || hello.value().maxWriterAdvance == 0 ||
+                hello.value().maxWriterAdvance > kMaxP2pWriterAdvance ||
+                hello.value().maxWriterWindowBytes == 0 ||
+                hello.value().maxWriterWindowBytes > kMaxP2pWriterWindowBytes) {
+                return Error{ErrorCode::ValidationError, "p2p hello violates protocol bounds"};
+            }
+            if (type == "hello_ack") {
+                (void)parsed.value().at("accepted").get<bool>();
+                const auto reason = parsed.value().value("reason", std::string{});
+                if (reason.size() > kMaxP2pIdentityBytes) {
+                    return Error{ErrorCode::ValidationError,
+                                 "p2p acknowledgement reason exceeds bound"};
+                }
+            }
+            return {};
+        }
+        if (type == "state") {
+            auto state = parseState(parsed.value());
+            return state ? Result<void>{} : Result<void>{state.error()};
+        }
+        if (type == "writer_window") {
+            auto frontier = parseWindowFrontier(parsed.value());
+            return frontier ? Result<void>{} : Result<void>{frontier.error()};
+        }
+        if (type == "history_proof") {
+            auto proof = parseHistoryProof(parsed.value());
+            return proof ? Result<void>{} : Result<void>{proof.error()};
+        }
+        return Error{ErrorCode::ValidationError, "unknown p2p handshake control message"};
+    } catch (const std::exception& error) {
+        return Error{ErrorCode::ValidationError,
+                     std::string("invalid p2p handshake control message: ") + error.what()};
+    }
+}
 
 Result<std::string> normalizePeerSpkiPin(std::string_view spkiPin) {
     if (!memory_sync::isSha256Digest(spkiPin)) {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3173,17 +3173,33 @@ if catch2_dep.found()
   )
 
   test('p2p_protocol', catch2_p2p_protocol_exe,
+    args: ['~[fuzz]'],
     suite: ['catch2', 'unit', 'daemon', 'p2p', 'network'],
     env: { 'LD_LIBRARY_PATH': _test_env_ld_library_path },
     timeout: 60,
     is_parallel: false
   )
 
+  test('p2p_protocol_fuzz_controls', catch2_p2p_protocol_exe,
+    args: ['[daemon][p2p][protocol][fuzz]'],
+    suite: ['catch2', 'unit', 'daemon', 'p2p', 'fuzz-smoke'],
+    env: { 'LD_LIBRARY_PATH': _test_env_ld_library_path },
+    timeout: 30
+  )
+
   test('p2p_delta', catch2_p2p_delta_exe,
+    args: ['~[fuzz]'],
     suite: ['catch2', 'unit', 'daemon', 'p2p', 'network'],
     env: { 'LD_LIBRARY_PATH': _test_env_ld_library_path },
     timeout: 60,
     is_parallel: false
+  )
+
+  test('p2p_delta_fuzz_controls', catch2_p2p_delta_exe,
+    args: ['[daemon][p2p][delta][fuzz]'],
+    suite: ['catch2', 'unit', 'daemon', 'p2p', 'fuzz-smoke'],
+    env: { 'LD_LIBRARY_PATH': _test_env_ld_library_path },
+    timeout: 30
   )
 
   test('p2p_delta_large_history', catch2_p2p_delta_exe,

--- a/tests/unit/daemon/p2p_delta_catch2_test.cpp
+++ b/tests/unit/daemon/p2p_delta_catch2_test.cpp
@@ -11,6 +11,8 @@
 #include <yams/memory_sync/writer_auth.h>
 #include <yams/storage/storage_backend.h>
 
+#include "../../../src/daemon/p2p/p2p_fuzz.h"
+
 #include <algorithm>
 #include <chrono>
 #include <cstring>
@@ -43,6 +45,15 @@ std::vector<std::byte> bytes(std::string_view text) {
     std::vector<std::byte> result(text.size());
     std::memcpy(result.data(), text.data(), text.size());
     return result;
+}
+
+yams::Result<void> validateDeltaJson(const nlohmann::json& json,
+                                     const DeltaExchangeOptions& options = {}) {
+    const auto encoded = json.dump();
+    return yams::daemon::p2p::detail::validateDeltaControlFrame(
+        std::span<const std::byte>(reinterpret_cast<const std::byte*>(encoded.data()),
+                                   encoded.size()),
+        options);
 }
 
 std::string text(const std::vector<std::byte>& data) {
@@ -263,6 +274,35 @@ ExchangePair runExchange(MemorySyncService& clientService, MemorySyncService& se
 }
 
 } // namespace
+
+TEST_CASE("direct P2P delta fuzz seam enforces bounded control messages",
+          "[daemon][p2p][delta][fuzz]") {
+    CHECK(validateDeltaJson(
+              nlohmann::json{{"type", "delta_batch"}, {"count", 1}, {"has_more", false}})
+              .has_value());
+    CHECK(validateDeltaJson(nlohmann::json{{"type", "replication_mode"}, {"mode", "delta"}})
+              .has_value());
+    CHECK_FALSE(
+        validateDeltaJson(nlohmann::json{{"type", "delta_batch"}, {"count", 0}, {"has_more", true}})
+            .has_value());
+    CHECK_FALSE(
+        validateDeltaJson(nlohmann::json{{"type", "delta_record"}, {"payload_size", 1ULL << 40}})
+            .has_value());
+    nlohmann::json snapshot{{"type", "snapshot_begin"},
+                            {"witness", "node-a"},
+                            {"frontier", {{"counters_", nlohmann::json::object()}}},
+                            {"commitments", nlohmann::json::array()},
+                            {"record_count", 0},
+                            {"payload_bytes", 0},
+                            {"root_digest", std::string(64, '0')},
+                            {"witness_key_id", "node-a-v1"},
+                            {"witness_algorithm", "Ed25519"},
+                            {"witness_signature", "AA=="}};
+    CHECK(validateDeltaJson(snapshot).has_value());
+    snapshot["record_count"] = DeltaExchangeOptions{}.maxSnapshotRecords + 1;
+    CHECK_FALSE(validateDeltaJson(snapshot).has_value());
+    CHECK_FALSE(validateDeltaJson(nlohmann::json{{"type", "unknown"}}).has_value());
+}
 
 TEST_CASE("direct P2P cold bootstrap installs an authenticated multiwriter snapshot",
           "[daemon][p2p][delta][cold-bootstrap][network][security]") {

--- a/tests/unit/daemon/p2p_protocol_catch2_test.cpp
+++ b/tests/unit/daemon/p2p_protocol_catch2_test.cpp
@@ -9,6 +9,8 @@
 #include <yams/daemon/p2p/p2p_protocol.h>
 #include <yams/memory_sync/writer_auth.h>
 
+#include "../../../src/daemon/p2p/p2p_fuzz.h"
+
 #include <chrono>
 #include <future>
 #include <string>
@@ -24,6 +26,12 @@ using yams::daemon::p2p::PeerHandshakeResult;
 using yams::daemon::p2p::TlsIdentity;
 
 namespace {
+
+yams::Result<void> validateHandshakeJson(const nlohmann::json& json) {
+    const auto text = json.dump();
+    return yams::daemon::p2p::detail::validateHandshakeControlFrame(
+        std::span<const std::byte>(reinterpret_cast<const std::byte*>(text.data()), text.size()));
+}
 
 TlsIdentity identity(std::string nodeId, const yams::memory_sync::WriterKeyPair& keyPair) {
     auto result = TlsIdentity::fromPrivateKeyPem(std::move(nodeId), keyPair.privateKeyPem);
@@ -116,6 +124,28 @@ PairResult runHandshake(PeerHandshakeConfig serverConfig, PeerHandshakeConfig cl
 }
 
 } // namespace
+
+TEST_CASE("p2p handshake fuzz seam enforces protocol-v4 control bounds",
+          "[daemon][p2p][protocol][fuzz]") {
+    const nlohmann::json hello{{"type", "hello"},
+                               {"protocol", yams::daemon::p2p::kP2pProtocolVersion},
+                               {"schema_version", yams::daemon::p2p::kP2pEnvelopeSchemaVersion},
+                               {"node_id", "node-a"},
+                               {"corpus_id", "corpus"},
+                               {"corpus_epoch", 1},
+                               {"max_writer_advance", 32},
+                               {"max_writer_window_bytes", 4096}};
+    CHECK(validateHandshakeJson(hello).has_value());
+
+    auto legacy = hello;
+    legacy["protocol"] = 3;
+    CHECK_FALSE(validateHandshakeJson(legacy).has_value());
+
+    auto oversized = hello;
+    oversized["node_id"] = std::string(yams::daemon::p2p::kMaxP2pIdentityBytes + 1, 'n');
+    CHECK_FALSE(validateHandshakeJson(oversized).has_value());
+    CHECK_FALSE(validateHandshakeJson(nlohmann::json{{"type", "unknown"}}).has_value());
+}
 
 TEST_CASE("P2P handshake freezes a bounded authenticated writer prefix",
           "[daemon][p2p][handshake][window][commitment]") {

--- a/tools/fuzzing/fuzz.sh
+++ b/tools/fuzzing/fuzz.sh
@@ -13,14 +13,14 @@ Usage: $0 <command> [args...]
 
 Commands:
     build                 Build Docker image with fuzzers
-    fuzz <target>         Run AFL++ fuzzer for target (e.g., ipc_protocol, ipc_roundtrip, proto_serializer)
+    fuzz <target>         Run AFL++ fuzzer (e.g., p2p_protocol, p2p_delta, ipc_protocol)
     exec <command>        Run a command inside the fuzzing container
     shell                 Open interactive shell in container
     clean                 Remove Docker image
 
 Examples:
   $0 build
-  $0 fuzz ipc_protocol
+  AFL_FUZZ_SECONDS=60 $0 fuzz p2p_protocol
   $0 shell
 EOF
     exit 1
@@ -48,17 +48,30 @@ cmd_fuzz() {
     local fuzzer_bin="/src/build/fuzzing/tools/fuzzing/fuzz_${target}"
     local corpus_dir="/fuzz/corpus/${target}"
     local findings_dir="/fuzz/findings/${target}"
+    local duration_args=()
+    if [[ -n "${AFL_FUZZ_SECONDS:-}" ]]; then
+        if [[ ! "${AFL_FUZZ_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Error: AFL_FUZZ_SECONDS must be a positive integer"
+            exit 1
+        fi
+        duration_args=(-V "${AFL_FUZZ_SECONDS}")
+    fi
+    local tty_arg=""
+    if [[ -t 0 && -t 1 ]]; then
+        tty_arg="-it"
+    fi
 
     # Ensure mounted host directories exist for AFL input/output.
     mkdir -p "${PROJECT_ROOT}/data/fuzz/corpus/${target}"
     mkdir -p "${PROJECT_ROOT}/data/fuzz/findings/${target}"
 
     echo "Running AFL++ fuzzer for target: ${target}"
-    docker run --rm -ti \
+    docker run --rm ${tty_arg:+"${tty_arg}"} \
         -v "${PROJECT_ROOT}/data/fuzz:/fuzz" \
         -e AFL_AUTORESUME=1 \
         "${IMAGE_NAME}" \
-        afl-fuzz -S "${fuzzer_id}" -i "${corpus_dir}" -o "${findings_dir}" -m none "${fuzzer_bin}"
+        afl-fuzz -S "${fuzzer_id}" -i "${corpus_dir}" -o "${findings_dir}" -m none \
+        "${duration_args[@]}" "${fuzzer_bin}"
 }
 
 cmd_exec() {

--- a/tools/fuzzing/fuzz_p2p_delta.cpp
+++ b/tools/fuzzing/fuzz_p2p_delta.cpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2026 YAMS Contributors
+
+#include "../../src/daemon/p2p/p2p_fuzz.h"
+
+// pi-lens-ignore: fatal error
+#include <yams/daemon/p2p/p2p_delta.h>
+#include <yams/daemon/p2p/p2p_transport.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size) {
+    if (data == nullptr || size > yams::daemon::p2p::kP2pMaxControlFrameBytes) {
+        return 0;
+    }
+    const auto frame = std::span<const std::byte>(reinterpret_cast<const std::byte*>(data), size);
+    const yams::daemon::p2p::DeltaExchangeOptions options;
+    (void)yams::daemon::p2p::detail::validateDeltaControlFrame(frame, options);
+    return 0;
+}

--- a/tools/fuzzing/fuzz_p2p_protocol.cpp
+++ b/tools/fuzzing/fuzz_p2p_protocol.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2026 YAMS Contributors
+
+#include "../../src/daemon/p2p/p2p_fuzz.h"
+
+// pi-lens-ignore: fatal error
+#include <yams/daemon/p2p/p2p_transport.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size) {
+    if (data == nullptr || size > yams::daemon::p2p::kP2pMaxControlFrameBytes) {
+        return 0;
+    }
+    const auto frame = std::span<const std::byte>(reinterpret_cast<const std::byte*>(data), size);
+    (void)yams::daemon::p2p::detail::validateHandshakeControlFrame(frame);
+    return 0;
+}

--- a/tools/fuzzing/generate_corpus.sh
+++ b/tools/fuzzing/generate_corpus.sh
@@ -13,6 +13,8 @@ echo "Generating seed corpus from protocol tests..."
 mkdir -p \
 	"${CORPUS_DIR}/ipc_protocol" \
 	"${CORPUS_DIR}/ipc_roundtrip" \
+	"${CORPUS_DIR}/p2p_protocol" \
+	"${CORPUS_DIR}/p2p_delta" \
 	"${CORPUS_DIR}/add_document" \
 	"${CORPUS_DIR}/proto_serializer" \
 	"${CORPUS_DIR}/request_handler" \
@@ -33,6 +35,27 @@ printf '\x00\x00\x00\x00' >> "$min_frame"  # checksum=0
 printf '\x00\x00\x00\x00' >> "$min_frame"  # flags=0
 
 cp "$min_frame" "${CORPUS_DIR}/ipc_roundtrip/01_min_frame.bin"
+
+# Direct-P2P control seeds. Keep a protocol-v3 hello so exact-version rejection remains covered
+# after the authenticated bounded-window protocol-v4 upgrade.
+cat > "${CORPUS_DIR}/p2p_protocol/01_hello_v4.json" <<'EOF'
+{"type":"hello","protocol":4,"schema_version":4,"node_id":"node-a","corpus_id":"corpus","corpus_epoch":1,"max_writer_advance":128,"max_writer_window_bytes":1048576}
+EOF
+cat > "${CORPUS_DIR}/p2p_protocol/02_legacy_hello_v3.json" <<'EOF'
+{"type":"hello","protocol":3,"schema_version":4,"node_id":"node-a","corpus_id":"corpus","corpus_epoch":1,"max_writer_advance":128,"max_writer_window_bytes":1048576}
+EOF
+cat > "${CORPUS_DIR}/p2p_protocol/03_empty_state.json" <<'EOF'
+{"type":"state","vv":{"counters_":{}},"seen":{},"commitments":[],"quarantined_writers":[]}
+EOF
+cat > "${CORPUS_DIR}/p2p_delta/01_delta_batch.json" <<'EOF'
+{"type":"delta_batch","count":1,"has_more":false}
+EOF
+cat > "${CORPUS_DIR}/p2p_delta/02_replication_mode.json" <<'EOF'
+{"type":"replication_mode","mode":"delta"}
+EOF
+cat > "${CORPUS_DIR}/p2p_delta/03_invalid_snapshot.json" <<'EOF'
+{"type":"snapshot_begin","witness":"node-a","frontier":{"counters_":{}},"commitments":[],"record_count":18446744073709551615,"payload_bytes":0,"root_digest":"0000000000000000000000000000000000000000000000000000000000000000","witness_key_id":"node-a-v1","witness_algorithm":"Ed25519","witness_signature":"AA=="}
+EOF
 
 # Some non-empty byte seeds for payload-focused fuzzers
 printf '\x00' > "${CORPUS_DIR}/add_document/00_zero.bin"

--- a/tools/fuzzing/meson.build
+++ b/tools/fuzzing/meson.build
@@ -86,6 +86,29 @@ fuzz_ipc_protocol = executable('fuzz_ipc_protocol',
   build_by_default: true,
 )
 
+# Direct P2P protocol-v4 handshake/control fuzzer.
+# The corpus retains protocol-v3 seeds to continuously exercise exact-version rejection.
+fuzz_p2p_protocol = executable('fuzz_p2p_protocol',
+  'fuzz_p2p_protocol.cpp',
+  include_directories: include_directories('../../include'),
+  link_with: yams_daemon_lib,
+  dependencies: fuzz_deps,
+  cpp_args: fuzzer_args,
+  link_args: fuzzer_args,
+  build_by_default: true,
+)
+
+# Direct P2P delta/bootstrap control-message fuzzer.
+fuzz_p2p_delta = executable('fuzz_p2p_delta',
+  'fuzz_p2p_delta.cpp',
+  include_directories: include_directories('../../include'),
+  link_with: yams_daemon_lib,
+  dependencies: fuzz_deps,
+  cpp_args: fuzzer_args,
+  link_args: fuzzer_args,
+  build_by_default: true,
+)
+
 # AddDocumentRequest Fuzzer
 fuzz_add_document = executable('fuzz_add_document',
   'fuzz_add_document.cpp',


### PR DESCRIPTION
## Summary

Final blocked draft child in the #68 stack, based on #73. This change closes the disclosed operator-wording and protocol-fuzz registration blockers without marking the umbrella ready, merging, or deploying.

- clarifies that peer/cycle status is local health telemetry, not proof of global corpus convergence
- documents exact protocol-v4 full-mesh verification and the remaining decision-grade live-performance gate
- adds fuzz seams that invoke the production handshake/state/history and delta/bootstrap control parsers
- retains a protocol-v3 seed to verify exact-version fail-closed rejection after the v4 upgrade
- bounds noninteractive AFL++ campaigns with `AFL_FUZZ_SECONDS`
- registers focused parser-smoke tests without duplicating them in the broad protocol/delta registrations
- tightens production delta-record, acknowledgement, bootstrap manifest, and bootstrap acknowledgement parser bounds through shared parser seams

## AI disclosure

Extensive AI assistance was used for implementation, test generation, and adversarial review. All changes were locally inspected and validated; remaining gates are disclosed above.

## Stack

- Base: `fix/p2p-apply-serialization` / #73 at `ed7b09a23cf1bfb5cb6be0bcfc769d826f9e82b4`
- Head: `fix/p2p-operator-validation` at `87e298e04415fbfb2ed5f06cd40712c428186f94`
- Umbrella: #68

Do not merge or deploy this child independently.
