### PR TITLE
fix(p2p): harden direct-P2P framing and ingress admission

### DIFF
--- a/include/yams/daemon/p2p/p2p_transport.h
+++ b/include/yams/daemon/p2p/p2p_transport.h
@@ -17,7 +17,11 @@
 namespace yams::daemon::p2p {
 
 /// Control-frame size cap (hello/state/delta envelopes) and value-payload cap.
-constexpr std::size_t kP2pMaxControlFrameBytes = std::size_t{64} * 1024;
+/// Sized for the worst-case authenticated `state` frame: 256 writers x 256-byte ids in the
+/// version vector, the `seen` watermark, 256 history commitments (id + counter + 64-hex digest),
+/// and the quarantined set total ~300 KB worst case; kept above that to stay stable as framing
+/// evolves without re-deriving the bound.
+constexpr std::size_t kP2pMaxControlFrameBytes = std::size_t{512} * 1024;
 constexpr std::size_t kP2pMaxValuePayloadBytes = std::size_t{16} * 1024 * 1024;
 constexpr std::size_t kP2pMaxConcurrentHandshakes = 64;
 constexpr std::size_t kP2pMaxConcurrentSessions = 64;

--- a/include/yams/memory_sync/memory_sync.h
+++ b/include/yams/memory_sync/memory_sync.h
@@ -1054,6 +1054,9 @@ public:
     /// to the local backend before becoming visible; replay is idempotent, recent
     /// operation forks are quarantined, and causal gaps/dependency gaps fail closed.
     Result<DeltaApplyResult> applyDeltas(std::span<const MemoryDelta> deltas) {
+        if (auto admitted = beforeDirectIngress(); !admitted) {
+            return admitted.error();
+        }
         if (auto loaded = ensureDurableQuarantineLoaded(); !loaded) {
             return loaded.error();
         }
@@ -2486,6 +2489,20 @@ private:
         if (backend_->isRemote() && control_.canAdmitRemoteWork && !control_.canAdmitRemoteWork()) {
             return Error{ErrorCode::ResourceExhausted,
                          "memory sync remote work denied by resource governor"};
+        }
+        return {};
+    }
+
+    /// Direct-P2P ingress is remote work by definition even though it lands on a local backend,
+    /// so the resource-admission gate applies unconditionally here (unlike shared-store sync,
+    /// which gates on `backend_->isRemote()`).
+    [[nodiscard]] Result<void> beforeDirectIngress() const {
+        if (control_.isCancelled && control_.isCancelled()) {
+            return Error{ErrorCode::OperationCancelled, "memory sync direct ingress cancelled"};
+        }
+        if (control_.canAdmitRemoteWork && !control_.canAdmitRemoteWork()) {
+            return Error{ErrorCode::ResourceExhausted,
+                         "memory sync direct ingress denied by resource governor"};
         }
         return {};
     }

--- a/src/daemon/p2p/p2p_delta.cpp
+++ b/src/daemon/p2p/p2p_delta.cpp
@@ -20,6 +20,7 @@ namespace {
 
 using detail::Json;
 using detail::readJson;
+using detail::readJsonFrame;
 using detail::writeJson;
 
 struct DeltaAcknowledgement {
@@ -180,17 +181,17 @@ Result<ReceivedDelta> receiveDeltaRecord(P2pConnection& connection,
                                          const DeltaExchangeOptions& options,
                                          std::size_t remainingBytes) {
     constexpr std::size_t kFramePrefixBytes = 4;
-    auto control = readJson(connection, options.timeout);
+    auto control = readJsonFrame(connection, options.timeout);
     if (!control) {
         return control.error();
     }
-    auto parsed = parseDeltaRecordControl(control.value());
+    auto parsed = parseDeltaRecordControl(control.value().json);
     if (!parsed) {
         return parsed.error();
     }
     auto delta = std::move(parsed.value().delta);
     const auto payloadSize = parsed.value().payloadSize;
-    const auto controlBytes = control.value().dump().size() + kFramePrefixBytes;
+    const auto controlBytes = control.value().payloadBytes + kFramePrefixBytes;
     const auto payloadBytes = payloadSize == 0 ? 0 : payloadSize + kFramePrefixBytes;
     if (controlBytes > remainingBytes || payloadBytes > remainingBytes - controlBytes) {
         return Error{ErrorCode::ResourceExhausted,
@@ -218,15 +219,15 @@ struct ReceivedBatch {
 Result<ReceivedBatch> receiveBatch(P2pConnection& connection, const DeltaExchangeOptions& options,
                                    std::size_t remainingDeltas, std::size_t remainingBytes) {
     constexpr std::size_t kFramePrefixBytes = 4;
-    auto control = readJson(connection, options.timeout);
+    auto control = readJsonFrame(connection, options.timeout);
     if (!control) {
         return control.error();
     }
-    auto header = parseBatchHeader(control.value(), options);
+    auto header = parseBatchHeader(control.value().json, options);
     if (!header) {
         return header.error();
     }
-    const auto headerBytes = control.value().dump().size() + kFramePrefixBytes;
+    const auto headerBytes = control.value().payloadBytes + kFramePrefixBytes;
     if (header.value().count > remainingDeltas) {
         return Error{ErrorCode::ResourceExhausted,
                      "p2p delta exchange exceeded aggregate delta limit"};
@@ -558,11 +559,11 @@ Result<BootstrapPhaseResult> receiveBootstrapPhase(P2pConnection& connection,
                      "cold bootstrap requires a durable zero state and explicit operator "
                      "enrollment"};
     }
-    auto begin = readJson(connection, options.timeout);
+    auto begin = readJsonFrame(connection, options.timeout);
     if (!begin) {
         return begin.error();
     }
-    auto manifest = parseSnapshotBegin(begin.value(), options);
+    auto manifest = parseSnapshotBegin(begin.value().json, options);
     if (!manifest) {
         return manifest.error();
     }
@@ -585,7 +586,7 @@ Result<BootstrapPhaseResult> receiveBootstrapPhase(P2pConnection& connection,
             .witnessSignature = std::move(manifest.value().witnessSignature)};
         snapshot.winners.reserve(count);
         constexpr std::size_t kFramePrefixBytes = 4;
-        std::size_t wireBytes = begin.value().dump().size() + kFramePrefixBytes;
+        std::size_t wireBytes = begin.value().payloadBytes + kFramePrefixBytes;
         if (wireBytes > options.maxSnapshotWireBytes) {
             return Error{ErrorCode::ResourceExhausted,
                          "cold bootstrap manifest exceeds aggregate wire bound"};

--- a/src/daemon/p2p/p2p_json.h
+++ b/src/daemon/p2p/p2p_json.h
@@ -28,14 +28,71 @@ inline Result<void> writeJson(P2pConnection& connection, const Json& json,
     }
 }
 
+/// Control frames are structurally flat (<= 5 nesting levels). Anything deeper is a
+/// pre-authentication stack-exhaustion probe and is rejected before nlohmann descends it.
+inline constexpr std::size_t kMaxP2pJsonNestingDepth = 32;
+
+inline bool exceedsJsonNestingDepth(std::string_view text, std::size_t maxDepth) {
+    std::size_t depth = 0;
+    bool inString = false;
+    bool escaped = false;
+    for (const char c : text) {
+        if (inString) {
+            if (escaped) {
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '"') {
+                inString = false;
+            }
+            continue;
+        }
+        if (c == '"') {
+            inString = true;
+        } else if (c == '[' || c == '{') {
+            if (++depth > maxDepth) {
+                return true;
+            }
+        } else if (c == ']' || c == '}') {
+            if (depth > 0) {
+                --depth;
+            }
+        }
+    }
+    return false;
+}
+
 inline Result<Json> parseJsonFrame(std::span<const std::byte> frame) {
     try {
         const std::string_view text(reinterpret_cast<const char*>(frame.data()), frame.size());
+        if (exceedsJsonNestingDepth(text, kMaxP2pJsonNestingDepth)) {
+            return Error{ErrorCode::ValidationError, "p2p JSON exceeds maximum nesting depth"};
+        }
         return Json::parse(text);
     } catch (const std::exception& error) {
         return Error{ErrorCode::SerializationError,
                      std::string("invalid p2p JSON: ") + error.what()};
     }
+}
+
+struct JsonFrame {
+    Json json;
+    std::size_t payloadBytes{0};
+};
+
+/// Read and parse one control frame, retaining the exact wire payload size so callers can
+/// account for bytes actually received rather than a compact re-serialization.
+inline Result<JsonFrame> readJsonFrame(P2pConnection& connection,
+                                       std::chrono::milliseconds timeout) {
+    auto frame = connection.readFrame(timeout);
+    if (!frame) {
+        return frame.error();
+    }
+    auto parsed = parseJsonFrame(frame.value());
+    if (!parsed) {
+        return parsed.error();
+    }
+    return JsonFrame{std::move(parsed.value()), frame.value().size()};
 }
 
 inline Result<Json> readJson(P2pConnection& connection, std::chrono::milliseconds timeout) {

--- a/tests/unit/daemon/p2p_delta_catch2_test.cpp
+++ b/tests/unit/daemon/p2p_delta_catch2_test.cpp
@@ -580,6 +580,109 @@ TEST_CASE("direct P2P delta receiver rejects aggregate bytes before reading payl
     listener.stop();
 }
 
+TEST_CASE("direct P2P delta receiver counts actual wire bytes including JSON padding",
+          "[daemon][p2p][delta][network][security]") {
+    TempDir clientDir{"padded-wire-client"};
+    TempDir serverDir{"padded-wire-server"};
+    MemorySyncService clientService{
+        backend(clientDir.path), MemorySyncConfig{"client-node", 60'000, "wire-delta-corpus", 1}};
+    MemorySyncService serverService{
+        backend(serverDir.path), MemorySyncConfig{"server-node", 60'000, "wire-delta-corpus", 1}};
+    auto clientKey = yams::memory_sync::generateWriterKeyPair();
+    auto serverKey = yams::memory_sync::generateWriterKeyPair();
+    REQUIRE(clientKey.has_value());
+    REQUIRE(serverKey.has_value());
+    auto clientIdentity = identity("client-node", clientKey.value());
+    auto serverIdentity = identity("server-node", serverKey.value());
+    const std::string serverPin = serverIdentity.spkiPin();
+    const std::string clientPin = clientIdentity.spkiPin();
+
+    const auto payload = bytes(std::string(64, 'x'));
+    yams::memory_sync::MemoryIndexRecord record;
+    record.entryHash = digest(payload);
+    record.origin = "client-node";
+    REQUIRE(record.vv.increment(record.origin));
+    record.corpusId = "wire-delta-corpus";
+    record.corpusEpoch = 1;
+    record.operationId = yams::memory_sync::makeOperationId(record.origin, 1);
+    record.logicalKey = "user/padded-wire";
+    record.recordKind = std::string(yams::memory_sync::kMemoryValueRecordKind);
+    const nlohmann::json mode{{"type", "replication_mode"}, {"mode", "delta"}};
+    const nlohmann::json batch{{"type", "delta_batch"}, {"count", 1}, {"has_more", false}};
+    const nlohmann::json wireRecord{{"type", "delta_record"},
+                                    {"logical_key", record.logicalKey},
+                                    {"record", record},
+                                    {"payload_size", payload.size()}};
+    std::string paddedRecord = wireRecord.dump();
+    paddedRecord.insert(paddedRecord.size() - 1, std::string(2048, ' '));
+
+    // Compact control frames fit this budget; the whitespace-padded record must not.
+    const auto byteLimit = batch.dump().size() + 4 + wireRecord.dump().size() + 4 + 256;
+
+    InMemoryPeerTrustStore clientTrust;
+    InMemoryPeerTrustStore serverTrust;
+    std::promise<yams::Result<DeltaExchangeStats>> serverDone;
+    auto serverFuture = serverDone.get_future();
+    P2pListener listener(P2pListener::Options{.host = "127.0.0.1",
+                                              .port = 0,
+                                              .identity = std::move(serverIdentity),
+                                              .allowedPeerPins = {clientPin},
+                                              .allowUnpinnedPeers = false,
+                                              .handshakeTimeout = 3s,
+                                              .maxConcurrentSessions = 1});
+    listener.setHandler([&](P2pConnection channel) {
+        auto handshake = yams::daemon::p2p::acceptPeerHandshake(
+            channel, handshakeConfig("server-node", serverService, true), serverTrust);
+        if (!handshake) {
+            serverDone.set_value(handshake.error());
+            return;
+        }
+        serverDone.set_value(yams::daemon::p2p::acceptDeltaExchange(
+            channel, serverService, handshake.value(),
+            DeltaExchangeOptions{.maxDeltasPerBatch = 2,
+                                 .maxBatches = 2,
+                                 .maxDeltasPerSession = 2,
+                                 .maxWireBytesPerSession = byteLimit,
+                                 .timeout = 3s}));
+    });
+    REQUIRE(listener.start().has_value());
+
+    auto channel =
+        yams::daemon::p2p::p2pConnect(P2pClientOptions{.host = "127.0.0.1",
+                                                       .port = listener.boundPort(),
+                                                       .identity = std::move(clientIdentity),
+                                                       .expectedPeerPin = serverPin,
+                                                       .allowUnpinnedPeer = false,
+                                                       .connectTimeout = 3s,
+                                                       .handshakeTimeout = 3s});
+    REQUIRE(channel.has_value());
+    auto handshake = yams::daemon::p2p::initiatePeerHandshake(
+        channel.value(), handshakeConfig("client-node", clientService, true), clientTrust);
+    REQUIRE(handshake.has_value());
+    for (const auto& json : {mode, batch}) {
+        const std::string encoded = json.dump();
+        REQUIRE(
+            channel.value()
+                .writeFrame(std::span<const std::byte>(
+                                reinterpret_cast<const std::byte*>(encoded.data()), encoded.size()),
+                            3s)
+                .has_value());
+    }
+    REQUIRE(channel.value()
+                .writeFrame(std::span<const std::byte>(
+                                reinterpret_cast<const std::byte*>(paddedRecord.data()),
+                                paddedRecord.size()),
+                            3s)
+                .has_value());
+
+    REQUIRE(serverFuture.wait_for(1s) == std::future_status::ready);
+    auto serverResult = serverFuture.get();
+    REQUIRE_FALSE(serverResult.has_value());
+    CHECK(serverResult.error().code == yams::ErrorCode::ResourceExhausted);
+    CHECK(serverService.currentVersion().empty());
+    listener.stop();
+}
+
 TEST_CASE("direct P2P delta exchange rejects options above protocol hard bounds",
           "[daemon][p2p][delta][network][limits]") {
     TempDir clientDir{"invalid-limits-client"};

--- a/tests/unit/daemon/p2p_protocol_catch2_test.cpp
+++ b/tests/unit/daemon/p2p_protocol_catch2_test.cpp
@@ -33,6 +33,11 @@ yams::Result<void> validateHandshakeJson(const nlohmann::json& json) {
         std::span<const std::byte>(reinterpret_cast<const std::byte*>(text.data()), text.size()));
 }
 
+yams::Result<void> validateHandshakeBytes(std::string_view text) {
+    return yams::daemon::p2p::detail::validateHandshakeControlFrame(
+        std::span<const std::byte>(reinterpret_cast<const std::byte*>(text.data()), text.size()));
+}
+
 TlsIdentity identity(std::string nodeId, const yams::memory_sync::WriterKeyPair& keyPair) {
     auto result = TlsIdentity::fromPrivateKeyPem(std::move(nodeId), keyPair.privateKeyPem);
     REQUIRE(result.has_value());
@@ -145,6 +150,20 @@ TEST_CASE("p2p handshake fuzz seam enforces protocol-v4 control bounds",
     oversized["node_id"] = std::string(yams::daemon::p2p::kMaxP2pIdentityBytes + 1, 'n');
     CHECK_FALSE(validateHandshakeJson(oversized).has_value());
     CHECK_FALSE(validateHandshakeJson(nlohmann::json{{"type", "unknown"}}).has_value());
+}
+
+TEST_CASE("p2p handshake control frame rejects excessive JSON nesting depth",
+          "[daemon][p2p][protocol][fuzz]") {
+    // A structurally valid hello whose unknown field is pathologically nested must be rejected by
+    // the depth bound rather than parsed (a pre-auth stack-exhaustion probe).
+    std::string deep =
+        "{\"type\":\"hello\",\"protocol\":4,\"schema_version\":4,\"node_id\":\"node-a\","
+        "\"corpus_id\":\"corpus\",\"corpus_epoch\":1,\"max_writer_advance\":32,"
+        "\"max_writer_window_bytes\":4096,\"nested\":";
+    deep.append(200, '[');
+    deep.append(200, ']');
+    deep += '}';
+    CHECK_FALSE(validateHandshakeBytes(deep).has_value());
 }
 
 TEST_CASE("P2P handshake freezes a bounded authenticated writer prefix",

--- a/tests/unit/daemon/p2p_transport_catch2_test.cpp
+++ b/tests/unit/daemon/p2p_transport_catch2_test.cpp
@@ -243,6 +243,53 @@ TEST_CASE("P2P TLS listener and client mutually authenticate and exchange frames
     CHECK_FALSE(listener.started());
 }
 
+TEST_CASE("P2P control frames accept the worst-case authenticated state size",
+          "[daemon][p2p][tls][network]") {
+    auto serverKey = yams::memory_sync::generateWriterKeyPair();
+    auto clientKey = yams::memory_sync::generateWriterKeyPair();
+    REQUIRE(serverKey.has_value());
+    REQUIRE(clientKey.has_value());
+    auto serverIdentity = identity("server-node", serverKey.value());
+    auto clientIdentity = identity("client-node", clientKey.value());
+    const std::string serverPin = serverIdentity.spkiPin();
+    const std::string clientPin = clientIdentity.spkiPin();
+
+    P2pListener::Options listenerOptions{.host = "127.0.0.1",
+                                         .port = 0,
+                                         .identity = std::move(serverIdentity),
+                                         .allowedPeerPins = {clientPin},
+                                         .handshakeTimeout = 2s,
+                                         .maxConcurrentSessions = 1};
+    P2pListener listener(std::move(listenerOptions));
+    std::promise<std::size_t> serverDone;
+    auto serverFuture = serverDone.get_future();
+    listener.setHandler([&](P2pConnection channel) {
+        auto frame = channel.readFrame(5s);
+        serverDone.set_value(frame ? frame.value().size() : 0);
+    });
+    REQUIRE(listener.start().has_value());
+
+    auto client =
+        yams::daemon::p2p::p2pConnect(P2pClientOptions{.host = "127.0.0.1",
+                                                       .port = listener.boundPort(),
+                                                       .identity = std::move(clientIdentity),
+                                                       .expectedPeerPin = serverPin,
+                                                       .connectTimeout = 2s,
+                                                       .handshakeTimeout = 2s});
+    REQUIRE(client.has_value());
+
+    // Exceeds the previous 64 KiB control-frame cap; must round-trip against the worst-case
+    // authenticated state frame (256 writers x 256-byte ids ~300 KB).
+    constexpr std::size_t largeSize = 200 * 1024;
+    const std::vector<std::byte> largeFrame(largeSize, std::byte{'x'});
+    REQUIRE(client.value().writeFrame(largeFrame, 5s).has_value());
+    REQUIRE(serverFuture.wait_for(5s) == std::future_status::ready);
+    CHECK(serverFuture.get() == largeSize);
+
+    client.value().close();
+    listener.stop();
+}
+
 TEST_CASE("P2P TLS read deadline interrupts a stalled peer", "[daemon][p2p][tls][network]") {
     auto serverKey = yams::memory_sync::generateWriterKeyPair();
     auto clientKey = yams::memory_sync::generateWriterKeyPair();

--- a/tests/unit/memory_sync/memory_sync_catch2_test.cpp
+++ b/tests/unit/memory_sync/memory_sync_catch2_test.cpp
@@ -222,6 +222,29 @@ TEST_CASE("MemorySyncLoop publish and read round-trips", "[memory-sync][sync-loo
     CHECK(text(value.value()) == "hello memory");
 }
 
+TEST_CASE("MemorySyncLoop applyDeltas honors the direct-ingress admission gate",
+          "[memory-sync][sync-loop][direct-delta][admission]") {
+    BackendFixture writerFixture{"admission-writer"};
+    BackendFixture readerFixture{"admission-reader"};
+    MemorySyncLoop writer{writerFixture.backend, "writer", "admission-corpus", 1};
+    MemorySyncLoop reader{readerFixture.backend,
+                          "reader",
+                          "admission-corpus",
+                          1,
+                          false,
+                          {},
+                          MemorySyncControl{.canAdmitRemoteWork = [] { return false; }}};
+
+    REQUIRE(writer.publish("user/key", bytes("value")).has_value());
+    auto deltas = writer.exportLocalDeltasAfter({});
+    REQUIRE(deltas.has_value());
+    REQUIRE_FALSE(deltas.value().deltas.empty());
+
+    const auto applied = reader.applyDeltas(deltas.value().deltas);
+    REQUIRE_FALSE(applied.has_value());
+    CHECK(applied.error().code == yams::ErrorCode::ResourceExhausted);
+}
+
 TEST_CASE("MemorySyncLoop rejects unsafe logical keys", "[memory-sync][sync-loop][security]") {
     BackendFixture fixture{"unsafe-keys"};
     MemorySyncLoop loop{fixture.backend, "A"};


### PR DESCRIPTION
## Summary

Stacked draft child of #74. Closes four direct-P2P wire/ingress findings from the deep review of the #68 stack, without merging or deploying anything.

1. **Pre-authentication JSON recursion DoS (P1)** — `parseJsonFrame` now rejects control frames nested deeper than 32 levels before `nlohmann` recursively descends them, so a ~32k-deep `[[[…]]]` hello cannot overflow the session-thread stack before any trust decision.
2. **Control-frame cap vs 256-writer state frame (P1)** — `kP2pMaxControlFrameBytes` raised 64 KiB → 512 KiB to cover the worst-case authenticated `state` frame (~300 KiB: version vector + `seen` watermark + 256 commitments + quarantined set).
3. **Direct-P2P ingress bypasses the resource governor (P2)** — `MemorySyncLoop::applyDeltas` now runs `beforeDirectIngress()` (unconditional `canAdmitRemoteWork` + `isCancelled`), so the daemon's `ResourceGovernor` can throttle a peer flooding deltas on the new replication path even though the backend is local.
4. **Wire-byte under-counting (P2)** — delta/bootstrap accounting now uses the exact received frame size (`readJsonFrame().payloadBytes`) instead of a compact re-serialization, so whitespace/duplicate-key padding from a peer counts against `maxWireBytesPerSession`/`maxSnapshotWireBytes`.

Confirmed non-issue (no change): the cold-bootstrap snapshot path is correctly multi-writer — each winner's `origin` is authenticated by its own schema-v4 writer signature (`validateBootstrapWinner` → `validateDirectDelta` → `writerAuth_->verify`) plus the witness root digest, so it does not require the single-writer `origin == peerNodeId` check used on the delta-continuation path.

## AI disclosure

Extensive AI assistance was used for implementation, test generation, and adversarial review. All changes were locally inspected and validated; the umbrella #68 remains blocked by the decision-grade live-performance gate.

## Stack

- Base: `fix/p2p-operator-validation` / #74 at `87e298e04415fbfb2ed5f06cd40712c428186f94`
- Head: `fix/p2p-wire-hardening` at `24923e95835bf31633ff9c54b46fe2a5c0b1e55c`
- Umbrella: #68

Do not merge or deploy this child independently.
