### PR TITLE
fix(p2p): harden CLI status and operator/key-rotation flows

### DIFF
--- a/include/yams/daemon/components/ServiceManager.h
+++ b/include/yams/daemon/components/ServiceManager.h
@@ -203,6 +203,7 @@ public:
     Result<p2p::P2pSyncResult> connectP2p(std::string_view connectionString);
     Result<void> disconnectP2p(std::string_view nodeId);
     Result<void> enrollP2pPeer(std::string_view nodeId, std::string_view spkiPin);
+    Result<void> forgetP2pPeer(std::string_view nodeId);
     Result<p2p::P2pLocalIdentity> getP2pIdentity() const;
     Result<std::vector<p2p::PeerRegistryRecord>> listP2pPeers() const;
     Result<void> stageMemorySyncDocumentDelete(std::string_view contentHash,

--- a/include/yams/daemon/ipc/ipc_protocol_requests.h
+++ b/include/yams/daemon/ipc/ipc_protocol_requests.h
@@ -3339,7 +3339,8 @@ enum class MemorySyncOperation : std::uint32_t {
     Disconnect = 5,
     Peers = 6,
     Identity = 7,
-    Enroll = 8
+    Enroll = 8,
+    Forget = 9
 };
 
 struct MemorySyncRequest {

--- a/include/yams/daemon/ipc/proto/ipc_envelope.proto
+++ b/include/yams/daemon/ipc/proto/ipc_envelope.proto
@@ -1206,6 +1206,7 @@ message MemorySyncRequest {
     PEERS = 6;
     IDENTITY = 7;
     ENROLL = 8;
+    FORGET = 9;
   }
   Operation operation = 1;
   string key = 2;

--- a/include/yams/daemon/p2p/p2p_manager.h
+++ b/include/yams/daemon/p2p/p2p_manager.h
@@ -87,6 +87,7 @@ public:
     Result<P2pSyncResult> connect(std::string_view connectionString);
     Result<void> disconnect(std::string_view nodeId);
     Result<void> enrollPeer(std::string_view nodeId, std::string_view spkiPin);
+    Result<void> forget(std::string_view nodeId);
     Result<P2pLocalIdentity> localIdentity() const;
     Result<std::vector<PeerRegistryRecord>> peers() const;
 

--- a/src/cli/commands/p2p_command.cpp
+++ b/src/cli/commands/p2p_command.cpp
@@ -121,9 +121,9 @@ Result<std::string> formatConnect(const daemon::MemorySyncResponse& response, bo
         return payload.value().dump(2);
     }
     const auto& value = payload.value();
-    return "connected " + value.at("peer_node_id").get<std::string>() +
-           " (sent=" + std::to_string(value.value("deltas_sent", 0U)) +
-           ", received=" + std::to_string(value.value("deltas_received", 0U)) + ")";
+    return "connected " + value.value("peer_node_id", std::string{}) +
+           " (sent=" + std::to_string(value.value("deltas_sent", std::uint64_t{0})) +
+           ", received=" + std::to_string(value.value("deltas_received", std::uint64_t{0})) + ")";
 }
 
 Result<std::string> formatDisconnect(const daemon::MemorySyncResponse& response, bool json) {
@@ -134,7 +134,18 @@ Result<std::string> formatDisconnect(const daemon::MemorySyncResponse& response,
     if (json) {
         return payload.value().dump(2);
     }
-    return "disconnected " + payload.value().at("node_id").get<std::string>();
+    return "disconnected " + payload.value().value("node_id", std::string{});
+}
+
+Result<std::string> formatForget(const daemon::MemorySyncResponse& response, bool json) {
+    auto payload = parseControlPayload(response);
+    if (!payload) {
+        return payload.error();
+    }
+    if (json) {
+        return payload.value().dump(2);
+    }
+    return "forgot " + payload.value().value("node_id", std::string{});
 }
 
 Result<std::string> formatPeers(const daemon::MemorySyncResponse& response, bool json) {
@@ -169,26 +180,17 @@ Result<std::string> formatStatus(const daemon::MemorySyncResponse& response, boo
         return Error{ErrorCode::InvalidState, "memory sync service is not started"};
     }
     if (!json) {
-        using yams::cli::ui::Severity;
-        using yams::cli::ui::severity_text;
-        auto health = [](bool bad) { return bad ? Severity::Warn : Severity::Good; };
         std::ostringstream out;
         // pi-lens-ignore: clang:no_member -- additive response field is compiled by Meson.
         out << "backend=" << response.backend << " node_id=" << response.nodeId
             << " corpus_id=" << response.corpusId << " corpus_epoch=" << response.corpusEpoch
             << " mode=" << response.mode << " trust=" << response.trustMode
-            << " peers=" << response.peerCount << " records=" << response.records << " quarantined="
-            << severity_text(health(response.quarantinedRecords > 0),
-                             std::to_string(response.quarantinedRecords))
-            << " auth_failures="
-            << severity_text(health(response.authFailures > 0),
-                             std::to_string(response.authFailures))
-            << " successful_cycles=" << response.successfulCycles << " failed_cycles="
-            << severity_text(health(response.failedCycles > 0),
-                             std::to_string(response.failedCycles))
-            << " last_success_age_ms="
-            << severity_text(health(response.lastSuccessAgeMs > 60000),
-                             std::to_string(response.lastSuccessAgeMs));
+            << " peers=" << response.peerCount << " records=" << response.records
+            << " quarantined=" << response.quarantinedRecords
+            << " auth_failures=" << response.authFailures
+            << " successful_cycles=" << response.successfulCycles
+            << " failed_cycles=" << response.failedCycles
+            << " last_success_age_ms=" << response.lastSuccessAgeMs;
         return out.str();
     }
     nlohmann::json output;
@@ -249,6 +251,12 @@ public:
         disconnect->add_option("node-id", disconnectNodeId_, "Peer node id")->required();
         disconnect->add_flag("--json", jsonOutput_, "Emit JSON");
         disconnect->callback([this]() { failOn(runDisconnect()); });
+
+        auto* forget =
+            cmd->add_subcommand("forget", "Remove a peer's pinned identity (key rotation)");
+        forget->add_option("node-id", forgetNodeId_, "Peer node id")->required();
+        forget->add_flag("--json", jsonOutput_, "Emit JSON");
+        forget->callback([this]() { failOn(runForget()); });
 
         auto* peers = cmd->add_subcommand("peers", "List trusted peers and reconnect state");
         peers->add_flag("--json", jsonOutput_, "Emit JSON");
@@ -369,6 +377,19 @@ private:
         return {};
     }
 
+    Result<void> runForget() {
+        auto response = call({daemon::MemorySyncOperation::Forget, forgetNodeId_, {}});
+        if (!response) {
+            return response.error();
+        }
+        auto output = formatForget(response.value(), jsonOutput_);
+        if (!output) {
+            return output.error();
+        }
+        std::cout << output.value() << "\n";
+        return {};
+    }
+
     Result<void> runPeers() {
         auto response = call({daemon::MemorySyncOperation::Peers, {}, {}});
         if (!response) {
@@ -441,6 +462,7 @@ private:
     YamsCLI* cli_{nullptr};
     std::string connectionString_;
     std::string disconnectNodeId_;
+    std::string forgetNodeId_;
     std::string enrollNodeId_;
     std::string enrollPin_;
     std::string publishKey_;

--- a/src/daemon/components/ConfigResolver.cpp
+++ b/src/daemon/components/ConfigResolver.cpp
@@ -1724,6 +1724,15 @@ bool ConfigResolver::applyMemorySync(const ConfigSections& sections, DaemonConfi
             config.memorySync.enabled = false;
             return false;
         }
+        // Direct transport reuses sync_interval_ms as the reconnect interval, which
+        // P2pManager::create bounds to p2p::kP2pMaxReconnectInterval (5 minutes). Reject here so a
+        // large value fails config resolution instead of aborting daemon startup later.
+        if (policy.transport == "direct" && *interval > 5 * 60 * 1000) {
+            spdlog::warn("Config: invalid memory_sync; sync_interval_ms exceeds the 5-minute "
+                         "direct reconnect ceiling");
+            config.memorySync.enabled = false;
+            return false;
+        }
         policy.syncIntervalMs = *interval;
     }
     const auto applyLimit = [&](std::string_view key, std::size_t& target) {

--- a/src/daemon/components/RequestDispatcher.cpp
+++ b/src/daemon/components/RequestDispatcher.cpp
@@ -233,6 +233,18 @@ RequestDispatcher::handleMemorySyncRequest(const MemorySyncRequest& req) {
             response.value = nlohmann::json{{"node_id", req.key}, {"remembered", false}}.dump();
             break;
         }
+        case MemorySyncOperation::Forget: {
+            auto forgotten = co_await dispatch::offload_to_worker(
+                serviceManager_, [manager = serviceManager_, nodeId = req.key] {
+                    return manager->forgetP2pPeer(nodeId);
+                });
+            if (!forgotten) {
+                co_return dispatch::makeErrorResponse(forgotten.error().code,
+                                                      forgotten.error().message);
+            }
+            response.value = nlohmann::json{{"node_id", req.key}}.dump();
+            break;
+        }
         case MemorySyncOperation::Peers: {
             auto peers = serviceManager_->listP2pPeers();
             if (!peers) {

--- a/src/daemon/components/ServiceManager.cpp
+++ b/src/daemon/components/ServiceManager.cpp
@@ -2638,10 +2638,14 @@ Result<ServiceManager::MemorySyncStatus> ServiceManager::getMemorySyncStatus() c
     std::uint64_t peerCount = 0;
     if (p2pManager_) {
         auto peers = p2pManager_->peers();
-        if (!peers) {
-            return peers.error();
+        if (peers) {
+            peerCount = peers.value().size();
+        } else {
+            // A transient peer-registry read failure must not fail the whole status IPC; degrade
+            // to peerCount=0 so the daemon stays observable while the registry recovers.
+            spdlog::warn("[ServiceManager] p2p peer registry read failed for status: {}",
+                         peers.error().message);
         }
-        peerCount = peers.value().size();
     }
     return MemorySyncStatus{
         memorySync_->started(),
@@ -2682,6 +2686,13 @@ Result<void> ServiceManager::enrollP2pPeer(std::string_view nodeId, std::string_
         return Error{ErrorCode::InvalidState, "direct P2P transport is not enabled"};
     }
     return p2pManager_->enrollPeer(nodeId, spkiPin);
+}
+
+Result<void> ServiceManager::forgetP2pPeer(std::string_view nodeId) {
+    if (!p2pManager_) {
+        return Error{ErrorCode::InvalidState, "direct P2P transport is not enabled"};
+    }
+    return p2pManager_->forget(nodeId);
 }
 
 Result<p2p::P2pLocalIdentity> ServiceManager::getP2pIdentity() const {

--- a/src/daemon/ipc/proto_serializer.cpp
+++ b/src/daemon/ipc/proto_serializer.cpp
@@ -28,7 +28,7 @@ using Envelope = yams::daemon::ipc::Envelope;
 namespace pb = yams::daemon::ipc;
 
 static_assert(static_cast<int>(pb::MemorySyncRequest_Operation_Operation_MAX) >=
-                  static_cast<int>(MemorySyncOperation::Enroll),
+                  static_cast<int>(MemorySyncOperation::Forget),
               "protobuf MemorySyncRequest.Operation must preserve all C++ wire values");
 
 // (bindings inserted later, after ProtoBinding primary template)

--- a/src/daemon/p2p/p2p_delta.cpp
+++ b/src/daemon/p2p/p2p_delta.cpp
@@ -37,7 +37,8 @@ Result<void> validateOptions(const DeltaExchangeOptions& options) {
         options.maxWireBytesPerSession == 0 || options.maxWireBytesPerSession > kMaxWireBytes ||
         options.maxSnapshotRecords == 0 || options.maxSnapshotRecords > kMaxP2pWriterAdvance ||
         options.maxSnapshotWireBytes == 0 || options.maxSnapshotWireBytes > kMaxWireBytes ||
-        options.timeout <= std::chrono::milliseconds::zero()) {
+        options.timeout <= std::chrono::milliseconds::zero() ||
+        options.timeout > kP2pMaxOperationTimeout) {
         return Error{ErrorCode::InvalidArgument, "invalid p2p delta exchange limits"};
     }
     return {};

--- a/src/daemon/p2p/p2p_manager.cpp
+++ b/src/daemon/p2p/p2p_manager.cpp
@@ -301,6 +301,8 @@ public:
         return {};
     }
 
+    Result<void> forget(std::string_view nodeId) { return registry_->removePeer(nodeId); }
+
     Result<P2pLocalIdentity> localIdentity() const {
         auto identity = TlsIdentity::fromPrivateKeyPem(options_.nodeId, options_.privateKeyPem);
         if (!identity) {
@@ -581,6 +583,9 @@ Result<void> P2pManager::disconnect(std::string_view nodeId) {
 }
 Result<void> P2pManager::enrollPeer(std::string_view nodeId, std::string_view spkiPin) {
     return impl_->enrollPeer(nodeId, spkiPin);
+}
+Result<void> P2pManager::forget(std::string_view nodeId) {
+    return impl_->forget(nodeId);
 }
 Result<P2pLocalIdentity> P2pManager::localIdentity() const {
     return impl_->localIdentity();

--- a/src/daemon/p2p/p2p_protocol.cpp
+++ b/src/daemon/p2p/p2p_protocol.cpp
@@ -60,7 +60,8 @@ Result<void> validateConfig(const PeerHandshakeConfig& config) {
         return Error{ErrorCode::InvalidArgument,
                      "p2p handshake requires node, corpus, and epoch identity"};
     }
-    if (config.timeout <= std::chrono::milliseconds::zero() || config.maxWriterAdvance == 0 ||
+    if (config.timeout <= std::chrono::milliseconds::zero() ||
+        config.timeout > kP2pMaxOperationTimeout || config.maxWriterAdvance == 0 ||
         config.maxWriterAdvance > kMaxP2pWriterAdvance || config.maxWriterWindowBytes == 0 ||
         config.maxWriterWindowBytes > kMaxP2pWriterWindowBytes) {
         return Error{ErrorCode::InvalidArgument,

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -182,8 +182,8 @@ src/daemon/components/EmbeddingService.cpp:2602:portability/env-read # reviewed 
 src/daemon/components/IngestService.cpp:56:portability/env-read # reviewed raw environment read
 src/daemon/components/LifecycleComponent.cpp:808:portability/env-read # reviewed raw environment read
 src/daemon/components/LifecycleComponent.cpp:818:portability/env-read # reviewed raw environment read
-src/daemon/components/RequestDispatcher.cpp:545:portability/env-read # reviewed raw environment read
-src/daemon/components/RequestDispatcher.cpp:548:portability/env-read # reviewed raw environment read
+src/daemon/components/RequestDispatcher.cpp:557:portability/env-read # reviewed raw environment read
+src/daemon/components/RequestDispatcher.cpp:560:portability/env-read # reviewed raw environment read
 src/daemon/components/RequestExecutor.cpp:44:portability/env-read # reviewed raw environment read
 src/daemon/components/dispatcher/request_dispatcher_models.cpp:38:portability/env-read # reviewed raw environment read
 src/detection/file_type_detector.cpp:612:portability/env-read # reviewed raw environment read

--- a/tests/unit/daemon/components/config_resolver_test.cpp
+++ b/tests/unit/daemon/components/config_resolver_test.cpp
@@ -1617,6 +1617,25 @@ TEST_CASE("ConfigResolver accepts authenticated direct P2P without a shared path
     CHECK(config.memorySync.writerAuthManifestPath == "/secure/writers.json");
 }
 
+TEST_CASE("ConfigResolver rejects direct P2P sync_interval_ms above the reconnect ceiling",
+          "[daemon][config][memory-sync][p2p][security]") {
+    ConfigResolver::ConfigSections sections = {
+        {"memory_sync",
+         {{"enabled", "true"},
+          {"node_id", "123e4567-e89b-42d3-a456-426614174000"},
+          {"corpus_id", "corpus-a"},
+          {"corpus_epoch", "9"},
+          {"transport", "direct"},
+          {"listen", "0.0.0.0:9721"},
+          {"sync_interval_ms", "300001"},
+          {"writer_auth_required", "true"},
+          {"writer_auth_manifest", "/secure/writers.json"}}},
+    };
+    DaemonConfig config;
+    CHECK_FALSE(ConfigResolver::applyMemorySync(sections, config));
+    CHECK_FALSE(config.memorySync.enabled);
+}
+
 TEST_CASE("ConfigResolver infers shared-store for legacy backend path",
           "[daemon][config][memory-sync]") {
     ConfigResolver::ConfigSections sections = {

--- a/tests/unit/daemon/p2p_delta_catch2_test.cpp
+++ b/tests/unit/daemon/p2p_delta_catch2_test.cpp
@@ -708,6 +708,17 @@ TEST_CASE("direct P2P delta exchange rejects options above protocol hard bounds"
                              .timeout = 3s});
     REQUIRE_FALSE(exchanged.client.has_value());
     CHECK(exchanged.client.error().code == yams::ErrorCode::InvalidArgument);
+
+    auto overTimeout = runExchange(
+        clientService, serverService, clientKey.value(), serverKey.value(), clientTrust,
+        serverTrust, true,
+        DeltaExchangeOptions{.maxDeltasPerBatch = 1,
+                             .maxBatches = 1,
+                             .maxDeltasPerSession = 1,
+                             .maxWireBytesPerSession = 1024,
+                             .timeout = yams::daemon::p2p::kP2pMaxOperationTimeout + 1ms});
+    REQUIRE_FALSE(overTimeout.client.has_value());
+    CHECK(overTimeout.client.error().code == yams::ErrorCode::InvalidArgument);
 }
 
 TEST_CASE("direct P2P delta exchange resumes across aggregate session limits",

--- a/tests/unit/daemon/peer_registry_catch2_test.cpp
+++ b/tests/unit/daemon/peer_registry_catch2_test.cpp
@@ -116,6 +116,33 @@ TEST_CASE("P2P peer registry persists operator enrollment",
     CHECK(trusted.value().pinnedByOperator);
 }
 
+TEST_CASE("P2P peer registry supports explicit key rotation via removal",
+          "[daemon][p2p][registry][sqlite][security]") {
+    TempDatabase database{"key-rotation"};
+    auto opened = PeerRegistry::open(database.path, 1);
+    REQUIRE(opened.has_value());
+    auto& registry = *opened.value();
+    const std::string firstPin(64, 'a');
+    const std::string rotatedPin(64, 'b');
+
+    REQUIRE(registry.enrollOperatorPeer("peer-node", firstPin).has_value());
+    auto replace = registry.enrollOperatorPeer("peer-node", rotatedPin);
+    REQUIRE_FALSE(replace.has_value());
+    CHECK(replace.error().code == yams::ErrorCode::Unauthorized);
+
+    REQUIRE(registry.removePeer("peer-node").has_value());
+    REQUIRE(registry.enrollOperatorPeer("peer-node", rotatedPin).has_value());
+
+    auto peers = registry.listPeers();
+    REQUIRE(peers.has_value());
+    REQUIRE(peers.value().size() == 1);
+    CHECK(peers.value().front().spkiPin == rotatedPin);
+    CHECK(peers.value().front().pinnedByOperator);
+    auto trusted = registry.verifyOrPin("peer-node", rotatedPin, false);
+    REQUIRE(trusted.has_value());
+    CHECK(trusted.value().pinnedByOperator);
+}
+
 TEST_CASE("P2P peer registry persists trust and causal state across restart",
           "[daemon][p2p][registry][sqlite]") {
     TempDatabase database{"restart"};


### PR DESCRIPTION
## Summary

Stacked draft child of #75. Closes the robustness/quality items from the deep review of the #68 stack that were not security-blocking but should land before the stack is moved to ready-for-review. No merge or deploy.

1. **`p2p status` text is machine-parseable again (P1)** — removed ANSI severity colorization from the `key=value` stream; every field is now a plain value.
2. **CLI connect/disconnect/forget stop throwing on malformed daemon responses (P1)** — replaced `.at("peer_node_id")`/`.at("node_id")` with `.value(key, default)` and widened the `deltas_sent`/`deltas_received` defaults to `std::uint64_t` (no `size_t`→`unsigned int` truncation).
3. **Handshake/delta timeout options are bounded to `kP2pMaxOperationTimeout` (P2)** — `validateConfig`/`validateOptions` now reject a timeout above 1 minute up front instead of passing config then dying at `readFrame`.
4. **`getMemorySyncStatus` degrades instead of failing (P2)** — a transient `p2p_peers` read failure now logs and reports `peerCount=0` rather than failing the whole status IPC.
5. **`sync_interval_ms` is ceiling-checked for direct transport (P2)** — a value above the 5-minute reconnect ceiling now fails config resolution instead of aborting daemon startup in `P2pManager::create`.
6. **Key rotation is possible via an explicit `forget` operation (P2)** — added `yams p2p forget <node-id>` end-to-end (proto enum `FORGET=9`, dispatcher, `ServiceManager::forgetP2pPeer`, `P2pManager::forget` → `PeerRegistry::removePeer`). Fail-closed enrollment is **preserved**: re-enrolling with a different pin is still rejected; rotation requires explicit forget-then-enroll.

## RED evidence

- `formatConnect`/`formatDisconnect` would throw `nlohmann::json::out_of_range`/`type_error` on a parseable-but-malformed response.
- `sync_interval_ms = 300001` passed config resolution and aborted daemon startup later.
- A peer enrolled with pin `A` could not be rotated (enroll with pin `b` returned `Unauthorized` and no removal path existed).

## Validation

Focused normal matrix (green, no regressions):

- `p2p_protocol` 495 / 14, `p2p_delta` 301 / 10, `p2p_manager` 180 / 12, `peer_registry` 91 / 6
- `service_manager` 789 / 47 passed + 1 skip
- `daemon_component_submodule` 1319 / 109 (config resolver + proto serializer)
- `memory_sync` 838 / 60, `memory_sync_service` 263 / 27

New coverage: timeout ceiling, direct `sync_interval_ms` ceiling, and an explicit key-rotation flow (enroll → fail-closed replace → forget → re-enroll rotated pin).

Changed-file formatting, Windows-header, GPL, portability (574 reviewed / 0 new), and `git diff --check` pass. Audit OpenGrep reports 166 pre-existing findings (159 in generated `ipc_protocol_requests.h`, 5 in `p2p_manager.cpp`, 2 reviewed getenv reads re-allowlisted after a line shift) — none introduced by this change.

TODO_PREPUSH

## AI disclosure

Extensive AI assistance was used for implementation, test generation, and adversarial review. All changes were locally inspected and validated; the umbrella #68 remains blocked by the decision-grade live-performance gate.

## Stack

- Base: `fix/p2p-wire-hardening` / #75 at `24923e95835bf31633ff9c54b46fe2a5c0b1e55c`
- Head: `fix/p2p-robustness` at `cd956acdbee34e6c560af1a47fdfc1057ad7fa50`
- Umbrella: #68

Do not merge or deploy this child independently.
