### PR TITLE
refactor(p2p): tighten tests, share helpers, and guard test hooks

### DIFF
--- a/include/yams/memory_sync/memory_sync.h
+++ b/include/yams/memory_sync/memory_sync.h
@@ -1544,13 +1544,19 @@ private:
         return {};
     }
 
-    std::string coldBootstrapRoot(const ColdBootstrapSnapshot& snapshot) const {
+    static nlohmann::json
+    commitmentsJson(const std::map<NodeId, WriterHistoryCommitment>& commitments) {
         nlohmann::json commitmentJson = nlohmann::json::array();
-        for (const auto& [writer, commitment] : snapshot.commitments) {
+        for (const auto& [writer, commitment] : commitments) {
             commitmentJson.push_back({{"writer_id", writer},
                                       {"counter", commitment.counter},
                                       {"digest", commitment.digest}});
         }
+        return commitmentJson;
+    }
+
+    std::string coldBootstrapRoot(const ColdBootstrapSnapshot& snapshot) const {
+        auto commitmentJson = commitmentsJson(snapshot.commitments);
         nlohmann::json winnerJson = nlohmann::json::array();
         std::vector<const MemoryDelta*> ordered;
         ordered.reserve(snapshot.winners.size());
@@ -3125,12 +3131,7 @@ private:
         for (const auto& [writer, source] : quarantinedWriters) {
             quarantineJson.push_back({{"writer_id", writer}, {"source_node_id", source}});
         }
-        nlohmann::json commitmentJson = nlohmann::json::array();
-        for (const auto& [writer, commitment] : commitments) {
-            commitmentJson.push_back({{"writer_id", writer},
-                                      {"counter", commitment.counter},
-                                      {"digest", commitment.digest}});
-        }
+        auto commitmentJson = commitmentsJson(commitments);
         auto artifact = nlohmann::json{{"schema_version", 1},
                                        {"corpus_id", corpusId_},
                                        {"corpus_epoch", corpusEpoch_},

--- a/src/daemon/p2p/p2p_manager.cpp
+++ b/src/daemon/p2p/p2p_manager.cpp
@@ -55,6 +55,7 @@ std::int64_t unixTimeMs() {
         .count();
 }
 
+#if YAMS_DAEMON_TEST_HOOKS_ENABLED
 std::mutex gReconnectLoopHookMutex;
 std::function<void()> gReconnectLoopHook;
 
@@ -68,6 +69,7 @@ void invokeReconnectLoopHook() {
         hook();
     }
 }
+#endif
 
 } // namespace
 
@@ -474,7 +476,9 @@ private:
             }
             waitLock.unlock();
             try {
+#if YAMS_DAEMON_TEST_HOOKS_ENABLED
                 invokeReconnectLoopHook();
+#endif
                 auto records = registry_->listPeers();
                 if (records) {
                     for (const auto& peer : records.value()) {

--- a/tests/common/p2p_test_helpers.h
+++ b/tests/common/p2p_test_helpers.h
@@ -1,0 +1,48 @@
+#pragma once
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2026 YAMS Contributors
+
+// Shared helpers for direct-P2P unit tests. bytes/text/TempDir were previously
+// copy-pasted across daemon/p2p test executables; keep them here so behavior
+// stays identical across suites.
+
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace yams::p2p_test {
+
+inline std::vector<std::byte> bytes(std::string_view text) {
+    std::vector<std::byte> result(text.size());
+    std::memcpy(result.data(), text.data(), text.size());
+    return result;
+}
+
+inline std::string text(const std::vector<std::byte>& data) {
+    return std::string(reinterpret_cast<const char*>(data.data()), data.size());
+}
+
+/// Scoped directory under the system temp dir, removed on destruction. The
+/// per-run timestamp suffix keeps concurrent test processes from colliding.
+class TempDir {
+public:
+    explicit TempDir(std::string_view label) {
+        path = std::filesystem::temp_directory_path() /
+               ("yams-p2p-test-" + std::string(label) + "-" +
+                std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+        std::filesystem::create_directories(path);
+    }
+    TempDir(const TempDir&) = delete;
+    TempDir& operator=(const TempDir&) = delete;
+    ~TempDir() {
+        std::error_code error;
+        std::filesystem::remove_all(path, error);
+    }
+
+    std::filesystem::path path;
+};
+
+} // namespace yams::p2p_test

--- a/tests/unit/daemon/p2p_delta_catch2_test.cpp
+++ b/tests/unit/daemon/p2p_delta_catch2_test.cpp
@@ -13,9 +13,10 @@
 
 #include "../../../src/daemon/p2p/p2p_fuzz.h"
 
+#include "common/p2p_test_helpers.h"
+
 #include <algorithm>
 #include <chrono>
-#include <cstring>
 #include <filesystem>
 #include <functional>
 #include <future>
@@ -40,12 +41,7 @@ using yams::memory_sync::MemorySyncConfig;
 using yams::memory_sync::MemorySyncService;
 
 namespace {
-
-std::vector<std::byte> bytes(std::string_view text) {
-    std::vector<std::byte> result(text.size());
-    std::memcpy(result.data(), text.data(), text.size());
-    return result;
-}
+using namespace yams::p2p_test;
 
 yams::Result<void> validateDeltaJson(const nlohmann::json& json,
                                      const DeltaExchangeOptions& options = {}) {
@@ -56,30 +52,12 @@ yams::Result<void> validateDeltaJson(const nlohmann::json& json,
         options);
 }
 
-std::string text(const std::vector<std::byte>& data) {
-    return std::string(reinterpret_cast<const char*>(data.data()), data.size());
-}
-
 std::string digest(std::span<const std::byte> data) {
     yams::crypto::SHA256Hasher hasher;
     hasher.init();
     hasher.update(data);
     return hasher.finalize();
 }
-
-struct TempDir {
-    explicit TempDir(std::string name) {
-        path = std::filesystem::temp_directory_path() /
-               ("yams-p2p-delta-" + std::move(name) + "-" +
-                std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
-        std::filesystem::create_directories(path);
-    }
-    ~TempDir() {
-        std::error_code error;
-        std::filesystem::remove_all(path, error);
-    }
-    std::filesystem::path path;
-};
 
 class InMemoryBackend final : public yams::storage::IStorageBackend {
 public:

--- a/tests/unit/daemon/p2p_manager_catch2_test.cpp
+++ b/tests/unit/daemon/p2p_manager_catch2_test.cpp
@@ -11,11 +11,10 @@
 #include <yams/memory_sync/writer_auth.h>
 #include <yams/storage/storage_backend.h>
 
-#include <algorithm>
-#include <array>
+#include "common/p2p_test_helpers.h"
+
 #include <atomic>
 #include <chrono>
-#include <cstring>
 #include <filesystem>
 #include <future>
 #include <memory>
@@ -30,31 +29,67 @@ using yams::daemon::p2p::P2pManagerOptions;
 using yams::memory_sync::MemorySyncService;
 
 namespace {
+using namespace yams::p2p_test;
+
+// Distinct key pair per writer identity so tests catch origin-binding regressions: a
+// record claiming origin "server-node" but signed with "client-node"'s key must fail
+// verification. The fixed set mirrors the writer ids used across these tests.
+struct TestWriterKeys {
+    yams::memory_sync::WriterKeyPair node;
+    yams::memory_sync::WriterKeyPair clientNode;
+    yams::memory_sync::WriterKeyPair serverNode;
+};
+
+const TestWriterKeys& testWriterKeys() {
+    static const TestWriterKeys keys = [] {
+        auto generate = [] {
+            auto generated = yams::memory_sync::generateWriterKeyPair();
+            if (!generated) {
+                throw std::runtime_error(generated.error().message);
+            }
+            return generated.value();
+        };
+        return TestWriterKeys{generate(), generate(), generate()};
+    }();
+    return keys;
+}
+
+const yams::memory_sync::WriterKeyPair* keyForWriter(const std::string& writerId) {
+    const auto& keys = testWriterKeys();
+    if (writerId == "node") {
+        return &keys.node;
+    }
+    if (writerId == "client-node") {
+        return &keys.clientNode;
+    }
+    if (writerId == "server-node") {
+        return &keys.serverNode;
+    }
+    return nullptr;
+}
 
 std::shared_ptr<const yams::memory_sync::WriterAuthenticator>
 testWriterAuthenticator(const std::string& writerId, const std::string& corpusId,
                         std::uint64_t corpusEpoch) {
-    static const auto keys = [] {
-        auto generated = yams::memory_sync::generateWriterKeyPair();
-        if (!generated) {
-            throw std::runtime_error(generated.error().message);
-        }
-        return generated.value();
-    }();
+    const auto& keys = testWriterKeys();
+    const auto* selfKey = keyForWriter(writerId);
+    if (selfKey == nullptr) {
+        throw std::runtime_error("test writer id not in the fixed test key set: " + writerId);
+    }
     yams::memory_sync::WriterAuthConfig config;
     config.required = true;
     config.localWriterId = writerId;
-    config.localKeyId = "manager-test-v1";
-    config.localPrivateKeyPem = keys.privateKeyPem;
-    for (const auto& trustedId :
-         std::array<std::string, 4>{"node", "client-node", "server-node", writerId}) {
-        if (std::ranges::none_of(config.trustedKeys, [&](const auto& trusted) {
-                return trusted.writerId == trustedId;
-            })) {
-            config.trustedKeys.push_back(yams::memory_sync::TrustedWriterKey{
-                trustedId, config.localKeyId, keys.publicKeyPem, false});
-        }
-    }
+    config.localKeyId = writerId + "-v1";
+    config.localPrivateKeyPem = selfKey->privateKeyPem;
+    // Trust every known writer with its own distinct key; each record's origin is bound to
+    // the key that signed it, so cross-writer forgery fails verification.
+    const auto trust = [&](const std::string& id, const yams::memory_sync::WriterKeyPair& key) {
+        config.trustedKeys.push_back(
+            yams::memory_sync::TrustedWriterKey{id, id + "-v1", key.publicKeyPem, false});
+    };
+    trust("node", keys.node);
+    trust("client-node", keys.clientNode);
+    trust("server-node", keys.serverNode);
     auto authenticator =
         yams::memory_sync::WriterAuthenticator::create(std::move(config), corpusId, corpusEpoch);
     if (!authenticator) {
@@ -71,32 +106,12 @@ struct MemorySyncConfig : yams::memory_sync::MemorySyncConfig {
                                               "manager-test-control-scope") {}
 };
 
-struct TempDir {
-    explicit TempDir(std::string_view label) {
-        path = std::filesystem::temp_directory_path() /
-               ("yams-p2p-manager-" + std::string(label) + "-" +
-                std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
-        std::filesystem::create_directories(path);
-    }
-    ~TempDir() {
-        std::error_code error;
-        std::filesystem::remove_all(path, error);
-    }
-    std::filesystem::path path;
-};
-
 std::unique_ptr<yams::storage::FilesystemBackend> backend(const std::filesystem::path& path) {
     yams::storage::BackendConfig config;
     config.type = "filesystem";
     config.localPath = path;
     auto result = std::make_unique<yams::storage::FilesystemBackend>();
     REQUIRE(result->initialize(config).has_value());
-    return result;
-}
-
-std::vector<std::byte> bytes(std::string_view text) {
-    std::vector<std::byte> result(text.size());
-    std::memcpy(result.data(), text.data(), text.size());
     return result;
 }
 

--- a/tests/unit/daemon/p2p_transport_catch2_test.cpp
+++ b/tests/unit/daemon/p2p_transport_catch2_test.cpp
@@ -7,13 +7,14 @@
 #include <yams/daemon/p2p/p2p_transport.h>
 #include <yams/memory_sync/writer_auth.h>
 
+#include "common/p2p_test_helpers.h"
+
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/address.hpp>
 #include <boost/asio/ip/tcp.hpp>
 
 #include <atomic>
 #include <chrono>
-#include <cstring>
 #include <future>
 #include <stdexcept>
 #include <string>
@@ -27,16 +28,7 @@ using yams::daemon::p2p::P2pListener;
 using yams::daemon::p2p::TlsIdentity;
 
 namespace {
-
-std::vector<std::byte> bytes(std::string_view text) {
-    std::vector<std::byte> result(text.size());
-    std::memcpy(result.data(), text.data(), text.size());
-    return result;
-}
-
-std::string text(const std::vector<std::byte>& data) {
-    return std::string(reinterpret_cast<const char*>(data.data()), data.size());
-}
+using namespace yams::p2p_test;
 
 TlsIdentity identity(std::string nodeId, const yams::memory_sync::WriterKeyPair& keyPair) {
     auto result = TlsIdentity::fromPrivateKeyPem(std::move(nodeId), keyPair.privateKeyPem);
@@ -612,17 +604,31 @@ TEST_CASE("P2P connection enforces one aggregate session deadline",
                                                        .handshakeTimeout = 2s,
                                                        .sessionTimeout = 500ms});
     REQUIRE(client.has_value());
-    const auto started = std::chrono::steady_clock::now();
     for (int exchange = 0; exchange < 2; ++exchange) {
         REQUIRE(client.value().writeFrame(bytes("ping"), 2s).has_value());
         auto response = client.value().readFrame(2s);
         REQUIRE(response.has_value());
         CHECK(text(response.value()) == "ping");
     }
-    std::this_thread::sleep_until(started + 600ms);
-    auto expired = client.value().writeFrame(bytes("late"), 2s);
-    REQUIRE_FALSE(expired.has_value());
-    CHECK(expired.error().code == yams::ErrorCode::Timeout);
+    // The session deadline is absolute (not idle-based), so a write only starts failing
+    // once 500ms of wall time have passed. Poll until it does instead of sleeping a fixed
+    // 600ms, which is timing-sensitive under load. At the boundary the failure surfaces as
+    // Timeout (client-side deadline check) or NotFound (the peer closed the channel after
+    // its own deadline); both prove the session expired.
+    const auto expiryDeadline = std::chrono::steady_clock::now() + 3s;
+    bool observedExpiry = false;
+    yams::ErrorCode expiryCode = yams::ErrorCode::InvalidState;
+    while (std::chrono::steady_clock::now() < expiryDeadline) {
+        auto attempt = client.value().writeFrame(bytes("late"), 2s);
+        if (!attempt) {
+            observedExpiry = true;
+            expiryCode = attempt.error().code;
+            break;
+        }
+        std::this_thread::sleep_for(10ms);
+    }
+    REQUIRE(observedExpiry);
+    CHECK((expiryCode == yams::ErrorCode::Timeout || expiryCode == yams::ErrorCode::NotFound));
     listener.stop();
 }
 

--- a/tests/unit/memory_sync/memory_sync_service_catch2_test.cpp
+++ b/tests/unit/memory_sync/memory_sync_service_catch2_test.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include <yams/compat/thread_stop_compat.h>
+#include <yams/config/config_helpers.h>
 #include <yams/memory_sync/memory_sync_service.h>
 #include <yams/storage/storage_backend.h>
 
@@ -538,6 +539,9 @@ TEST_CASE("MemorySyncService callback can request stop without self-join",
 
 TEST_CASE("MemorySyncService concurrent lifecycle and status calls remain race-free",
           "[memory-sync][service][lifecycle][stress]") {
+    if (!yams::config::getenv_optional("YAMS_RUN_STRESS_TESTS").has_value()) {
+        SKIP("Stress tests disabled. Set YAMS_RUN_STRESS_TESTS=1 to enable.");
+    }
     TempDirGuard tmp;
     MemorySyncService service{makeBackend(tmp.path), MemorySyncConfig{"A", 10}};
     std::atomic<std::uint32_t> lifecycleFailures{0};


### PR DESCRIPTION
## Summary

Stacked draft child of #76. Closes the remaining code-quality / test-quality findings from the deep review of the #68 stack that were not security-blocking. The large `memory_sync.h` body split is intentionally deferred to its own follow-up (it is a ~3,400-line mechanical move best reviewed in isolation). No merge or deploy.

1. **Test hooks compiled out of production (P2)** — `gReconnectLoopHook` storage, `invokeReconnectLoopHook`, and the reconnect-loop call site are now guarded by `YAMS_DAEMON_TEST_HOOKS_ENABLED`, matching the already-guarded `testing_setReconnectLoopHook`. Production builds no longer carry the test-hook machinery.
2. **Distinct writer keys per identity (P1 test-quality)** — `testWriterAuthenticator` previously signed every node with one shared key and trusted every node with that same key, masking origin-binding regressions. Each writer id (`node`/`client-node`/`server-node`) now has its own key pair, and each authenticator trusts every writer with *that writer's own* key, so a record claiming origin `server-node` but signed with `client-node`'s key now fails verification. Constructor signature unchanged; zero call-site churn.
3. **Shared test helpers (P2)** — the copy-pasted `bytes`/`text`/`TempDir` helpers are extracted to `tests/common/p2p_test_helpers.h` (`namespace yams::p2p_test`, `inline`) and reused by the transport/delta/manager suites.
4. **Timing-sensitive sleep removed (P2)** — the transport session-expiry test no longer sleeps a fixed 600ms; it polls until a write fails (bounded 3s), accepting either the client-side Timeout or the peer-closed NotFound manifestation of the absolute session deadline.
5. **`[stress]` opt-in (P2)** — the memory-sync-service concurrent-lifecycle race test now `SKIP`s unless `YAMS_RUN_STRESS_TESTS=1`, matching the repo's existing FTS5 stress pattern, so the default suite no longer runs stress coverage.
6. **Commitment-JSON dedup (P2)** — the byte-identical `commitments` array serialization in `MemorySyncLoop::coldBootstrapRoot` and `persistReplicationCheckpoint` is now one static `commitmentsJson()` helper. Output is byte-identical (verified by the cold-bootstrap root-hash tests, 838/60 passing).

## Validation

Focused normal matrix (green):

- `p2p_transport` 261 / 18 (×3 runs, deterministic)
- `p2p_delta` 301 / 10 · `p2p_manager` 180 / 12 · `p2p_protocol` 495 / 14 · `peer_registry` 91 / 6
- `memory_sync` 838 / 60 (cold-bootstrap root hashes unchanged ⇒ byte-identical JSON)
- `memory_sync_service` 260 assertions / 26 passed + 1 skipped (the `[stress]` case now skips by default)

Formatting, `git diff --check`, license, Windows-header, and portability checks pass. commitlint passes; the local `dco` default range includes 119 pre-DCO experimental commits (pre-existing; the pushed range is what the pre-push hook validates).

Ordinary pre-push gate passed without bypass: cross-compile smoke, ASAN **195/195**, TSAN **280/280**. Evidence: `build/local-ci/pre-push-ci-gate/summary-20260830T141716Z-62734.md`.

## AI disclosure

Extensive AI assistance was used for implementation, test generation, and adversarial review. All changes were locally inspected and validated; the umbrella #68 remains blocked by the decision-grade live-performance gate.

## Stack

- Base: `fix/p2p-robustness` / #76 at `cd956acdbee34e6c560af1a47fdfc1057ad7fa50`
- Head: `fix/p2p-quality` at `a7d73d2509c51f320d1237c6c57f71190185fec9`
- Umbrella: #68

Deferred follow-up: split the ~3,400-line inline `MemorySyncLoop` bodies from `include/yams/memory_sync/memory_sync.h` into `src/memory_sync/memory_sync.cpp`, and deduplicate the cross-file commitment parse sites (bounds differ per caller).

Do not merge or deploy this child independently.
