### PR TITLE
refactor(daemon): narrow checkpoint WAL capability

### DIFF
--- a/include/yams/daemon/components/CheckpointManager.h
+++ b/include/yams/daemon/components/CheckpointManager.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <yams/core/types.h>
+
 #include <boost/asio/any_io_executor.hpp>
 
 #include <atomic>
@@ -14,10 +16,6 @@
 #include <memory>
 #include <mutex>
 #include <thread>
-
-namespace yams::metadata {
-class MetadataRepository;
-}
 
 namespace yams::daemon {
 
@@ -49,7 +47,8 @@ public:
         VectorIndexCoordinator* vectorIndexCoordinator{nullptr};
         StateComponent* state{nullptr};
         search::HotzoneManager* hotzoneManager{nullptr};
-        metadata::MetadataRepository* metadataRepository{nullptr};
+        std::function<Result<void>()> checkpointWal;
+        std::function<Result<void>()> checkpointWalTruncate;
         boost::asio::any_io_executor executor;
         std::shared_ptr<std::atomic<bool>> stopRequested;
     };

--- a/src/daemon/components/CheckpointManager.cpp
+++ b/src/daemon/components/CheckpointManager.cpp
@@ -55,17 +55,20 @@ void CheckpointManager::stop() {
         checkpointThread_.join();
     }
 
-    if (deps_.checkpointWalTruncate) {
+    const auto& shutdownCheckpoint =
+        deps_.checkpointWalTruncate ? deps_.checkpointWalTruncate : deps_.checkpointWal;
+    if (shutdownCheckpoint) {
+        const char* mode = deps_.checkpointWalTruncate ? "TRUNCATE" : "PASSIVE";
         try {
-            auto result = deps_.checkpointWalTruncate();
+            auto result = shutdownCheckpoint();
             if (result) {
-                spdlog::info("[CheckpointManager] Shutdown WAL checkpoint (TRUNCATE) completed");
+                spdlog::info("[CheckpointManager] Shutdown WAL checkpoint ({}) completed", mode);
             } else {
-                spdlog::warn("[CheckpointManager] Shutdown WAL TRUNCATE failed: {}",
+                spdlog::warn("[CheckpointManager] Shutdown WAL {} failed: {}", mode,
                              result.error().message);
             }
         } catch (const std::exception& e) {
-            spdlog::warn("[CheckpointManager] Shutdown WAL TRUNCATE threw: {}", e.what());
+            spdlog::warn("[CheckpointManager] Shutdown WAL {} threw: {}", mode, e.what());
         }
     }
 }
@@ -245,11 +248,7 @@ bool CheckpointManager::checkpointWal() {
                      *preSize / (1024ULL * 1024ULL), kTruncateWatermarkBytes / (1024ULL * 1024ULL));
     }
 
-    if (wantsTruncate) {
-        if (!deps_.checkpointWalTruncate) {
-            return true;
-        }
-
+    if (wantsTruncate && deps_.checkpointWalTruncate) {
         // ── TRUNCATE with retry (exclusive-lock contention is common under load) ──
         constexpr int kMaxRetries = 3;
         for (int attempt = 0; attempt < kMaxRetries; ++attempt) {

--- a/src/daemon/components/CheckpointManager.cpp
+++ b/src/daemon/components/CheckpointManager.cpp
@@ -5,7 +5,6 @@
 #include <yams/daemon/components/StateComponent.h>
 #include <yams/daemon/components/VectorIndexCoordinator.h>
 #include <yams/daemon/components/VectorSystemManager.h>
-#include <yams/metadata/metadata_repository.h>
 #include <yams/search/hotzone_manager.h>
 #include <yams/vector/vector_database.h>
 
@@ -56,9 +55,9 @@ void CheckpointManager::stop() {
         checkpointThread_.join();
     }
 
-    if (deps_.metadataRepository) {
+    if (deps_.checkpointWalTruncate) {
         try {
-            auto result = deps_.metadataRepository->checkpointWalTruncate();
+            auto result = deps_.checkpointWalTruncate();
             if (result) {
                 spdlog::info("[CheckpointManager] Shutdown WAL checkpoint (TRUNCATE) completed");
             } else {
@@ -220,7 +219,7 @@ bool CheckpointManager::checkpointHotzone() {
 }
 
 bool CheckpointManager::checkpointWal() {
-    if (!deps_.metadataRepository) {
+    if (!deps_.checkpointWal && !deps_.checkpointWalTruncate) {
         return true;
     }
 
@@ -247,6 +246,10 @@ bool CheckpointManager::checkpointWal() {
     }
 
     if (wantsTruncate) {
+        if (!deps_.checkpointWalTruncate) {
+            return true;
+        }
+
         // ── TRUNCATE with retry (exclusive-lock contention is common under load) ──
         constexpr int kMaxRetries = 3;
         for (int attempt = 0; attempt < kMaxRetries; ++attempt) {
@@ -257,7 +260,7 @@ bool CheckpointManager::checkpointWal() {
                 std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
             }
             try {
-                auto result = deps_.metadataRepository->checkpointWalTruncate();
+                auto result = deps_.checkpointWalTruncate();
                 if (result) {
                     stats_.wal_checkpoints.fetch_add(1, std::memory_order_relaxed);
                     auto postSize = walSizeBytes();
@@ -281,8 +284,12 @@ bool CheckpointManager::checkpointWal() {
     }
 
     // ── Routine PASSIVE checkpoint ──
+    if (!deps_.checkpointWal) {
+        return true;
+    }
+
     try {
-        auto result = deps_.metadataRepository->checkpointWal();
+        auto result = deps_.checkpointWal();
         if (result) {
             stats_.wal_checkpoints.fetch_add(1, std::memory_order_relaxed);
             spdlog::debug("[CheckpointManager] WAL checkpoint (PASSIVE) completed");

--- a/src/daemon/components/ServiceManager.cpp
+++ b/src/daemon/components/ServiceManager.cpp
@@ -618,7 +618,14 @@ ServiceManager::ServiceManager(const DaemonConfig& config, StateComponent& state
             checkpointDeps.vectorIndexCoordinator = vectorIndexCoordinator_.get();
             checkpointDeps.state = &state_;
             checkpointDeps.hotzoneManager = nullptr;
-            checkpointDeps.metadataRepository = getMetadataRepo().get();
+            if (auto metadataRepository = getMetadataRepo()) {
+                checkpointDeps.checkpointWal = [metadataRepository]() {
+                    return metadataRepository->checkpointWal();
+                };
+                checkpointDeps.checkpointWalTruncate = [metadataRepository]() {
+                    return metadataRepository->checkpointWalTruncate();
+                };
+            }
             checkpointDeps.executor = workCoordinator_->getExecutor();
             checkpointDeps.stopRequested = std::make_shared<std::atomic<bool>>(false);
 

--- a/tests/unit/daemon/components/checkpoint_manager_test.cpp
+++ b/tests/unit/daemon/components/checkpoint_manager_test.cpp
@@ -233,6 +233,23 @@ TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager routine checkpoint
     CHECK((recorder->truncateCalls == 0));
 }
 
+TEST_CASE_METHOD(CheckpointManagerFixture,
+                 "CheckpointManager watermark falls back to bound passive callback",
+                 "[daemon][components][checkpoint][catch2]") {
+    auto recorder = std::make_shared<WalCheckpointRecorder>();
+    constexpr std::uint64_t kWatermarkBytes = 256ULL * 1024ULL * 1024ULL;
+    createSparseFile(tempDir / "yams.db-wal", kWatermarkBytes + 1);
+    auto cfg = makeConfig();
+    auto deps = makeDeps();
+    deps.checkpointWal = [recorder]() { return recorder->checkpointWal(); };
+    CheckpointManager mgr(cfg, deps);
+
+    CHECK(mgr.checkpointNow());
+
+    CHECK((recorder->passiveCalls == 1));
+    CHECK((recorder->truncateCalls == 0));
+}
+
 TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager watermark checkpoint truncates WAL",
                  "[daemon][components][checkpoint][catch2]") {
     auto recorder = std::make_shared<WalCheckpointRecorder>();
@@ -247,6 +264,23 @@ TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager watermark checkpoi
 
     CHECK((recorder->passiveCalls == 0));
     CHECK((recorder->truncateCalls == 1));
+}
+
+TEST_CASE_METHOD(CheckpointManagerFixture,
+                 "CheckpointManager shutdown falls back to bound passive callback",
+                 "[daemon][components][checkpoint][catch2]") {
+    auto recorder = std::make_shared<WalCheckpointRecorder>();
+    auto cfg = makeConfig();
+    auto deps = makeDeps();
+    deps.checkpointWal = [recorder]() { return recorder->checkpointWal(); };
+    CheckpointManager mgr(cfg, deps);
+    mgr.start();
+    std::this_thread::sleep_for(50ms);
+
+    mgr.stop();
+
+    CHECK((recorder->passiveCalls == 1));
+    CHECK((recorder->truncateCalls == 0));
 }
 
 TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager shutdown truncates WAL",

--- a/tests/unit/daemon/components/checkpoint_manager_test.cpp
+++ b/tests/unit/daemon/components/checkpoint_manager_test.cpp
@@ -8,8 +8,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <yams/daemon/components/CheckpointManager.h>
-#include <yams/metadata/connection_pool.h>
-#include <yams/metadata/metadata_repository.h>
 
 #include <boost/asio/io_context.hpp>
 
@@ -24,17 +22,13 @@ using namespace std::chrono_literals;
 
 namespace {
 
-class CountingMetadataRepository : public yams::metadata::MetadataRepository {
-public:
-    explicit CountingMetadataRepository(yams::metadata::ConnectionPool& pool)
-        : yams::metadata::MetadataRepository(pool) {}
-
-    yams::Result<void> checkpointWal() override {
+struct WalCheckpointRecorder {
+    yams::Result<void> checkpointWal() {
         ++passiveCalls;
         return {};
     }
 
-    yams::Result<void> checkpointWalTruncate() override {
+    yams::Result<void> checkpointWalTruncate() {
         ++truncateCalls;
         return {};
     }
@@ -42,6 +36,12 @@ public:
     int passiveCalls{0};
     int truncateCalls{0};
 };
+
+void bindWalCallbacks(CheckpointManager::Dependencies& deps,
+                      const std::shared_ptr<WalCheckpointRecorder>& recorder) {
+    deps.checkpointWal = [recorder]() { return recorder->checkpointWal(); };
+    deps.checkpointWalTruncate = [recorder]() { return recorder->checkpointWalTruncate(); };
+}
 
 void createSparseFile(const std::filesystem::path& path, std::uint64_t sizeBytes) {
     std::ofstream out(path, std::ios::binary | std::ios::trunc);
@@ -207,70 +207,62 @@ TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager manual checkpoint"
     }
 }
 
-TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager routine checkpoint is passive",
+TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager missing WAL callbacks are a no-op",
                  "[daemon][components][checkpoint][catch2]") {
-    yams::metadata::ConnectionPoolConfig poolConfig;
-    poolConfig.minConnections = 1;
-    poolConfig.maxConnections = 1;
-    poolConfig.enableWAL = true;
-    yams::metadata::ConnectionPool pool((tempDir / "metadata.db").string(), poolConfig);
-    REQUIRE(pool.initialize().has_value());
-    CountingMetadataRepository repository(pool);
-
-    auto cfg = makeConfig();
-    auto deps = makeDeps();
-    deps.metadataRepository = &repository;
-    CheckpointManager mgr(cfg, deps);
-
-    CHECK(mgr.checkpointNow());
-
-    CHECK((repository.passiveCalls == 1));
-    CHECK((repository.truncateCalls == 0));
-}
-
-TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager watermark checkpoint truncates WAL",
-                 "[daemon][components][checkpoint][catch2]") {
-    yams::metadata::ConnectionPoolConfig poolConfig;
-    poolConfig.minConnections = 1;
-    poolConfig.maxConnections = 1;
-    poolConfig.enableWAL = true;
-    yams::metadata::ConnectionPool pool((tempDir / "metadata.db").string(), poolConfig);
-    REQUIRE(pool.initialize().has_value());
-    CountingMetadataRepository repository(pool);
-
     constexpr std::uint64_t kWatermarkBytes = 256ULL * 1024ULL * 1024ULL;
     createSparseFile(tempDir / "yams.db-wal", kWatermarkBytes + 1);
     auto cfg = makeConfig();
     auto deps = makeDeps();
-    deps.metadataRepository = &repository;
+    CheckpointManager mgr(cfg, deps);
+
+    CHECK(mgr.checkpointNow());
+    CHECK((mgr.checkpointErrorCount() == 0));
+}
+
+TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager routine checkpoint is passive",
+                 "[daemon][components][checkpoint][catch2]") {
+    auto recorder = std::make_shared<WalCheckpointRecorder>();
+    auto cfg = makeConfig();
+    auto deps = makeDeps();
+    bindWalCallbacks(deps, recorder);
     CheckpointManager mgr(cfg, deps);
 
     CHECK(mgr.checkpointNow());
 
-    CHECK((repository.passiveCalls == 0));
-    CHECK((repository.truncateCalls == 1));
+    CHECK((recorder->passiveCalls == 1));
+    CHECK((recorder->truncateCalls == 0));
+}
+
+TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager watermark checkpoint truncates WAL",
+                 "[daemon][components][checkpoint][catch2]") {
+    auto recorder = std::make_shared<WalCheckpointRecorder>();
+    constexpr std::uint64_t kWatermarkBytes = 256ULL * 1024ULL * 1024ULL;
+    createSparseFile(tempDir / "yams.db-wal", kWatermarkBytes + 1);
+    auto cfg = makeConfig();
+    auto deps = makeDeps();
+    bindWalCallbacks(deps, recorder);
+    CheckpointManager mgr(cfg, deps);
+
+    CHECK(mgr.checkpointNow());
+
+    CHECK((recorder->passiveCalls == 0));
+    CHECK((recorder->truncateCalls == 1));
 }
 
 TEST_CASE_METHOD(CheckpointManagerFixture, "CheckpointManager shutdown truncates WAL",
                  "[daemon][components][checkpoint][catch2]") {
-    yams::metadata::ConnectionPoolConfig poolConfig;
-    poolConfig.minConnections = 1;
-    poolConfig.maxConnections = 1;
-    poolConfig.enableWAL = true;
-    yams::metadata::ConnectionPool pool((tempDir / "metadata.db").string(), poolConfig);
-    REQUIRE(pool.initialize().has_value());
-    CountingMetadataRepository repository(pool);
-
+    auto recorder = std::make_shared<WalCheckpointRecorder>();
     auto cfg = makeConfig();
     auto deps = makeDeps();
-    deps.metadataRepository = &repository;
+    bindWalCallbacks(deps, recorder);
     CheckpointManager mgr(cfg, deps);
     mgr.start();
     std::this_thread::sleep_for(50ms);
 
     mgr.stop();
 
-    CHECK((repository.truncateCalls == 1));
+    CHECK((recorder->passiveCalls == 0));
+    CHECK((recorder->truncateCalls == 1));
 }
 
 TEST_CASE("CheckpointManager config defaults", "[daemon][components][checkpoint][catch2]") {


### PR DESCRIPTION
> **Stack:** root PR. Merge order: #84 → #85 → #86 → #87 → #88.

## Summary

- replace `CheckpointManager`'s concrete `MetadataRepository` dependency with narrow PASSIVE and TRUNCATE checkpoint callbacks
- bind callbacks in `ServiceManager` while retaining repository lifetime
- preserve WAL watermark, retry, shutdown, logging, and null-dependency behavior

## Validation

- Debug ThreadSanitizer build: `catch2_daemon_component_submodule`
- `daemon_component_submodule`: **1/1 passed** (10.95s)
- format, portability, license, Windows-header, OpenGrep, DCO, and diff checks passed

## Architecture evidence

Brick 0.1.0 schema-v4 comparison used one canonical root and identical production-only exclusions.

- removed node: `MetadataRepository` forward declaration from `CheckpointManager.h`
- `CheckpointManager.cpp` dependency fan-out: **21 → 20** (concrete repository import removed)
- stable-ID diff: **+0 / -1 / ~75 nodes**, **+3 / -2 / ~986 edges**
- all changed nodes are line/LOC changes; all changed edges are evidence-location changes
- cycle count remains 8, all pre-existing single-function self-loops

Brick is lexical evidence; the focused tests above are the behavior signal.
