### PR TITLE
refactor(repair): share embedding candidate policy

### DIFF
--- a/include/yams/repair/embedding_repair_util.h
+++ b/include/yams/repair/embedding_repair_util.h
@@ -43,6 +43,24 @@ struct EmbeddingRepairConfig {
     std::atomic<bool>* cancelRequested = nullptr;
 };
 
+struct EmbeddingRepairCandidateScan {
+    std::vector<std::string> documentHashes;
+    size_t documentsScanned = 0;
+    size_t eligibleByMime = 0;
+    size_t eligibleByExtractedText = 0;
+    std::vector<std::string> excludedSamples;
+};
+
+/**
+ * Select metadata documents eligible for embedding repair.
+ *
+ * Normal scans query only documents missing embeddings; force scans query all documents.
+ * Text-like MIME types, requested MIME prefixes, and documents with extracted content are eligible.
+ */
+Result<EmbeddingRepairCandidateScan>
+selectEmbeddingRepairCandidates(metadata::IMetadataRepository& metadataRepo,
+                                const std::vector<std::string>& includeMimePrefixes, bool force);
+
 class BulkIngestLease {
 public:
     BulkIngestLease() = default;

--- a/src/daemon/components/RepairService.cpp
+++ b/src/daemon/components/RepairService.cpp
@@ -22,6 +22,7 @@
 #include <yams/metadata/document_metadata.h>
 #include <yams/metadata/metadata_repository.h>
 #include <yams/metadata/query_helpers.h>
+#include <yams/repair/embedding_repair_util.h>
 #include <yams/vector/sqlite_vec_backend.h>
 #include <yams/vector/vector_database.h>
 
@@ -2904,52 +2905,21 @@ RepairService::generateMissingEmbeddingsAsync(const RepairRequest& req, const Pr
         progress(ev);
     }
 
-    metadata::DocumentQueryOptions queryOpts;
-    if (!req.force) {
-        queryOpts.hasEmbedding = false;
-    }
-    auto docs = meta->queryDocumentsForGrepCandidates(queryOpts);
-    if (!docs) {
+    auto candidateScanResult =
+        repair::selectEmbeddingRepairCandidates(*meta, req.includeMime, req.force);
+    if (!candidateScanResult) {
         result.message = "Failed to query";
         co_return result;
     }
-
-    auto isEmbeddable = [&req](const std::string& m) -> bool {
-        if (m.rfind("text/", 0) == 0)
-            return true;
-        if (m == "application/json" || m == "application/xml" || m == "application/x-yaml" ||
-            m == "application/yaml")
-            return true;
-        for (const auto& inc : req.includeMime) {
-            if (!inc.empty() && (m == inc || m.rfind(inc, 0) == 0))
-                return true;
-        }
-        return false;
-    };
-
-    std::vector<std::string> hashes;
-    size_t eligibleByMime = 0;
-    size_t eligibleByExtractedText = 0;
-    std::vector<std::string> excludedSamples;
-    for (const auto& d : docs.value()) {
-        const bool hasExtractedText = d.contentExtracted;
-        if (isEmbeddable(d.mimeType)) {
-            ++eligibleByMime;
-            hashes.push_back(d.sha256Hash);
-        } else if (hasExtractedText) {
-            ++eligibleByExtractedText;
-            hashes.push_back(d.sha256Hash);
-        } else if (excludedSamples.size() < 8) {
-            excludedSamples.push_back(d.filePath + " mime=" + d.mimeType +
-                                      " extracted=" + std::string(d.contentExtracted ? "1" : "0"));
-        }
-    }
+    auto candidateScan = std::move(candidateScanResult.value());
+    const auto& hashes = candidateScan.documentHashes;
 
     spdlog::info("RepairService::generateMissingEmbeddingsAsync candidates: scanned={} eligible={} "
                  "eligible_by_mime={} eligible_by_extracted_text={} excluded_samples=[{}] "
                  "force={} missing_only_query={}",
-                 docs.value().size(), hashes.size(), eligibleByMime, eligibleByExtractedText,
-                 excludedSamples.size(), req.force ? 1 : 0, req.force ? 0 : 1);
+                 candidateScan.documentsScanned, hashes.size(), candidateScan.eligibleByMime,
+                 candidateScan.eligibleByExtractedText, candidateScan.excludedSamples.size(),
+                 req.force ? 1 : 0, req.force ? 0 : 1);
 
     if (progress) {
         RepairEvent ev;
@@ -3097,52 +3067,21 @@ RepairOperationResult RepairService::generateMissingEmbeddings(const RepairReque
         progress(ev);
     }
 
-    metadata::DocumentQueryOptions queryOpts;
-    if (!req.force) {
-        queryOpts.hasEmbedding = false;
-    }
-    auto docs = meta->queryDocumentsForGrepCandidates(queryOpts);
-    if (!docs) {
+    auto candidateScanResult =
+        repair::selectEmbeddingRepairCandidates(*meta, req.includeMime, req.force);
+    if (!candidateScanResult) {
         result.message = "Failed to query";
         return result;
     }
-
-    // Filter for embeddable MIME types
-    auto isEmbeddable = [&req](const std::string& m) -> bool {
-        if (m.rfind("text/", 0) == 0)
-            return true;
-        if (m == "application/json" || m == "application/xml" || m == "application/x-yaml" ||
-            m == "application/yaml")
-            return true;
-        for (const auto& inc : req.includeMime)
-            if (!inc.empty() && (m == inc || m.rfind(inc, 0) == 0))
-                return true;
-        return false;
-    };
-
-    std::vector<std::string> hashes;
-    size_t eligibleByMime = 0;
-    size_t eligibleByExtractedText = 0;
-    std::vector<std::string> excludedSamples;
-    for (const auto& d : docs.value()) {
-        const bool hasExtractedText = d.contentExtracted;
-        if (isEmbeddable(d.mimeType)) {
-            ++eligibleByMime;
-            hashes.push_back(d.sha256Hash);
-        } else if (hasExtractedText) {
-            ++eligibleByExtractedText;
-            hashes.push_back(d.sha256Hash);
-        } else if (excludedSamples.size() < 8) {
-            excludedSamples.push_back(d.filePath + " mime=" + d.mimeType +
-                                      " extracted=" + std::string(d.contentExtracted ? "1" : "0"));
-        }
-    }
+    auto candidateScan = std::move(candidateScanResult.value());
+    const auto& hashes = candidateScan.documentHashes;
 
     spdlog::info("RepairService::generateMissingEmbeddings candidates: scanned={} eligible={} "
                  "eligible_by_mime={} eligible_by_extracted_text={} excluded_samples=[{}] "
                  "force={} missing_only_query={}",
-                 docs.value().size(), hashes.size(), eligibleByMime, eligibleByExtractedText,
-                 excludedSamples.size(), req.force ? 1 : 0, req.force ? 0 : 1);
+                 candidateScan.documentsScanned, hashes.size(), candidateScan.eligibleByMime,
+                 candidateScan.eligibleByExtractedText, candidateScan.excludedSamples.size(),
+                 req.force ? 1 : 0, req.force ? 0 : 1);
 
     if (progress) {
         RepairEvent ev;

--- a/src/repair/embedding_repair_util.cpp
+++ b/src/repair/embedding_repair_util.cpp
@@ -10,6 +10,7 @@
 #include <yams/vector/vector_database.h>
 
 #include <spdlog/spdlog.h>
+#include <algorithm>
 #include <atomic>
 #include <cmath>
 #include <ctime>
@@ -31,6 +32,21 @@ namespace {
 constexpr size_t kMaxTextForEmbeddingBytes = 1'000'000; // 1MB (advisory)
 constexpr size_t kMaxTextToPersistInMetadataBytes =
     size_t{16} * 1024 * 1024; // 16 MiB (best-effort)
+constexpr size_t kMaxEmbeddingRepairExcludedSamples = 8;
+
+bool isEmbeddingRepairMimeEligible(std::string_view mimeType,
+                                   const std::vector<std::string>& includeMimePrefixes) {
+    if (mimeType.starts_with("text/") || mimeType == "application/json" ||
+        mimeType == "application/xml" || mimeType == "application/x-yaml" ||
+        mimeType == "application/yaml") {
+        return true;
+    }
+
+    return std::any_of(includeMimePrefixes.begin(), includeMimePrefixes.end(),
+                       [mimeType](const std::string& prefix) {
+                           return !prefix.empty() && mimeType.starts_with(prefix);
+                       });
+}
 
 bool isLikelyTextualMime(std::string_view mimeType) {
     return mimeType.starts_with("text/") || mimeType == "application/json" ||
@@ -165,6 +181,42 @@ private:
     int fd_;
 };
 } // namespace
+
+Result<EmbeddingRepairCandidateScan>
+selectEmbeddingRepairCandidates(metadata::IMetadataRepository& metadataRepo,
+                                const std::vector<std::string>& includeMimePrefixes, bool force) {
+    metadata::DocumentQueryOptions queryOptions;
+    if (!force) {
+        queryOptions.hasEmbedding = false;
+    }
+
+    auto documents = metadataRepo.queryDocumentsForGrepCandidates(queryOptions);
+    if (!documents) {
+        return documents.error();
+    }
+
+    EmbeddingRepairCandidateScan scan;
+    scan.documentsScanned = documents.value().size();
+    scan.documentHashes.reserve(scan.documentsScanned);
+    scan.excludedSamples.reserve(
+        std::min(scan.documentsScanned, kMaxEmbeddingRepairExcludedSamples));
+
+    for (const auto& document : documents.value()) {
+        if (isEmbeddingRepairMimeEligible(document.mimeType, includeMimePrefixes)) {
+            ++scan.eligibleByMime;
+            scan.documentHashes.push_back(document.sha256Hash);
+        } else if (document.contentExtracted) {
+            ++scan.eligibleByExtractedText;
+            scan.documentHashes.push_back(document.sha256Hash);
+        } else if (scan.excludedSamples.size() < kMaxEmbeddingRepairExcludedSamples) {
+            scan.excludedSamples.push_back(
+                document.filePath + " mime=" + document.mimeType +
+                " extracted=" + std::string(document.contentExtracted ? "1" : "0"));
+        }
+    }
+
+    return scan;
+}
 
 Result<EmbeddingRepairStats>
 repairMissingEmbeddings(const std::shared_ptr<api::IContentStore>& contentStore,

--- a/tests/unit/repair/embedding_repair_scan_catch2_test.cpp
+++ b/tests/unit/repair/embedding_repair_scan_catch2_test.cpp
@@ -264,6 +264,13 @@ public:
         return InMemoryMetadata::queryDocuments(options);
     }
 
+    Result<std::vector<metadata::GrepCandidateProjection>>
+    queryDocumentsForGrepCandidates(const metadata::DocumentQueryOptions& options) override {
+        queryHadEmbeddingFilter_ = options.hasEmbedding.has_value();
+        queriedEmbeddingValue_ = options.hasEmbedding.value_or(false);
+        return metadata::IMetadataRepository::queryDocumentsForGrepCandidates(options);
+    }
+
     bool queryHadEmbeddingFilter() const { return queryHadEmbeddingFilter_; }
     bool queriedEmbeddingValue() const { return queriedEmbeddingValue_; }
 

--- a/tests/unit/repair/embedding_repair_scan_catch2_test.cpp
+++ b/tests/unit/repair/embedding_repair_scan_catch2_test.cpp
@@ -253,4 +253,89 @@ TEST_CASE("RepairUtilScan returns empty list for empty metadata", "[repair][embe
     std::filesystem::remove_all(tmp, ec);
 }
 
+namespace {
+
+class CandidateMetadata final : public InMemoryMetadata {
+public:
+    Result<std::vector<metadata::DocumentInfo>>
+    queryDocuments(const metadata::DocumentQueryOptions& options) override {
+        queryHadEmbeddingFilter_ = options.hasEmbedding.has_value();
+        queriedEmbeddingValue_ = options.hasEmbedding.value_or(false);
+        return InMemoryMetadata::queryDocuments(options);
+    }
+
+    bool queryHadEmbeddingFilter() const { return queryHadEmbeddingFilter_; }
+    bool queriedEmbeddingValue() const { return queriedEmbeddingValue_; }
+
+private:
+    bool queryHadEmbeddingFilter_{false};
+    bool queriedEmbeddingValue_{false};
+};
+
+metadata::DocumentInfo makeCandidate(std::string hash, std::string path, std::string mime,
+                                     bool contentExtracted = false) {
+    metadata::DocumentInfo doc{};
+    doc.sha256Hash = std::move(hash);
+    doc.filePath = std::move(path);
+    doc.mimeType = std::move(mime);
+    doc.contentExtracted = contentExtracted;
+    return doc;
+}
+
+} // namespace
+
+TEST_CASE("Embedding repair candidate policy preserves MIME and extracted-content eligibility",
+          "[repair][embedding][catch2]") {
+    auto repo = std::make_shared<CandidateMetadata>();
+    repo->add(makeCandidate("text", "/docs/readme.txt", "text/plain"));
+    repo->add(makeCandidate("json", "/docs/data.json", "application/json", true));
+    repo->add(makeCandidate("xml", "/docs/data.xml", "application/xml"));
+    repo->add(makeCandidate("x-yaml", "/docs/data.yaml", "application/x-yaml"));
+    repo->add(makeCandidate("yaml", "/docs/config.yaml", "application/yaml"));
+    repo->add(makeCandidate("custom-exact", "/docs/report.pdf", "application/pdf"));
+    repo->add(makeCandidate("custom-prefix", "/docs/photo.png", "image/png"));
+    repo->add(makeCandidate("extracted", "/docs/archive.bin", "application/octet-stream", true));
+    repo->add(makeCandidate("javascript", "/docs/app.js", "application/javascript"));
+    repo->add(makeCandidate("excluded", "/docs/video.mp4", "video/mp4"));
+
+    const auto scan = selectEmbeddingRepairCandidates(
+        *repo, {"application/pdf", "image/", "", "not/a-match"}, false);
+
+    REQUIRE(scan);
+    CHECK(repo->queryHadEmbeddingFilter());
+    CHECK_FALSE(repo->queriedEmbeddingValue());
+    CHECK(scan.value().documentsScanned == 10u);
+    CHECK(scan.value().eligibleByMime == 7u);
+    CHECK(scan.value().eligibleByExtractedText == 1u);
+    CHECK((scan.value().documentHashes == std::vector<std::string>{"text", "json", "xml", "x-yaml",
+                                                                   "yaml", "custom-exact",
+                                                                   "custom-prefix", "extracted"}));
+    CHECK((scan.value().excludedSamples ==
+           std::vector<std::string>{"/docs/app.js mime=application/javascript extracted=0",
+                                    "/docs/video.mp4 mime=video/mp4 extracted=0"}));
+}
+
+TEST_CASE("Embedding repair candidate policy force scans all documents and caps exclusions",
+          "[repair][embedding][catch2]") {
+    auto repo = std::make_shared<CandidateMetadata>();
+    for (int i = 0; i < 10; ++i) {
+        repo->add(makeCandidate("excluded-" + std::to_string(i),
+                                "/docs/excluded-" + std::to_string(i), "video/mp4"));
+    }
+
+    const auto scan = selectEmbeddingRepairCandidates(*repo, {}, true);
+
+    REQUIRE(scan);
+    CHECK_FALSE(repo->queryHadEmbeddingFilter());
+    CHECK(scan.value().documentsScanned == 10u);
+    CHECK(scan.value().documentHashes.empty());
+    CHECK(scan.value().eligibleByMime == 0u);
+    CHECK(scan.value().eligibleByExtractedText == 0u);
+    REQUIRE(scan.value().excludedSamples.size() == 8u);
+    CHECK(scan.value().excludedSamples.front() ==
+          std::string("/docs/excluded-0 mime=video/mp4 extracted=0"));
+    CHECK(scan.value().excludedSamples.back() ==
+          std::string("/docs/excluded-7 mime=video/mp4 extracted=0"));
+}
+
 } // namespace yams::repair::test


### PR DESCRIPTION
> **Stack:** depends on #84; followed by #86 → #87 → #88.

## Summary

- extract shared embedding-repair candidate selection into `embedding_repair_util`
- preserve MIME/include-prefix filtering, extracted-content fallback, force-query behavior, counts, ordering, and excluded samples
- keep asynchronous backoff and synchronous monitoring/lifecycle paths separate

## Validation

- Debug ThreadSanitizer build: `catch2_repair_submodule`
- `repair_submodule`: **1/1 passed** (2.04s)
- the initial characterization exposed a concrete-repository projection override in the test double; the corrected test now exercises the interface fallback
- format, portability, license, Windows-header, OpenGrep, DCO, and diff checks passed

## Architecture evidence

Brick 0.1.0 schema-v4 comparison used one canonical root and identical production-only exclusions.

- `RepairService.cpp` Brick LOC: **3,144 → 3,087**
- candidate policy moved to `embedding_repair_util.cpp` (**707 → 752** LOC)
- stable-ID diff: **+4 / -0 / ~43 nodes**, **+12 / -2 / ~656 edges**
- added records correspond to `EmbeddingRepairCandidateScan` and the shared selector
- all changed nodes are line/LOC changes; all changed edges are evidence-location changes
- cycle count remains 8, all pre-existing single-function self-loops

Brick is lexical evidence; the focused tests above are the behavior signal.
