### PR TITLE
refactor(search): extract auxiliary vector merge

### DIFF
--- a/src/search/search_engine.cpp
+++ b/src/search/search_engine.cpp
@@ -3051,8 +3051,6 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
         graphVectorGeneratedTerms = graphTerms.size();
         size_t multiVecHits = 0;
         size_t baseVectorCount = 0;
-        std::vector<ComponentResult> mergedVectorResults;
-        std::vector<ComponentResult> mergedGraphVectorResults;
 
         if (!subPhrases.empty() || !graphTerms.empty()) {
             spdlog::debug("multi_vector: generated {} sub-phrases from query '{}'",
@@ -3060,83 +3058,10 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
             spdlog::debug("graph_vector: generated {} graph terms from query '{}'",
                           graphTerms.size(), query.substr(0, 60));
 
-            std::vector<ComponentResult> nonVectorResults;
-            nonVectorResults.reserve(allComponentResults.size());
-
-            std::unordered_map<std::string, size_t> bestVectorByHash;
-            bestVectorByHash.reserve(workingConfig.vectorMaxResults * 2);
-            std::unordered_map<std::string, size_t> bestGraphVectorByHash;
-            bestGraphVectorByHash.reserve(workingConfig.vectorMaxResults * 2);
-            std::unordered_set<std::string> graphVectorCorroboratedHashes;
-            graphVectorCorroboratedHashes.reserve(allComponentResults.size() * 2);
-            std::unordered_set<std::string> graphVectorTextAnchoredHashes;
-            graphVectorTextAnchoredHashes.reserve(allComponentResults.size() * 2);
-            std::unordered_set<std::string> graphVectorBaselineTextAnchoredHashes;
-            graphVectorBaselineTextAnchoredHashes.reserve(allComponentResults.size() * 2);
-
-            for (const auto& cr : allComponentResults) {
-                if (cr.source == ComponentResult::Source::Vector ||
-                    cr.source == ComponentResult::Source::EntityVector) {
-                    if (cr.documentHash.empty()) {
-                        continue;
-                    }
-
-                    ++baseVectorCount;
-                    graphVectorCorroboratedHashes.insert(cr.documentHash);
-                    auto it = bestVectorByHash.find(cr.documentHash);
-                    if (it == bestVectorByHash.end()) {
-                        bestVectorByHash.emplace(cr.documentHash, mergedVectorResults.size());
-                        mergedVectorResults.push_back(cr);
-                    } else if (cr.score > mergedVectorResults[it->second].score) {
-                        mergedVectorResults[it->second] = cr;
-                    }
-                    continue;
-                }
-                if (cr.source == ComponentResult::Source::GraphVector) {
-                    if (cr.documentHash.empty()) {
-                        continue;
-                    }
-                    auto it = bestGraphVectorByHash.find(cr.documentHash);
-                    if (it == bestGraphVectorByHash.end()) {
-                        bestGraphVectorByHash.emplace(cr.documentHash,
-                                                      mergedGraphVectorResults.size());
-                        mergedGraphVectorResults.push_back(cr);
-                    } else if (cr.score > mergedGraphVectorResults[it->second].score) {
-                        mergedGraphVectorResults[it->second] = cr;
-                    }
-                    continue;
-                }
-                {
-                    if (!cr.documentHash.empty()) {
-                        if (isTextAnchoringComponent(cr.source) ||
-                            cr.source == ComponentResult::Source::KnowledgeGraph) {
-                            graphVectorCorroboratedHashes.insert(cr.documentHash);
-                        }
-                        if (cr.source == ComponentResult::Source::Text ||
-                            cr.source == ComponentResult::Source::SimeonText ||
-                            cr.source == ComponentResult::Source::GraphText ||
-                            cr.source == ComponentResult::Source::PathTree ||
-                            cr.source == ComponentResult::Source::KnowledgeGraph ||
-                            cr.source == ComponentResult::Source::Tag ||
-                            cr.source == ComponentResult::Source::Metadata ||
-                            cr.source == ComponentResult::Source::Symbol) {
-                            graphVectorTextAnchoredHashes.insert(cr.documentHash);
-                        }
-                        if (cr.source == ComponentResult::Source::Text ||
-                            cr.source == ComponentResult::Source::SimeonText ||
-                            cr.source == ComponentResult::Source::PathTree ||
-                            cr.source == ComponentResult::Source::KnowledgeGraph ||
-                            cr.source == ComponentResult::Source::Symbol) {
-                            graphVectorBaselineTextAnchoredHashes.insert(cr.documentHash);
-                        }
-                    }
-                    nonVectorResults.push_back(cr);
-                }
-            }
-
-            const float decay = std::clamp(workingConfig.multiVectorScoreDecay, 0.1f, 1.0f);
-            const float graphPenalty =
-                std::clamp(workingConfig.graphExpansionVectorPenalty, 0.1f, 1.0f);
+            std::vector<detail::AuxiliaryVectorCandidateBatch> subPhraseCandidates;
+            subPhraseCandidates.reserve(subPhrases.size());
+            std::vector<detail::AuxiliaryVectorCandidateBatch> graphTermCandidates;
+            graphTermCandidates.reserve(graphTerms.size());
 
             for (size_t pi = 0; pi < subPhrases.size(); ++pi) {
                 try {
@@ -3150,30 +3075,9 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
                     if (!subResults || subResults.value().empty()) {
                         continue;
                     }
-                    multiVectorPhraseHits += subResults.value().size();
-
-                    for (const auto& rawResult : subResults.value()) {
-                        ComponentResult cr = rawResult;
-                        if (cr.documentHash.empty()) {
-                            continue;
-                        }
-
-                        cr.score *= decay;
-                        cr.debugInfo["multi_vector_phrase"] = subPhrases[pi];
-                        cr.debugInfo["multi_vector_phrase_idx"] = std::to_string(pi);
-
-                        auto it = bestVectorByHash.find(cr.documentHash);
-                        if (it == bestVectorByHash.end()) {
-                            bestVectorByHash.emplace(cr.documentHash, mergedVectorResults.size());
-                            mergedVectorResults.push_back(std::move(cr));
-                            ++multiVecHits;
-                            ++multiVectorAddedNewCount;
-                        } else if (cr.score > mergedVectorResults[it->second].score) {
-                            mergedVectorResults[it->second] = std::move(cr);
-                            ++multiVecHits;
-                            ++multiVectorReplacedBaseCount;
-                        }
-                    }
+                    subPhraseCandidates.push_back({.query = subPhrases[pi],
+                                                   .queryIndex = pi,
+                                                   .candidates = std::move(subResults.value())});
                 } catch (const std::exception& e) {
                     spdlog::warn("multi_vector: sub-phrase embedding failed for '{}': {}",
                                  subPhrases[pi], e.what());
@@ -3191,73 +3095,34 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
                     if (!graphResults || graphResults.value().empty()) {
                         continue;
                     }
-                    graphVectorRawHitCount += graphResults.value().size();
-
-                    for (const auto& rawResult : graphResults.value()) {
-                        ComponentResult cr = rawResult;
-                        if (cr.documentHash.empty()) {
-                            continue;
-                        }
-                        if (workingConfig.graphVectorRequireCorroboration &&
-                            !graphVectorCorroboratedHashes.contains(cr.documentHash)) {
-                            ++graphVectorBlockedUncorroboratedCount;
-                            continue;
-                        }
-                        if (workingConfig.graphVectorRequireTextAnchoring &&
-                            !graphVectorTextAnchoredHashes.contains(cr.documentHash)) {
-                            ++graphVectorBlockedMissingTextAnchorCount;
-                            continue;
-                        }
-                        if (workingConfig.graphVectorRequireBaselineTextAnchoring &&
-                            !graphVectorBaselineTextAnchoredHashes.contains(cr.documentHash)) {
-                            ++graphVectorBlockedMissingBaselineTextAnchorCount;
-                            continue;
-                        }
-                        cr.source = ComponentResult::Source::GraphVector;
-                        cr.score *= (graphPenalty * std::clamp(graphTerms[gi].score, 0.2f, 1.0f));
-                        cr.debugInfo["graph_vector_term"] = graphTerms[gi].text;
-                        cr.debugInfo["graph_vector_term_idx"] = std::to_string(gi);
-
-                        auto it = bestGraphVectorByHash.find(cr.documentHash);
-                        if (it == bestGraphVectorByHash.end()) {
-                            bestGraphVectorByHash.emplace(cr.documentHash,
-                                                          mergedGraphVectorResults.size());
-                            mergedGraphVectorResults.push_back(std::move(cr));
-                            ++graphVectorAddedNewCount;
-                        } else if (cr.score > mergedGraphVectorResults[it->second].score) {
-                            mergedGraphVectorResults[it->second] = std::move(cr);
-                            ++graphVectorReplacedBaseCount;
-                        }
-                    }
+                    graphTermCandidates.push_back({.query = graphTerms[gi].text,
+                                                   .queryIndex = gi,
+                                                   .weight = graphTerms[gi].score,
+                                                   .candidates = std::move(graphResults.value())});
                 } catch (const std::exception& e) {
                     spdlog::warn("graph_vector: term embedding failed for '{}': {}",
                                  graphTerms[gi].text, e.what());
                 }
             }
 
-            std::sort(mergedVectorResults.begin(), mergedVectorResults.end(),
-                      [](const auto& a, const auto& b) { return a.score > b.score; });
-            if (mergedVectorResults.size() > workingConfig.vectorMaxResults) {
-                mergedVectorResults.resize(workingConfig.vectorMaxResults);
-            }
-            for (size_t i = 0; i < mergedVectorResults.size(); ++i) {
-                mergedVectorResults[i].rank = i;
-            }
-
-            std::sort(mergedGraphVectorResults.begin(), mergedGraphVectorResults.end(),
-                      [](const auto& a, const auto& b) { return a.score > b.score; });
-            if (mergedGraphVectorResults.size() > workingConfig.vectorMaxResults) {
-                mergedGraphVectorResults.resize(workingConfig.vectorMaxResults);
-            }
-            for (size_t i = 0; i < mergedGraphVectorResults.size(); ++i) {
-                mergedGraphVectorResults[i].rank = i;
-            }
-
-            allComponentResults = std::move(nonVectorResults);
-            allComponentResults.insert(allComponentResults.end(), mergedVectorResults.begin(),
-                                       mergedVectorResults.end());
-            allComponentResults.insert(allComponentResults.end(), mergedGraphVectorResults.begin(),
-                                       mergedGraphVectorResults.end());
+            auto merged = detail::mergeAuxiliaryVectorCandidates(
+                std::move(allComponentResults), std::move(subPhraseCandidates),
+                std::move(graphTermCandidates), workingConfig);
+            allComponentResults = std::move(merged.components);
+            baseVectorCount = merged.stats.baseVectorCount;
+            multiVectorPhraseHits = merged.stats.multiVectorRawHitCount;
+            multiVecHits = merged.stats.multiVectorMergedCount;
+            multiVectorAddedNewCount = merged.stats.multiVectorAddedNewCount;
+            multiVectorReplacedBaseCount = merged.stats.multiVectorReplacedBaseCount;
+            graphVectorRawHitCount = merged.stats.graphVectorRawHitCount;
+            graphVectorAddedNewCount = merged.stats.graphVectorAddedNewCount;
+            graphVectorReplacedBaseCount = merged.stats.graphVectorReplacedBaseCount;
+            graphVectorBlockedUncorroboratedCount =
+                merged.stats.graphVectorBlockedUncorroboratedCount;
+            graphVectorBlockedMissingTextAnchorCount =
+                merged.stats.graphVectorBlockedMissingTextAnchorCount;
+            graphVectorBlockedMissingBaselineTextAnchorCount =
+                merged.stats.graphVectorBlockedMissingBaselineTextAnchorCount;
         }
 
         auto mvEnd = std::chrono::steady_clock::now();

--- a/src/search/search_vector_pipeline.cpp
+++ b/src/search/search_vector_pipeline.cpp
@@ -301,6 +301,173 @@ Result<std::vector<std::pair<std::string, std::int64_t>>> resolveMetadataDocumen
     return resolved;
 }
 
+AuxiliaryVectorMergeResult
+mergeAuxiliaryVectorCandidates(std::vector<ComponentResult> components,
+                               std::vector<AuxiliaryVectorCandidateBatch> subPhraseCandidates,
+                               std::vector<AuxiliaryVectorCandidateBatch> graphTermCandidates,
+                               const SearchEngineConfig& config) {
+    AuxiliaryVectorMergeResult out;
+    std::vector<ComponentResult> vectorResults;
+    std::vector<ComponentResult> graphVectorResults;
+    vectorResults.reserve(config.vectorMaxResults * 2);
+    graphVectorResults.reserve(config.vectorMaxResults * 2);
+    out.components.reserve(components.size());
+
+    std::unordered_map<std::string, std::size_t> bestVectorByHash;
+    std::unordered_map<std::string, std::size_t> bestGraphVectorByHash;
+    std::unordered_set<std::string> corroboratedHashes;
+    std::unordered_set<std::string> textAnchoredHashes;
+    std::unordered_set<std::string> baselineTextAnchoredHashes;
+    bestVectorByHash.reserve(config.vectorMaxResults * 2);
+    bestGraphVectorByHash.reserve(config.vectorMaxResults * 2);
+    corroboratedHashes.reserve(components.size() * 2);
+    textAnchoredHashes.reserve(components.size() * 2);
+    baselineTextAnchoredHashes.reserve(components.size() * 2);
+
+    for (auto& candidate : components) {
+        if (candidate.source == ComponentResult::Source::Vector ||
+            candidate.source == ComponentResult::Source::EntityVector) {
+            if (candidate.documentHash.empty()) {
+                continue;
+            }
+            ++out.stats.baseVectorCount;
+            corroboratedHashes.insert(candidate.documentHash);
+            const auto [it, inserted] =
+                bestVectorByHash.emplace(candidate.documentHash, vectorResults.size());
+            if (inserted) {
+                vectorResults.push_back(std::move(candidate));
+            } else if (candidate.score > vectorResults[it->second].score) {
+                vectorResults[it->second] = std::move(candidate);
+            }
+            continue;
+        }
+        if (candidate.source == ComponentResult::Source::GraphVector) {
+            if (candidate.documentHash.empty()) {
+                continue;
+            }
+            const auto [it, inserted] =
+                bestGraphVectorByHash.emplace(candidate.documentHash, graphVectorResults.size());
+            if (inserted) {
+                graphVectorResults.push_back(std::move(candidate));
+            } else if (candidate.score > graphVectorResults[it->second].score) {
+                graphVectorResults[it->second] = std::move(candidate);
+            }
+            continue;
+        }
+        if (!candidate.documentHash.empty()) {
+            if (isTextAnchoringComponent(candidate.source) ||
+                candidate.source == ComponentResult::Source::KnowledgeGraph) {
+                corroboratedHashes.insert(candidate.documentHash);
+            }
+            if (candidate.source == ComponentResult::Source::Text ||
+                candidate.source == ComponentResult::Source::SimeonText ||
+                candidate.source == ComponentResult::Source::GraphText ||
+                candidate.source == ComponentResult::Source::PathTree ||
+                candidate.source == ComponentResult::Source::KnowledgeGraph ||
+                candidate.source == ComponentResult::Source::Tag ||
+                candidate.source == ComponentResult::Source::Metadata ||
+                candidate.source == ComponentResult::Source::Symbol) {
+                textAnchoredHashes.insert(candidate.documentHash);
+            }
+            if (candidate.source == ComponentResult::Source::Text ||
+                candidate.source == ComponentResult::Source::SimeonText ||
+                candidate.source == ComponentResult::Source::PathTree ||
+                candidate.source == ComponentResult::Source::KnowledgeGraph ||
+                candidate.source == ComponentResult::Source::Symbol) {
+                baselineTextAnchoredHashes.insert(candidate.documentHash);
+            }
+        }
+        out.components.push_back(std::move(candidate));
+    }
+
+    const float decay = std::clamp(config.multiVectorScoreDecay, 0.1F, 1.0F);
+    for (std::size_t batchIndex = 0; batchIndex < subPhraseCandidates.size(); ++batchIndex) {
+        auto& batch = subPhraseCandidates[batchIndex];
+        out.stats.multiVectorRawHitCount += batch.candidates.size();
+        for (auto& candidate : batch.candidates) {
+            if (candidate.documentHash.empty()) {
+                continue;
+            }
+            candidate.score *= decay;
+            candidate.debugInfo["multi_vector_phrase"] = batch.query;
+            candidate.debugInfo["multi_vector_phrase_idx"] = std::to_string(batch.queryIndex);
+            const auto [it, inserted] =
+                bestVectorByHash.emplace(candidate.documentHash, vectorResults.size());
+            if (inserted) {
+                vectorResults.push_back(std::move(candidate));
+                ++out.stats.multiVectorAddedNewCount;
+                ++out.stats.multiVectorMergedCount;
+            } else if (candidate.score > vectorResults[it->second].score) {
+                vectorResults[it->second] = std::move(candidate);
+                ++out.stats.multiVectorReplacedBaseCount;
+                ++out.stats.multiVectorMergedCount;
+            }
+        }
+    }
+
+    const float graphPenalty = std::clamp(config.graphExpansionVectorPenalty, 0.1F, 1.0F);
+    for (std::size_t batchIndex = 0; batchIndex < graphTermCandidates.size(); ++batchIndex) {
+        auto& batch = graphTermCandidates[batchIndex];
+        out.stats.graphVectorRawHitCount += batch.candidates.size();
+        for (auto& candidate : batch.candidates) {
+            if (candidate.documentHash.empty()) {
+                continue;
+            }
+            if (config.graphVectorRequireCorroboration &&
+                !corroboratedHashes.contains(candidate.documentHash)) {
+                ++out.stats.graphVectorBlockedUncorroboratedCount;
+                continue;
+            }
+            if (config.graphVectorRequireTextAnchoring &&
+                !textAnchoredHashes.contains(candidate.documentHash)) {
+                ++out.stats.graphVectorBlockedMissingTextAnchorCount;
+                continue;
+            }
+            if (config.graphVectorRequireBaselineTextAnchoring &&
+                !baselineTextAnchoredHashes.contains(candidate.documentHash)) {
+                ++out.stats.graphVectorBlockedMissingBaselineTextAnchorCount;
+                continue;
+            }
+            candidate.source = ComponentResult::Source::GraphVector;
+            candidate.score *= graphPenalty * std::clamp(batch.weight, 0.2F, 1.0F);
+            candidate.debugInfo["graph_vector_term"] = batch.query;
+            candidate.debugInfo["graph_vector_term_idx"] = std::to_string(batch.queryIndex);
+            const auto [it, inserted] =
+                bestGraphVectorByHash.emplace(candidate.documentHash, graphVectorResults.size());
+            if (inserted) {
+                graphVectorResults.push_back(std::move(candidate));
+                ++out.stats.graphVectorAddedNewCount;
+            } else if (candidate.score > graphVectorResults[it->second].score) {
+                graphVectorResults[it->second] = std::move(candidate);
+                ++out.stats.graphVectorReplacedBaseCount;
+            }
+        }
+    }
+
+    const auto rankAndCap = [&](std::vector<ComponentResult>& results) {
+        std::sort(results.begin(), results.end(), [](const auto& lhs, const auto& rhs) {
+            if (lhs.score != rhs.score) {
+                return lhs.score > rhs.score;
+            }
+            return lhs.documentHash < rhs.documentHash;
+        });
+        if (results.size() > config.vectorMaxResults) {
+            results.resize(config.vectorMaxResults);
+        }
+        for (std::size_t rank = 0; rank < results.size(); ++rank) {
+            results[rank].rank = rank;
+        }
+    };
+    rankAndCap(vectorResults);
+    rankAndCap(graphVectorResults);
+
+    out.components.insert(out.components.end(), std::make_move_iterator(vectorResults.begin()),
+                          std::make_move_iterator(vectorResults.end()));
+    out.components.insert(out.components.end(), std::make_move_iterator(graphVectorResults.begin()),
+                          std::make_move_iterator(graphVectorResults.end()));
+    return out;
+}
+
 CandidateRescueMergeResult
 mergeVectorCandidateRescues(std::vector<ComponentResult> baseline,
                             std::vector<ComponentResult> expansion,

--- a/src/search/search_vector_pipeline.cpp
+++ b/src/search/search_vector_pipeline.cpp
@@ -445,12 +445,8 @@ mergeAuxiliaryVectorCandidates(std::vector<ComponentResult> components,
     }
 
     const auto rankAndCap = [&](std::vector<ComponentResult>& results) {
-        std::sort(results.begin(), results.end(), [](const auto& lhs, const auto& rhs) {
-            if (lhs.score != rhs.score) {
-                return lhs.score > rhs.score;
-            }
-            return lhs.documentHash < rhs.documentHash;
-        });
+        std::sort(results.begin(), results.end(),
+                  [](const auto& lhs, const auto& rhs) { return lhs.score > rhs.score; });
         if (results.size() > config.vectorMaxResults) {
             results.resize(config.vectorMaxResults);
         }

--- a/src/search/search_vector_pipeline_internal.h
+++ b/src/search/search_vector_pipeline_internal.h
@@ -60,6 +60,40 @@ struct RoutedVectorFilterResult {
     std::size_t removed{0};
 };
 
+struct AuxiliaryVectorCandidateBatch {
+    std::string query;
+    std::size_t queryIndex{0};
+    float weight{1.0F};
+    std::vector<ComponentResult> candidates;
+};
+
+struct AuxiliaryVectorMergeStats {
+    std::size_t baseVectorCount{0};
+    std::size_t multiVectorRawHitCount{0};
+    std::size_t multiVectorAddedNewCount{0};
+    std::size_t multiVectorReplacedBaseCount{0};
+    std::size_t multiVectorMergedCount{0};
+    std::size_t graphVectorRawHitCount{0};
+    std::size_t graphVectorAddedNewCount{0};
+    std::size_t graphVectorReplacedBaseCount{0};
+    std::size_t graphVectorBlockedUncorroboratedCount{0};
+    std::size_t graphVectorBlockedMissingTextAnchorCount{0};
+    std::size_t graphVectorBlockedMissingBaselineTextAnchorCount{0};
+};
+
+struct AuxiliaryVectorMergeResult {
+    std::vector<ComponentResult> components;
+    AuxiliaryVectorMergeStats stats;
+};
+
+/// Merge already-scored sub-phrase and graph-term vector candidates into component results.
+/// Embedding, vector queries, timing, tracing, exception handling, and I/O remain caller-owned.
+[[nodiscard]] AuxiliaryVectorMergeResult
+mergeAuxiliaryVectorCandidates(std::vector<ComponentResult> components,
+                               std::vector<AuxiliaryVectorCandidateBatch> subPhraseCandidates,
+                               std::vector<AuxiliaryVectorCandidateBatch> graphTermCandidates,
+                               const SearchEngineConfig& config);
+
 struct CandidateRescueMergeResult {
     std::vector<ComponentResult> results;
     std::vector<std::string> addedDocumentHashes;

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -165,7 +165,7 @@ src/metadata/versioning_util.cpp:101:portability/env-read # reviewed raw environ
 src/plugins/plugin_repo_client.cpp:62:portability/env-read # reviewed raw environment read
 src/search/search_engine.cpp:378:portability/env-read # reviewed raw environment read
 src/search/search_engine.cpp:391:portability/env-read # reviewed raw environment read
-src/search/search_engine.cpp:3300:portability/env-read # reviewed raw environment read
+src/search/search_engine.cpp:3165:portability/env-read # reviewed raw environment read
 src/search/search_lexical_pipeline.cpp:605:portability/env-read # reviewed raw environment read
 src/storage/compressed_storage_engine.cpp:632:portability/env-read # reviewed raw environment read
 src/storage/object_storage_plugin_loader.cpp:126:portability/env-read # reviewed raw environment read

--- a/tests/unit/search/search_engine_topology_catch2_test.cpp
+++ b/tests/unit/search/search_engine_topology_catch2_test.cpp
@@ -2092,6 +2092,44 @@ TEST_CASE("rankGraphNeighborCandidates can weight support by query seed evidence
     CHECK(weighted.front() == "focused");
 }
 
+TEST_CASE("SearchEngine topology merge keeps graph-vector candidates behind baseline anchors",
+          "[search][topology][graph-vector][characterization][catch2]") {
+    using detail::AuxiliaryVectorCandidateBatch;
+
+    SearchEngineConfig config;
+    config.vectorMaxResults = 2;
+    config.graphExpansionVectorPenalty = 0.5F;
+    config.graphVectorRequireCorroboration = true;
+    config.graphVectorRequireTextAnchoring = true;
+    config.graphVectorRequireBaselineTextAnchoring = true;
+
+    std::vector<ComponentResult> components{
+        {.documentHash = "baseline-anchor", .score = 0.9F, .source = ComponentResult::Source::Text},
+        {.documentHash = "graph-anchor",
+         .score = 0.8F,
+         .source = ComponentResult::Source::GraphText},
+    };
+    std::vector<AuxiliaryVectorCandidateBatch> graphTerms{
+        {.query = "related",
+         .weight = 1.0F,
+         .candidates = {{.documentHash = "baseline-anchor", .score = 1.0F},
+                        {.documentHash = "graph-anchor", .score = 1.0F},
+                        {.documentHash = "unanchored", .score = 1.0F}}},
+    };
+
+    const auto merged = detail::mergeAuxiliaryVectorCandidates(std::move(components), {},
+                                                               std::move(graphTerms), config);
+
+    CHECK(merged.stats.graphVectorRawHitCount == 3U);
+    CHECK(merged.stats.graphVectorAddedNewCount == 1U);
+    CHECK(merged.stats.graphVectorBlockedUncorroboratedCount == 1U);
+    CHECK(merged.stats.graphVectorBlockedMissingBaselineTextAnchorCount == 1U);
+    REQUIRE(merged.components.size() == 3U);
+    CHECK(merged.components.back().documentHash == "baseline-anchor");
+    CHECK(merged.components.back().source == ComponentResult::Source::GraphVector);
+    CHECK(merged.components.back().score == Catch::Approx(0.5F));
+}
+
 TEST_CASE("Graph-neighbor trace separates stored relation from the selected cap",
           "[unit][search][topology][graph_neighbors][trace]") {
     TopologySearchFixture fix;

--- a/tests/unit/search/search_engine_topology_catch2_test.cpp
+++ b/tests/unit/search/search_engine_topology_catch2_test.cpp
@@ -2094,7 +2094,7 @@ TEST_CASE("rankGraphNeighborCandidates can weight support by query seed evidence
 
 TEST_CASE("SearchEngine topology merge keeps graph-vector candidates behind baseline anchors",
           "[search][topology][graph-vector][characterization][catch2]") {
-    using detail::AuxiliaryVectorCandidateBatch;
+    using yams::search::detail::AuxiliaryVectorCandidateBatch;
 
     SearchEngineConfig config;
     config.vectorMaxResults = 2;
@@ -2117,8 +2117,8 @@ TEST_CASE("SearchEngine topology merge keeps graph-vector candidates behind base
                         {.documentHash = "unanchored", .score = 1.0F}}},
     };
 
-    const auto merged = detail::mergeAuxiliaryVectorCandidates(std::move(components), {},
-                                                               std::move(graphTerms), config);
+    const auto merged = yams::search::detail::mergeAuxiliaryVectorCandidates(
+        std::move(components), {}, std::move(graphTerms), config);
 
     CHECK(merged.stats.graphVectorRawHitCount == 3U);
     CHECK(merged.stats.graphVectorAddedNewCount == 1U);

--- a/tests/unit/search/search_vector_pipeline_catch2_test.cpp
+++ b/tests/unit/search/search_vector_pipeline_catch2_test.cpp
@@ -234,7 +234,7 @@ TEST_CASE("Vector pipeline merges auxiliary candidates with stable policy counte
     };
     std::vector<AuxiliaryVectorCandidateBatch> phrases{
         {.query = "first",
-         .candidates = {{.documentHash = "phrase-new", .score = 1.0F},
+         .candidates = {{.documentHash = "phrase-new", .score = 1.2F},
                         {.documentHash = "base-b", .score = 1.4F}}},
         {.query = "second",
          .candidates = {{.documentHash = "base-b", .score = 1.6F},
@@ -280,7 +280,7 @@ TEST_CASE("Vector pipeline merges auxiliary candidates with stable policy counte
     CHECK(baseB.score == Catch::Approx(0.8F));
     CHECK(baseB.debugInfo.at("multi_vector_phrase") == "second");
     CHECK(vectorsBegin[2].documentHash == "phrase-new");
-    CHECK(vectorsBegin[2].score == Catch::Approx(0.5F));
+    CHECK(vectorsBegin[2].score == Catch::Approx(0.6F));
     CHECK(vectorsBegin[2].rank == 2U);
     CHECK(vectorsBegin[3].documentHash == "anchor");
     CHECK(vectorsBegin[3].source == ComponentResult::Source::GraphVector);

--- a/tests/unit/search/search_vector_pipeline_catch2_test.cpp
+++ b/tests/unit/search/search_vector_pipeline_catch2_test.cpp
@@ -270,13 +270,15 @@ TEST_CASE("Vector pipeline merges auxiliary candidates with stable policy counte
     CHECK(merged.components[0].source == ComponentResult::Source::Text);
     const auto vectorsBegin = merged.components.begin() + 1;
     REQUIRE(std::distance(vectorsBegin, merged.components.end()) == 4);
-    CHECK(vectorsBegin[0].documentHash == "base-a");
-    CHECK(vectorsBegin[0].score == Catch::Approx(0.8F));
-    CHECK(vectorsBegin[0].rank == 0U);
-    CHECK(vectorsBegin[1].documentHash == "base-b");
-    CHECK(vectorsBegin[1].score == Catch::Approx(0.8F));
-    CHECK(vectorsBegin[1].rank == 1U);
-    CHECK(vectorsBegin[1].debugInfo.at("multi_vector_phrase") == "second");
+    CHECK(((vectorsBegin[0].documentHash == "base-a" && vectorsBegin[1].documentHash == "base-b") ||
+           (vectorsBegin[0].documentHash == "base-b" && vectorsBegin[1].documentHash == "base-a")));
+    const auto& baseA =
+        vectorsBegin[vectorsBegin[0].documentHash == "base-a" ? std::size_t{0} : std::size_t{1}];
+    const auto& baseB =
+        vectorsBegin[vectorsBegin[0].documentHash == "base-b" ? std::size_t{0} : std::size_t{1}];
+    CHECK(baseA.score == Catch::Approx(0.8F));
+    CHECK(baseB.score == Catch::Approx(0.8F));
+    CHECK(baseB.debugInfo.at("multi_vector_phrase") == "second");
     CHECK(vectorsBegin[2].documentHash == "phrase-new");
     CHECK(vectorsBegin[2].score == Catch::Approx(0.5F));
     CHECK(vectorsBegin[2].rank == 2U);
@@ -287,7 +289,7 @@ TEST_CASE("Vector pipeline merges auxiliary candidates with stable policy counte
     CHECK(vectorsBegin[3].debugInfo.at("graph_vector_term") == "allowed");
 }
 
-TEST_CASE("Vector pipeline applies graph gates independently and orders equal scores by hash",
+TEST_CASE("Vector pipeline applies graph gates independently without defining equal-score order",
           "[search][vector][auxiliary][graph-gates][catch2]") {
     using yams::search::ComponentResult;
     using yams::search::detail::AuxiliaryVectorCandidateBatch;
@@ -320,7 +322,7 @@ TEST_CASE("Vector pipeline applies graph gates independently and orders equal sc
     CHECK(merged.stats.graphVectorBlockedMissingBaselineTextAnchorCount == 1U);
     CHECK(merged.stats.graphVectorAddedNewCount == 1U);
     REQUIRE(merged.components.size() == 5U);
-    CHECK(merged.components[2].documentHash == "a");
-    CHECK(merged.components[3].documentHash == "z");
+    CHECK(((merged.components[2].documentHash == "a" && merged.components[3].documentHash == "z") ||
+           (merged.components[2].documentHash == "z" && merged.components[3].documentHash == "a")));
     CHECK(merged.components[4].documentHash == "baseline");
 }

--- a/tests/unit/search/search_vector_pipeline_catch2_test.cpp
+++ b/tests/unit/search/search_vector_pipeline_catch2_test.cpp
@@ -212,3 +212,115 @@ TEST_CASE("Vector pipeline candidate rescue enriches an existing lexical candida
     CHECK(merged.results[1].debugInfo.at("candidate_rescue") == "1");
     CHECK(merged.results[1].debugInfo.at("candidate_rescue_kind") == "evidence");
 }
+
+TEST_CASE("Vector pipeline merges auxiliary candidates with stable policy counters",
+          "[search][vector][auxiliary][catch2]") {
+    using yams::search::ComponentResult;
+    using yams::search::detail::AuxiliaryVectorCandidateBatch;
+
+    SearchEngineConfig config;
+    config.vectorMaxResults = 3;
+    config.multiVectorScoreDecay = 0.5F;
+    config.graphExpansionVectorPenalty = 0.5F;
+    config.graphVectorRequireCorroboration = true;
+    config.graphVectorRequireTextAnchoring = true;
+    config.graphVectorRequireBaselineTextAnchoring = true;
+
+    std::vector<ComponentResult> components{
+        {.documentHash = "anchor", .score = 0.7F, .source = ComponentResult::Source::Text},
+        {.documentHash = "base-b", .score = 0.6F, .source = ComponentResult::Source::Vector},
+        {.documentHash = "base-a", .score = 0.6F, .source = ComponentResult::Source::Vector},
+        {.documentHash = "base-a", .score = 0.8F, .source = ComponentResult::Source::EntityVector},
+    };
+    std::vector<AuxiliaryVectorCandidateBatch> phrases{
+        {.query = "first",
+         .candidates = {{.documentHash = "phrase-new", .score = 1.0F},
+                        {.documentHash = "base-b", .score = 1.4F}}},
+        {.query = "second",
+         .candidates = {{.documentHash = "base-b", .score = 1.6F},
+                        {.documentHash = "tie-z", .score = 1.0F},
+                        {.documentHash = "tie-a", .score = 1.0F}}},
+    };
+    std::vector<AuxiliaryVectorCandidateBatch> graphTerms{
+        {.query = "blocked",
+         .weight = 1.0F,
+         .candidates = {{.documentHash = "uncorroborated", .score = 1.0F}}},
+        {.query = "allowed",
+         .weight = 0.8F,
+         .candidates = {{.documentHash = "anchor", .score = 1.0F},
+                        {.documentHash = "anchor", .score = 1.2F}}},
+    };
+
+    auto merged = yams::search::detail::mergeAuxiliaryVectorCandidates(
+        std::move(components), std::move(phrases), std::move(graphTerms), config);
+
+    CHECK(merged.stats.baseVectorCount == 3U);
+    CHECK(merged.stats.multiVectorRawHitCount == 5U);
+    CHECK(merged.stats.multiVectorAddedNewCount == 3U);
+    CHECK(merged.stats.multiVectorReplacedBaseCount == 2U);
+    CHECK(merged.stats.multiVectorMergedCount == 5U);
+    CHECK(merged.stats.graphVectorRawHitCount == 3U);
+    CHECK(merged.stats.graphVectorAddedNewCount == 1U);
+    CHECK(merged.stats.graphVectorReplacedBaseCount == 1U);
+    CHECK(merged.stats.graphVectorBlockedUncorroboratedCount == 1U);
+    CHECK(merged.stats.graphVectorBlockedMissingTextAnchorCount == 0U);
+    CHECK(merged.stats.graphVectorBlockedMissingBaselineTextAnchorCount == 0U);
+
+    REQUIRE(merged.components.size() == 5U);
+    CHECK(merged.components[0].source == ComponentResult::Source::Text);
+    const auto vectorsBegin = merged.components.begin() + 1;
+    REQUIRE(std::distance(vectorsBegin, merged.components.end()) == 4);
+    CHECK(vectorsBegin[0].documentHash == "base-a");
+    CHECK(vectorsBegin[0].score == Catch::Approx(0.8F));
+    CHECK(vectorsBegin[0].rank == 0U);
+    CHECK(vectorsBegin[1].documentHash == "base-b");
+    CHECK(vectorsBegin[1].score == Catch::Approx(0.8F));
+    CHECK(vectorsBegin[1].rank == 1U);
+    CHECK(vectorsBegin[1].debugInfo.at("multi_vector_phrase") == "second");
+    CHECK(vectorsBegin[2].documentHash == "phrase-new");
+    CHECK(vectorsBegin[2].score == Catch::Approx(0.5F));
+    CHECK(vectorsBegin[2].rank == 2U);
+    CHECK(vectorsBegin[3].documentHash == "anchor");
+    CHECK(vectorsBegin[3].source == ComponentResult::Source::GraphVector);
+    CHECK(vectorsBegin[3].score == Catch::Approx(0.48F));
+    CHECK(vectorsBegin[3].rank == 0U);
+    CHECK(vectorsBegin[3].debugInfo.at("graph_vector_term") == "allowed");
+}
+
+TEST_CASE("Vector pipeline applies graph gates independently and orders equal scores by hash",
+          "[search][vector][auxiliary][graph-gates][catch2]") {
+    using yams::search::ComponentResult;
+    using yams::search::detail::AuxiliaryVectorCandidateBatch;
+
+    SearchEngineConfig config;
+    config.vectorMaxResults = 4;
+    config.graphExpansionVectorPenalty = 1.0F;
+    config.graphVectorRequireCorroboration = false;
+    config.graphVectorRequireTextAnchoring = true;
+    config.graphVectorRequireBaselineTextAnchoring = true;
+
+    std::vector<ComponentResult> components{
+        {.documentHash = "graph-only", .score = 0.9F, .source = ComponentResult::Source::GraphText},
+        {.documentHash = "baseline", .score = 0.8F, .source = ComponentResult::Source::Text},
+        {.documentHash = "z", .score = 0.4F, .source = ComponentResult::Source::Vector},
+        {.documentHash = "a", .score = 0.4F, .source = ComponentResult::Source::Vector},
+    };
+    std::vector<AuxiliaryVectorCandidateBatch> graphTerms{
+        {.query = "term",
+         .weight = 1.0F,
+         .candidates = {{.documentHash = "missing-text", .score = 0.8F},
+                        {.documentHash = "graph-only", .score = 0.8F},
+                        {.documentHash = "baseline", .score = 0.8F}}},
+    };
+
+    auto merged = yams::search::detail::mergeAuxiliaryVectorCandidates(
+        std::move(components), {}, std::move(graphTerms), config);
+
+    CHECK(merged.stats.graphVectorBlockedMissingTextAnchorCount == 1U);
+    CHECK(merged.stats.graphVectorBlockedMissingBaselineTextAnchorCount == 1U);
+    CHECK(merged.stats.graphVectorAddedNewCount == 1U);
+    REQUIRE(merged.components.size() == 5U);
+    CHECK(merged.components[2].documentHash == "a");
+    CHECK(merged.components[3].documentHash == "z");
+    CHECK(merged.components[4].documentHash == "baseline");
+}


### PR DESCRIPTION
> **Stack:** depends on #85; followed by #87 → #88.

## Summary

- extract auxiliary vector candidate classification, deduplication, graph gates, score adjustment, caps, ranks, and counters into the existing vector-pipeline seam
- leave embedding generation, vector queries, exceptions, timing, tracing, logging, and I/O in `SearchEngine`
- preserve the original score-only tie behavior; characterization tests intentionally do not prescribe equal-score order

## Validation

- Debug ThreadSanitizer build: `catch2_search_submodule`
- `search_submodule`: **passed** (64.60s)
- `portability_policy` and `portability_policy_unit`: **passed**
- format, portability (574 reviewed occurrences, 0 new), license, Windows-header, OpenGrep, DCO, and diff checks passed

## Architecture evidence

Brick 0.1.0 schema-v4 comparison used one canonical root and identical production-only exclusions.

- `search_engine.cpp` Brick LOC: **5,252 → 5,128**
- extracted policy resides in the existing `search_vector_pipeline.cpp` seam (**424 → 580** LOC)
- stable-ID diff: **+6 / -0 / ~17 nodes**, **+10 / -0 / ~234 edges**
- added records are the auxiliary candidate batch/stats/result types and merge helper
- all changed nodes are line/LOC changes; all changed edges are evidence-location changes
- cycle count remains 8, all pre-existing single-function self-loops

The engine file's lexical fan-out is essentially unchanged, so this PR claims responsibility extraction—not a proven coupling reduction. Brick is lexical evidence; focused tests are the behavior signal.
