### PR TITLE
ci: mirror approved refs to Forgejo

### DIFF
--- a/.github/workflows/mirror-forgejo.yml
+++ b/.github/workflows/mirror-forgejo.yml
@@ -1,0 +1,123 @@
+name: Mirror source to Forgejo
+
+on:
+  push:
+    branches:
+      - main
+      - experimental
+    tags:
+      - "v[0-9]*"
+      - "yams-v[0-9]*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Approved branch or release tag to reconcile
+        required: true
+        default: experimental
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: forgejo-source-mirror
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    if: github.repository == 'trvon/yams'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out canonical repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve approved source ref
+        id: source
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          REQUESTED_REF: ${{ inputs.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            case "${REQUESTED_REF}" in
+              main|experimental)
+                source_ref="refs/heads/${REQUESTED_REF}"
+                ;;
+              v[0-9]*|yams-v[0-9]*)
+                source_ref="refs/tags/${REQUESTED_REF}"
+                ;;
+              *)
+                echo "Ref is outside the approved mirror allowlist: ${REQUESTED_REF}" >&2
+                exit 1
+                ;;
+            esac
+          else
+            source_ref="${EVENT_REF}"
+          fi
+
+          case "${source_ref}" in
+            refs/heads/main|refs/heads/experimental|refs/tags/v[0-9]*|refs/tags/yams-v[0-9]*) ;;
+            *)
+              echo "Resolved ref is outside the approved mirror allowlist: ${source_ref}" >&2
+              exit 1
+              ;;
+          esac
+
+          git fetch --no-tags origin "${source_ref}:refs/mirror/source"
+          expected_sha="$(git rev-parse refs/mirror/source)"
+          printf 'source_ref=%s\n' "${source_ref}" >>"${GITHUB_OUTPUT}"
+          printf 'expected_sha=%s\n' "${expected_sha}" >>"${GITHUB_OUTPUT}"
+
+      - name: Configure restricted Forgejo SSH identity
+        env:
+          MIRROR_SSH_KEY: ${{ secrets.FORGEJO_MIRROR_SSH_KEY }}
+          MIRROR_KNOWN_HOSTS: ${{ secrets.FORGEJO_MIRROR_KNOWN_HOSTS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          set +x
+          test -n "${MIRROR_SSH_KEY}"
+          test -n "${MIRROR_KNOWN_HOSTS}"
+          umask 077
+          mkdir -p "${HOME}/.ssh"
+          printf '%s\n' "${MIRROR_SSH_KEY}" >"${HOME}/.ssh/forgejo_mirror"
+          printf '%s\n' "${MIRROR_KNOWN_HOSTS}" >"${HOME}/.ssh/known_hosts"
+          git config core.sshCommand \
+            "ssh -i ${HOME}/.ssh/forgejo_mirror -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
+          git remote add forgejo ssh://git@git.trevon.dev:2222/trevon/yams.git
+
+      - name: Push one explicit ref
+        env:
+          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git push forgejo "refs/mirror/source:${SOURCE_REF}"
+
+      - name: Verify mirrored SHA
+        env:
+          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
+          EXPECTED_SHA: ${{ steps.source.outputs.expected_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual_sha="$(git ls-remote --exit-code forgejo "${SOURCE_REF}" | awk 'NR == 1 { print $1 }')"
+          if [[ "${actual_sha}" != "${EXPECTED_SHA}" ]]; then
+            echo "Forgejo verification failed for ${SOURCE_REF}" >&2
+            echo "expected=${EXPECTED_SHA}" >&2
+            echo "actual=${actual_sha}" >&2
+            exit 1
+          fi
+          echo "Verified ${SOURCE_REF} at ${EXPECTED_SHA}"
+
+      - name: Remove temporary key
+        if: always()
+        shell: bash
+        run: rm -f "${HOME}/.ssh/forgejo_mirror"

--- a/docs/source-mirroring.md
+++ b/docs/source-mirroring.md
@@ -1,0 +1,61 @@
+# Source mirroring
+
+GitHub (`github.com/trvon/yams`) is the canonical YAMS source repository. The
+Forgejo repository at `git.trevon.dev/trevon/yams` is a one-way availability
+mirror; it is not a second source of truth.
+
+## Mirrored refs
+
+The `Mirror source to Forgejo` GitHub workflow mirrors only:
+
+- `refs/heads/main`
+- `refs/heads/experimental`
+- release tags beginning with `v` or `yams-v`
+
+Each run fetches one approved GitHub ref into a temporary local ref, pushes one
+explicit source-to-destination refspec, and compares the Forgejo ref SHA with
+the fetched GitHub SHA. Runs are serialized. The workflow does not prune,
+force-update, or mirror every ref.
+
+A manual dispatch accepts only `main`, `experimental`, or an approved release
+tag. Use it to reconcile an allowed ref after a transient outage.
+
+## Required secrets
+
+Configure these GitHub Actions secrets in the canonical repository:
+
+- `FORGEJO_MIRROR_SSH_KEY`: private half of a dedicated Forgejo deploy key with
+  write access only to `trevon/yams`.
+- `FORGEJO_MIRROR_KNOWN_HOSTS`: a pinned `known_hosts` entry for
+  `[git.trevon.dev]:2222`.
+
+Verify the Forgejo SSH host-key fingerprint out of band before storing the
+`known_hosts` entry. Do not generate trust dynamically inside the workflow.
+The deploy key must not be reused for package publication, administration, or
+another repository.
+
+## Initial reconciliation
+
+1. Compare the approved GitHub and Forgejo branch SHAs.
+2. Confirm the Forgejo branch is an ancestor of, or equal to, the canonical
+   GitHub branch.
+3. Install the two secrets above.
+4. Dispatch one allowed branch at a time, starting with `main`.
+5. Confirm the workflow's post-push SHA verification succeeds.
+6. Reconcile approved release tags only after both branches are verified.
+
+The workflow must be present on GitHub's default branch before relying on its
+push and manual-dispatch triggers.
+
+## Failure recovery
+
+A rejected non-fast-forward update indicates drift; it is not permission to
+force-push. Stop automation and preserve both SHAs. Determine whether Forgejo
+contains unique commits, then restore it through an explicitly reviewed
+operator action. Never add automatic pruning or a repository-wide mirror push
+to recover from drift.
+
+If SSH authentication or host verification fails, rotate or correct the
+repository-scoped deploy key or pinned host entry, then manually dispatch the
+same approved ref. If the push succeeds but SHA verification fails, treat the
+run as failed and inspect the exact destination ref before retrying.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,8 @@ nav:
   - Benchmarks: benchmarks/index.md
   - Roadmap: roadmap.md
   - Newsletter: newsletter.md
+  - Operations:
+      - Source mirroring: source-mirroring.md
 
 theme:
   name: material

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -46,6 +46,13 @@ portability_policy_script = files('scripts/check_portability.py')
 portability_policy_tests = files('scripts/test_check_portability.py')
 portability_allowlist = files('scripts/portability_allowlist.txt')
 repository_metadata_policy_script = files('scripts/check_repository_metadata.py')
+forgejo_mirror_policy_script = files('scripts/check_forgejo_mirror_workflow.py')
+test('forgejo_mirror_policy',
+  python_exe,
+  args: [forgejo_mirror_policy_script, '--root', meson.project_source_root()],
+  suite: ['unit', 'policy', 'repository'],
+  timeout: 30,
+)
 test('repository_metadata_policy',
   python_exe,
   args: [repository_metadata_policy_script, '--root', meson.project_source_root()],

--- a/tests/scripts/check_forgejo_mirror_workflow.py
+++ b/tests/scripts/check_forgejo_mirror_workflow.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Static safety policy for the GitHub-to-Forgejo mirror workflow."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+REQUIRED = (
+    "contents: read",
+    "group: forgejo-source-mirror",
+    "cancel-in-progress: false",
+    "refs/heads/main",
+    "refs/heads/experimental",
+    "refs/tags/v[0-9]*",
+    "refs/tags/yams-v[0-9]*",
+    "FORGEJO_MIRROR_SSH_KEY",
+    "FORGEJO_MIRROR_KNOWN_HOSTS",
+    "StrictHostKeyChecking=yes",
+    'git push forgejo "refs/mirror/source:${SOURCE_REF}"',
+    'git ls-remote --exit-code forgejo "${SOURCE_REF}"',
+    '"${actual_sha}" != "${EXPECTED_SHA}"',
+)
+
+FORBIDDEN = (
+    "-" + "-mirror",
+    "-" + "-prune",
+    "-" + "-force",
+    "git push " + "-f ",
+    "git push " + "--delete",
+    "ssh-keyscan",
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+    workflow = args.root.resolve() / ".github/workflows/mirror-forgejo.yml"
+
+    if not workflow.is_file():
+        print(f"missing workflow: {workflow}")
+        return 1
+
+    text = workflow.read_text(encoding="utf-8")
+    failures = [
+        f"missing required control: {value}" for value in REQUIRED if value not in text
+    ]
+    failures.extend(
+        f"forbidden mirror operation: {value}" for value in FORBIDDEN if value in text
+    )
+
+    if text.count("git push forgejo") != 1:
+        failures.append("workflow must contain exactly one explicit Forgejo push")
+    if "pull_request:" in text:
+        failures.append("mirror workflow must not receive credentials on pull requests")
+
+    if failures:
+        print("\n".join(failures))
+        return 1
+
+    print("Forgejo mirror workflow policy: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a serialized GitHub Actions workflow that mirrors only `main`, `experimental`, and approved release tags to Forgejo
- use a dedicated repository-scoped SSH key and an out-of-band pinned host key
- push one explicit refspec without force, prune, deletion, or repository-wide mirror behavior
- verify the exact destination SHA after every push
- add recovery/initial-reconciliation documentation and a registered static safety policy

GitHub remains canonical. Forgejo is a one-way availability mirror.

## Stack

- depends on #91, which replaces the retired SourceHut metadata
- review only the five-file diff against `docs/forgejo-primary-mirror`

No credentials were used during local validation and no Forgejo refs were changed.

## Deployment prerequisites

Before dispatching this workflow, configure `FORGEJO_MIRROR_SSH_KEY` and `FORGEJO_MIRROR_KNOWN_HOSTS` as described in `docs/source-mirroring.md`. Initial reconciliation remains an explicit operator action.
