### PR TITLE
ci: trust experimental release artifacts

### DIFF
--- a/.github/workflows/matrix-warm.yml
+++ b/.github/workflows/matrix-warm.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: boolean
         default: false
+      checkout_ref:
+        description: Immutable source SHA to warm
+        required: false
+        type: string
+        default: ""
 
 jobs:
   warm:
@@ -81,10 +86,11 @@ jobs:
       YAMS_MSBUILD_VS_VERSION: ${{ matrix.msbuild_vs_version || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
           submodules: false # Manual submodule init below (some use SSH URLs)
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Initialize required submodules
         shell: bash

--- a/.github/workflows/mirror-forgejo.yml
+++ b/.github/workflows/mirror-forgejo.yml
@@ -1,0 +1,123 @@
+name: Mirror source to Forgejo
+
+on:
+  push:
+    branches:
+      - main
+      - experimental
+    tags:
+      - "v[0-9]*"
+      - "yams-v[0-9]*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Approved branch or release tag to reconcile
+        required: true
+        default: experimental
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: forgejo-source-mirror
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    if: github.repository == 'trvon/yams'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out canonical repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve approved source ref
+        id: source
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          REQUESTED_REF: ${{ inputs.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            case "${REQUESTED_REF}" in
+              main|experimental)
+                source_ref="refs/heads/${REQUESTED_REF}"
+                ;;
+              v[0-9]*|yams-v[0-9]*)
+                source_ref="refs/tags/${REQUESTED_REF}"
+                ;;
+              *)
+                echo "Ref is outside the approved mirror allowlist: ${REQUESTED_REF}" >&2
+                exit 1
+                ;;
+            esac
+          else
+            source_ref="${EVENT_REF}"
+          fi
+
+          case "${source_ref}" in
+            refs/heads/main|refs/heads/experimental|refs/tags/v[0-9]*|refs/tags/yams-v[0-9]*) ;;
+            *)
+              echo "Resolved ref is outside the approved mirror allowlist: ${source_ref}" >&2
+              exit 1
+              ;;
+          esac
+
+          git fetch --no-tags origin "${source_ref}:refs/mirror/source"
+          expected_sha="$(git rev-parse refs/mirror/source)"
+          printf 'source_ref=%s\n' "${source_ref}" >>"${GITHUB_OUTPUT}"
+          printf 'expected_sha=%s\n' "${expected_sha}" >>"${GITHUB_OUTPUT}"
+
+      - name: Configure restricted Forgejo SSH identity
+        env:
+          MIRROR_SSH_KEY: ${{ secrets.FORGEJO_MIRROR_SSH_KEY }}
+          MIRROR_KNOWN_HOSTS: ${{ secrets.FORGEJO_MIRROR_KNOWN_HOSTS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          set +x
+          test -n "${MIRROR_SSH_KEY}"
+          test -n "${MIRROR_KNOWN_HOSTS}"
+          umask 077
+          mkdir -p "${HOME}/.ssh"
+          printf '%s\n' "${MIRROR_SSH_KEY}" >"${HOME}/.ssh/forgejo_mirror"
+          printf '%s\n' "${MIRROR_KNOWN_HOSTS}" >"${HOME}/.ssh/known_hosts"
+          git config core.sshCommand \
+            "ssh -i ${HOME}/.ssh/forgejo_mirror -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
+          git remote add forgejo ssh://git@git.trevon.dev:2222/trevon/yams.git
+
+      - name: Push one explicit ref
+        env:
+          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git push forgejo "refs/mirror/source:${SOURCE_REF}"
+
+      - name: Verify mirrored SHA
+        env:
+          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
+          EXPECTED_SHA: ${{ steps.source.outputs.expected_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual_sha="$(git ls-remote --exit-code forgejo "${SOURCE_REF}" | awk 'NR == 1 { print $1 }')"
+          if [[ "${actual_sha}" != "${EXPECTED_SHA}" ]]; then
+            echo "Forgejo verification failed for ${SOURCE_REF}" >&2
+            echo "expected=${EXPECTED_SHA}" >&2
+            echo "actual=${actual_sha}" >&2
+            exit 1
+          fi
+          echo "Verified ${SOURCE_REF} at ${EXPECTED_SHA}"
+
+      - name: Remove temporary key
+        if: always()
+        shell: bash
+        run: rm -f "${HOME}/.ssh/forgejo_mirror"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,109 @@ permissions:
   contents: write
 
 jobs:
+  resolve-release:
+    name: Resolve immutable release source
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.source.outputs.source_sha }}
+      source_ref: ${{ steps.source.outputs.source_ref }}
+      channel: ${{ steps.meta.outputs.channel }}
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+      release_name: ${{ steps.meta.outputs.release_name }}
+      base_version: ${{ steps.meta.outputs.base_version }}
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+    steps:
+      - name: Resolve canonical source once
+        id: source
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          REQUESTED_CHANNEL: ${{ inputs.channel || 'nightly' }}
+        with:
+          script: |
+            const requestedChannel = process.env.REQUESTED_CHANNEL;
+            let channel = 'stable';
+            if (context.eventName === 'schedule') {
+              channel = 'nightly';
+            } else if (context.eventName === 'workflow_dispatch') {
+              channel = ['stable', 'weekly', 'nightly'].includes(requestedChannel)
+                ? requestedChannel
+                : 'nightly';
+            }
+            core.setOutput('channel', channel);
+
+            if (channel !== 'stable') {
+              const ref = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'heads/experimental',
+              });
+              core.setOutput('source_sha', ref.data.object.sha);
+              core.setOutput('source_ref', 'refs/heads/experimental');
+            } else {
+              core.setOutput('source_sha', context.sha);
+              core.setOutput('source_ref', context.ref);
+            }
+
+      - name: Checkout immutable source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          submodules: false
+          ref: ${{ steps.source.outputs.source_sha }}
+
+      - name: Resolve release metadata once
+        id: meta
+        env:
+          RESOLVED_CHANNEL: ${{ steps.source.outputs.channel }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SHORT_HASH=$(git rev-parse --short HEAD)
+          channel="$RESOLVED_CHANNEL"
+
+          if [ "$channel" = "stable" ]; then
+            TAG="${GITHUB_REF_NAME}"
+            VERSION="${TAG#yams-v}"
+            if [ "$VERSION" = "$TAG" ]; then
+              VERSION="${TAG#v}"
+            fi
+            TAG_OUT="$TAG"
+            RELEASE_NAME="YAMS ${VERSION}"
+          elif [ "$channel" = "nightly" ]; then
+            DATE_ISO=$(date -u +%Y-%m-%d)
+            DATE_COMPACT=$(date -u +%Y%m%d)
+            VERSION="nightly-${DATE_COMPACT}-${SHORT_HASH}"
+            TAG_OUT="nightly-${DATE_COMPACT}-${SHORT_HASH}"
+            RELEASE_NAME="YAMS Nightly ${DATE_ISO} (${SHORT_HASH})"
+          else
+            YEAR=$(date -u +%G)
+            WEEK=$(date -u +%V)
+            VERSION="weekly-${YEAR}w${WEEK}-${SHORT_HASH}"
+            TAG_OUT="$VERSION"
+            RELEASE_NAME="YAMS Weekly ${YEAR}-w${WEEK} (${SHORT_HASH})"
+          fi
+
+          BASE_NUMERIC_VERSION="$(git describe --tags --abbrev=0 --match='v*' 2>/dev/null || echo 0.0.0)"
+          BASE_NUMERIC_VERSION="${BASE_NUMERIC_VERSION#v}"
+
+          {
+            echo "channel=$channel"
+            echo "version=$VERSION"
+            echo "tag=$TAG_OUT"
+            echo "release_name=$RELEASE_NAME"
+            echo "base_version=$BASE_NUMERIC_VERSION"
+            if [ "$channel" = "stable" ]; then
+              echo "prerelease=false"
+            else
+              echo "prerelease=true"
+            fi
+          } >> "$GITHUB_OUTPUT"
+
   check-commits:
     name: Check for new commits (nightly only)
+    needs: resolve-release
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' && github.actor != 'nektos/act'
     outputs:
@@ -72,32 +173,32 @@ jobs:
             }
             core.setOutput('last_release_sha', lastSha);
 
-            const headRef = await github.rest.git.getRef({
-              owner,
-              repo,
-              ref: 'heads/main',
-            });
-            const currentSha = headRef.data.object.sha;
+            const currentSha = '${{ needs.resolve-release.outputs.source_sha }}';
 
             if (lastSha !== currentSha) {
-              const compare = await github.rest.repos.compareCommits({
-                owner,
-                repo,
-                base: lastSha,
-                head: currentSha,
-              });
-              const total = compare.data.total_commits ?? 1;
               core.setOutput('has_new_commits', 'true');
-              core.info(`Found ${total} new commit(s) since last nightly (${tagName})`);
+              try {
+                const compare = await github.rest.repos.compareCommits({
+                  owner,
+                  repo,
+                  base: lastSha,
+                  head: currentSha,
+                });
+                const total = compare.data.total_commits ?? 1;
+                core.info(`Found ${total} new commit(s) since last nightly (${tagName})`);
+              } catch (error) {
+                core.info(`Release SHAs differ; comparison was unavailable: ${error.message}`);
+              }
             } else {
               core.setOutput('has_new_commits', 'false');
               core.info(`No new commits since last nightly release (${tagName}), skipping`);
             }
 
   warm:
-    needs: [check-commits]
+    needs: [resolve-release, check-commits]
     if: |
       always() &&
+      needs.resolve-release.result == 'success' &&
       github.actor != 'nektos/act' &&
       (needs.check-commits.result == 'skipped' || 
        needs.check-commits.outputs.has_new_commits == 'true' ||
@@ -107,12 +208,14 @@ jobs:
     with:
       build_type: Release
       enable_onnx: false
+      checkout_ref: ${{ needs.resolve-release.outputs.source_sha }}
 
   build-release:
     name: Build and Package (matrix)
-    needs: warm
+    needs: [resolve-release, warm]
     if: |
       always() &&
+      needs.resolve-release.result == 'success' &&
       (needs.warm.result == 'success' || needs.warm.result == 'skipped')
     strategy:
       fail-fast: false
@@ -167,10 +270,11 @@ jobs:
       STAGE_DIR: stage
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           submodules: false # Manual submodule init below (some use SSH URLs)
+          ref: ${{ needs.resolve-release.outputs.source_sha }}
       - name: Initialize required submodules
         shell: bash
         run: |
@@ -221,53 +325,12 @@ jobs:
           build_dir="build/pkg/arch-${arch_name}"
           meson_build_dir="${build_dir}/meson-${arch_name}"
 
-          event="${{ github.event_name }}"
-          input_channel="${{ inputs.channel || '' }}"
-          short_hash="$(git rev-parse --short HEAD)"
-
-          if [ "$event" = "push" ]; then
-            channel="stable"
-            version="${GITHUB_REF_NAME#yams-v}"
-            if [ "$version" = "$GITHUB_REF_NAME" ]; then
-              version="${GITHUB_REF_NAME#v}"
-            fi
-            git_ref_value="${{ github.ref }}"
-          elif [ "$event" = "workflow_dispatch" ] && [ -n "$input_channel" ]; then
-            case "$input_channel" in
-              stable)
-                channel="stable"
-                version="${GITHUB_REF_NAME#yams-v}"
-                if [ "$version" = "$GITHUB_REF_NAME" ]; then
-                  version="${GITHUB_REF_NAME#v}"
-                fi
-                git_ref_value="${{ github.ref }}"
-                ;;
-              weekly)
-                channel="weekly"
-                year="$(date -u +%G)"
-                week="$(date -u +%V)"
-                version="weekly-${year}w${week}-${short_hash}"
-                git_ref_value="refs/tags/v${version}"
-                ;;
-              *)
-                channel="nightly"
-                date_compact="$(date -u +%Y%m%d)"
-                version="nightly-${date_compact}-${short_hash}"
-                git_ref_value="refs/tags/v${version}"
-                ;;
-            esac
-          elif [ "$event" = "schedule" ]; then
-            channel="nightly"
-            date_compact="$(date -u +%Y%m%d)"
-            version="nightly-${date_compact}-${short_hash}"
-            git_ref_value="refs/tags/v${version}"
+          channel="${{ needs.resolve-release.outputs.channel }}"
+          version="${{ needs.resolve-release.outputs.version }}"
+          if [ "$channel" = "stable" ]; then
+            git_ref_value="${{ needs.resolve-release.outputs.source_ref }}"
           else
-            channel="stable"
-            version="${GITHUB_REF_NAME#yams-v}"
-            if [ "$version" = "$GITHUB_REF_NAME" ]; then
-              version="${GITHUB_REF_NAME#v}"
-            fi
-            git_ref_value="${{ github.ref }}"
+            git_ref_value="refs/tags/v${version}"
           fi
 
           echo "Arch release channel=${channel} version=${version} build_dir=${build_dir} meson_build_dir=${meson_build_dir}"
@@ -441,71 +504,19 @@ jobs:
           done
           echo "Stdlib flags sanitized for macOS (forcing -stdlib=libc++)."
 
-      - name: Determine release channel and version/tag
+      - name: Load resolved release metadata
         if: matrix.arch_container != true
         id: meta
         shell: bash
         run: |
-          set -euo pipefail
-
-          EVENT="${{ github.event_name }}"
-          INPUT_CHANNEL="${{ inputs.channel || '' }}"
-          SHORT_HASH=$(git rev-parse --short HEAD)
-
-          channel=""
-          if [ "$EVENT" = "push" ]; then
-            channel="stable"
-          elif [ "$EVENT" = "workflow_dispatch" ] && [ -n "$INPUT_CHANNEL" ]; then
-            case "$INPUT_CHANNEL" in
-              stable|weekly|nightly) channel="$INPUT_CHANNEL" ;;
-              *) channel="nightly" ;;
-            esac
-          elif [ "$EVENT" = "schedule" ]; then
-            channel="nightly"
-          else
-            channel="stable"
-          fi
-
-          # Derive version and tag
-          if [ "$channel" = "stable" ]; then
-            TAG="${GITHUB_REF_NAME}"
-            VERSION="${TAG#yams-v}"
-            if [ "$VERSION" = "$TAG" ]; then
-              VERSION="${TAG#v}"
-            fi
-            TAG_OUT="$TAG"
-            RELEASE_NAME="YAMS ${VERSION}"
-          elif [ "$channel" = "nightly" ]; then
-            DATE_ISO=$(date -u +%Y-%m-%d)
-            DATE_COMPACT=$(date -u +%Y%m%d)
-            VERSION="nightly-${DATE_COMPACT}-${SHORT_HASH}"
-            TAG_OUT="nightly-${DATE_COMPACT}-${SHORT_HASH}"
-            RELEASE_NAME="YAMS Nightly ${DATE_ISO} (${SHORT_HASH})"
-          else # weekly
-            YEAR=$(date -u +%G)   # ISO week-numbering year
-            WEEK=$(date -u +%V)   # ISO week number 01-53
-            VERSION="weekly-${YEAR}w${WEEK}-${SHORT_HASH}"
-            TAG_OUT="$VERSION"
-            RELEASE_NAME="YAMS Weekly ${YEAR}-w${WEEK} (${SHORT_HASH})"
-          fi
-
-          BASE_NUMERIC_VERSION="$(git describe --tags --abbrev=0 --match='v*' 2>/dev/null || echo 0.0.0)"
-          BASE_NUMERIC_VERSION="${BASE_NUMERIC_VERSION#v}"
-
           {
-            echo "channel=$channel"
-            echo "version=$VERSION"
-            echo "tag=$TAG_OUT"
-            echo "release_name=$RELEASE_NAME"
-            echo "base_version=$BASE_NUMERIC_VERSION"
-            if [ "$channel" = "stable" ]; then
-              echo "prerelease=false"
-            else
-              echo "prerelease=true"
-            fi
+            echo "channel=${{ needs.resolve-release.outputs.channel }}"
+            echo "version=${{ needs.resolve-release.outputs.version }}"
+            echo "tag=${{ needs.resolve-release.outputs.tag }}"
+            echo "release_name=${{ needs.resolve-release.outputs.release_name }}"
+            echo "base_version=${{ needs.resolve-release.outputs.base_version }}"
+            echo "prerelease=${{ needs.resolve-release.outputs.prerelease }}"
           } >> "$GITHUB_OUTPUT"
-
-          echo "Detected channel=$channel, version=$VERSION, tag=$TAG_OUT, name=$RELEASE_NAME"
 
       - name: Download CI benchmark artifacts (-yams, if available)
         if: github.event_name == 'workflow_run' && matrix.os == 'linux-hosted' && github.actor != 'nektos/act'
@@ -1376,11 +1387,15 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    needs: [check-commits, build-release]
+    needs: [resolve-release, check-commits, build-release]
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-publish-${{ needs.resolve-release.outputs.channel }}-${{ needs.resolve-release.outputs.source_sha }}
+      cancel-in-progress: false
     # Skip release creation when: running under act, OR check-commits skipped release
     if: |
-      always() && !cancelled() && 
+      always() && !cancelled() &&
+      needs.resolve-release.result == 'success' &&
       github.actor != 'nektos/act' &&
       (needs.check-commits.result == 'skipped' || needs.check-commits.outputs.has_new_commits == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       needs.build-release.result == 'success'
@@ -1392,83 +1407,25 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       tag: ${{ steps.meta.outputs.tag }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout immutable release source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           submodules: false
-          repository: ${{ github.event.workflow_run.head_repository.full_name || github.repository }}
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          ref: ${{ needs.resolve-release.outputs.source_sha }}
 
-      - name: Determine release channel and version/tag
+      - name: Load resolved release metadata
         id: meta
         shell: bash
         run: |
-          set -euo pipefail
-
-          EVENT="${{ github.event_name }}"
-          INPUT_CHANNEL="${{ inputs.channel || '' }}"
-          SHORT_HASH=$(git rev-parse --short HEAD)
-
-          channel=""
-          if [ "$EVENT" = "push" ]; then
-            channel="stable"
-          elif [ "$EVENT" = "workflow_dispatch" ] && [ -n "$INPUT_CHANNEL" ]; then
-            case "$INPUT_CHANNEL" in
-              stable|weekly|nightly) channel="$INPUT_CHANNEL" ;;
-              *) channel="nightly" ;;
-            esac
-          elif [ "$EVENT" = "schedule" ]; then
-            channel="nightly"
-          else
-            channel="stable"
-          fi
-
-          # Derive version and tag
-          if [ "$channel" = "stable" ]; then
-            TAG="${GITHUB_REF_NAME}"
-            VERSION="${TAG#yams-v}"
-            if [ "$VERSION" = "$TAG" ]; then
-              VERSION="${TAG#v}"
-            fi
-            TAG_OUT="$TAG"
-            RELEASE_NAME="YAMS ${VERSION}"
-          elif [ "$channel" = "nightly" ]; then
-            DATE_ISO=$(date -u +%Y-%m-%d)
-            DATE_COMPACT=$(date -u +%Y%m%d)
-            VERSION="nightly-${DATE_COMPACT}-${SHORT_HASH}"
-            TAG_OUT="nightly-${DATE_COMPACT}-${SHORT_HASH}"
-            RELEASE_NAME="YAMS Nightly ${DATE_ISO} (${SHORT_HASH})"
-          else # weekly
-            YEAR=$(date -u +%G)   # ISO week-numbering year
-            WEEK=$(date -u +%V)   # ISO week number 01-53
-            VERSION="weekly-${YEAR}w${WEEK}-${SHORT_HASH}"
-            TAG_OUT="$VERSION"
-            RELEASE_NAME="YAMS Weekly ${YEAR}-w${WEEK} (${SHORT_HASH})"
-          fi
-
-          BASE_NUMERIC_VERSION="$(git describe --tags --abbrev=0 --match='v*' 2>/dev/null || echo 0.0.0)"
-          BASE_NUMERIC_VERSION="${BASE_NUMERIC_VERSION#v}"
-
           {
-            echo "channel=$channel"
-            echo "version=$VERSION"
-            echo "tag=$TAG_OUT"
-            echo "release_name=$RELEASE_NAME"
-            echo "base_version=$BASE_NUMERIC_VERSION"
-            if [ "$channel" = "stable" ]; then
-              echo "prerelease=false"
-            else
-              echo "prerelease=true"
-            fi
+            echo "channel=${{ needs.resolve-release.outputs.channel }}"
+            echo "version=${{ needs.resolve-release.outputs.version }}"
+            echo "tag=${{ needs.resolve-release.outputs.tag }}"
+            echo "release_name=${{ needs.resolve-release.outputs.release_name }}"
+            echo "base_version=${{ needs.resolve-release.outputs.base_version }}"
+            echo "prerelease=${{ needs.resolve-release.outputs.prerelease }}"
           } >> "$GITHUB_OUTPUT"
-
-          echo "Detected channel=$channel, version=$VERSION, tag=$TAG_OUT, name=$RELEASE_NAME"
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -2457,6 +2414,7 @@ jobs:
           files: assets/*
           draft: true
           prerelease: ${{ steps.meta.outputs.prerelease }}
+          target_commitish: ${{ needs.resolve-release.outputs.source_sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,12 @@ jobs:
       release_name: ${{ steps.meta.outputs.release_name }}
       base_version: ${{ steps.meta.outputs.base_version }}
       prerelease: ${{ steps.meta.outputs.prerelease }}
+      tests_run_id: ${{ steps.tests.outputs.tests_run_id }}
+      tests_run_attempt: ${{ steps.tests.outputs.tests_run_attempt }}
+      tests_run_url: ${{ steps.tests.outputs.tests_run_url }}
+    permissions:
+      contents: read
+      actions: read
     steps:
       - name: Resolve canonical source once
         id: source
@@ -58,18 +64,74 @@ jobs:
             }
             core.setOutput('channel', channel);
 
+            let sourceSha;
+            let sourceRef;
             if (channel !== 'stable') {
               const ref = await github.rest.git.getRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'heads/experimental',
               });
-              core.setOutput('source_sha', ref.data.object.sha);
-              core.setOutput('source_ref', 'refs/heads/experimental');
+              sourceSha = ref.data.object.sha;
+              sourceRef = 'refs/heads/experimental';
             } else {
-              core.setOutput('source_sha', context.sha);
-              core.setOutput('source_ref', context.ref);
+              sourceSha = context.sha;
+              sourceRef = context.ref;
             }
+            if (!/^[0-9a-f]{40}$/.test(sourceSha)) {
+              core.setFailed(`Resolved source is not a full commit SHA: ${sourceSha}`);
+              return;
+            }
+            core.setOutput('source_sha', sourceSha);
+            core.setOutput('source_ref', sourceRef);
+
+      - name: Require successful Tests run for exact experimental source
+        id: tests
+        if: steps.source.outputs.channel != 'stable'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+        with:
+          script: |
+            const sourceSha = process.env.SOURCE_SHA;
+            if (!/^[0-9a-f]{40}$/.test(sourceSha)) {
+              core.setFailed(`Refusing Tests lookup for invalid source SHA: ${sourceSha}`);
+              return;
+            }
+
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'tests.yml',
+              head_sha: sourceSha,
+              status: 'completed',
+              per_page: 100,
+            });
+            const successful = runs
+              .filter((run) =>
+                run.name === 'Tests' &&
+                run.status === 'completed' &&
+                run.conclusion === 'success' &&
+                run.head_sha === sourceSha)
+              .sort((left, right) => right.id - left.id);
+            if (successful.length === 0) {
+              core.setFailed(
+                `No successful completed Tests workflow run has exact head_sha ${sourceSha}`,
+              );
+              return;
+            }
+
+            const run = successful[0];
+            if (!run.html_url || !run.html_url.endsWith(`/actions/runs/${run.id}`) ||
+                !Number.isInteger(run.run_attempt) || run.run_attempt < 1) {
+              core.setFailed(`Tests run ${run.id} returned incomplete immutable identity`);
+              return;
+            }
+            const attemptUrl = `${run.html_url}/attempts/${run.run_attempt}`;
+            core.info(`Using exact-sha Tests run ${run.id} attempt ${run.run_attempt}: ${attemptUrl}`);
+            core.setOutput('tests_run_id', String(run.id));
+            core.setOutput('tests_run_attempt', String(run.run_attempt));
+            core.setOutput('tests_run_url', attemptUrl);
 
       - name: Checkout immutable source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -87,7 +149,13 @@ jobs:
           set -euo pipefail
 
           SHORT_HASH=$(git rev-parse --short HEAD)
+          SOURCE_SHA=$(git rev-parse HEAD)
           channel="$RESOLVED_CHANNEL"
+
+          if ! [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Resolved source is not a full commit SHA: $SOURCE_SHA" >&2
+            exit 1
+          fi
 
           if [ "$channel" = "stable" ]; then
             TAG="${GITHUB_REF_NAME}"
@@ -101,7 +169,7 @@ jobs:
             DATE_ISO=$(date -u +%Y-%m-%d)
             DATE_COMPACT=$(date -u +%Y%m%d)
             VERSION="nightly-${DATE_COMPACT}-${SHORT_HASH}"
-            TAG_OUT="nightly-${DATE_COMPACT}-${SHORT_HASH}"
+            TAG_OUT="experimental-nightly-${DATE_COMPACT}-${SOURCE_SHA}"
             RELEASE_NAME="YAMS Nightly ${DATE_ISO} (${SHORT_HASH})"
           else
             YEAR=$(date -u +%G)
@@ -138,42 +206,55 @@ jobs:
     steps:
       - name: Check if there are new commits since last nightly release
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          SOURCE_SHA: ${{ needs.resolve-release.outputs.source_sha }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const currentSha = process.env.SOURCE_SHA;
+            if (!/^[0-9a-f]{40}$/.test(currentSha)) {
+              core.setFailed(`Invalid resolved source SHA: ${currentSha}`);
+              return;
+            }
+
             const releases = await github.paginate(github.rest.repos.listReleases, {
               owner,
               repo,
               per_page: 100,
             });
-            const latest = releases.find((r) => r.tag_name?.startsWith('nightly-'));
+            const immutableNightly = /^experimental-nightly-[0-9]{8}-[0-9a-f]{40}$/;
+            const legacyNightly = /^nightly-[0-9]{8}-[0-9a-f]{7,40}$/;
+            const latest = releases.find((release) =>
+              immutableNightly.test(release.tag_name ?? '') ||
+              legacyNightly.test(release.tag_name ?? ''));
             if (!latest) {
-              core.info('No previous nightly release found, will create one');
+              core.info('No previous valid nightly release found, will create one');
               core.setOutput('has_new_commits', 'true');
               core.setOutput('last_release_sha', 'none');
               return;
             }
 
             const tagName = latest.tag_name;
-            const tagRef = await github.rest.git.getRef({
+            let object = (await github.rest.git.getRef({
               owner,
               repo,
               ref: `tags/${tagName}`,
-            });
-            let lastSha = tagRef.data.object.sha;
-            if (tagRef.data.object.type === 'tag') {
-              const tagObj = await github.rest.git.getTag({
+            })).data.object;
+            for (let depth = 0; object.type === 'tag' && depth < 5; depth += 1) {
+              object = (await github.rest.git.getTag({
                 owner,
                 repo,
-                tag_sha: lastSha,
-              });
-              lastSha = tagObj.data.object.sha;
+                tag_sha: object.sha,
+              })).data.object;
             }
+            if (object.type !== 'commit' || !/^[0-9a-f]{40}$/.test(object.sha)) {
+              core.setFailed(`Nightly tag ${tagName} did not resolve safely to a commit`);
+              return;
+            }
+            const lastSha = object.sha;
             core.setOutput('last_release_sha', lastSha);
-
-            const currentSha = '${{ needs.resolve-release.outputs.source_sha }}';
 
             if (lastSha !== currentSha) {
               core.setOutput('has_new_commits', 'true');
@@ -256,14 +337,28 @@ jobs:
             build_packages: true
             meson_args: ""
             hosted: true
-          - os: arch-linux-hosted
+          - os: arch-linux-hosted-x86_64
             runs_on: ubuntu-24.04
-            suffix: linux-x86_64
+            suffix: arch-x86_64
             packaging: pkg.tar.zst
             build_packages: true
             meson_args: ""
             hosted: false
             arch_container: true
+            arch_name: x86_64
+            expected_host_arch: x86_64
+            docker_platform: linux/amd64
+          - os: arch-linux-hosted-aarch64
+            runs_on: ubuntu-24.04-arm
+            suffix: arch-aarch64
+            packaging: pkg.tar.zst
+            build_packages: true
+            meson_args: ""
+            hosted: false
+            arch_container: true
+            arch_name: aarch64
+            expected_host_arch: aarch64
+            docker_platform: linux/arm64
     runs-on: ${{ matrix.runs_on }}
     env:
       BUILD_DIR: build/release
@@ -310,17 +405,31 @@ jobs:
         run: |
           echo "macos_only=true: skipping linux-hosted build-release job entry"
           exit 0
-      - name: Build Arch Linux (container-based)
+      - name: Build Arch Linux (native container platform)
         if: matrix.arch_container == true
         shell: bash
         run: |
           set -euo pipefail
 
-          case "${{ matrix.suffix }}" in
-            linux-x86_64) arch_name="x86_64" ;;
-            linux-arm64) arch_name="aarch64" ;;
-            *) echo "Unexpected Arch suffix: ${{ matrix.suffix }}" >&2; exit 1 ;;
+          arch_name="${{ matrix.arch_name }}"
+          expected_host_arch="${{ matrix.expected_host_arch }}"
+          docker_platform="${{ matrix.docker_platform }}"
+          host_arch="$(uname -m)"
+          if [ "$host_arch" != "$expected_host_arch" ]; then
+            echo "ERROR: Arch lane requires native host ${expected_host_arch}, got ${host_arch}" >&2
+            exit 1
+          fi
+
+          docker_arch="$(docker info --format '{{.Architecture}}')"
+          case "$docker_arch" in
+            amd64 | x86_64) docker_arch="x86_64" ;;
+            arm64 | aarch64) docker_arch="aarch64" ;;
+            *) echo "ERROR: unsupported Docker host architecture: $docker_arch" >&2; exit 1 ;;
           esac
+          if [ "$docker_arch" != "$expected_host_arch" ]; then
+            echo "ERROR: Docker host ${docker_arch} is not native ${expected_host_arch}" >&2
+            exit 1
+          fi
 
           build_dir="build/pkg/arch-${arch_name}"
           meson_build_dir="${build_dir}/meson-${arch_name}"
@@ -333,24 +442,15 @@ jobs:
             git_ref_value="refs/tags/v${version}"
           fi
 
-          echo "Arch release channel=${channel} version=${version} build_dir=${build_dir} meson_build_dir=${meson_build_dir}"
+          echo "Arch release channel=${channel} version=${version} host=${host_arch} platform=${docker_platform} build_dir=${build_dir} meson_build_dir=${meson_build_dir}"
 
-          case "${arch_name}" in
-            x86_64) docker_platform="linux/amd64" ;;
-            aarch64) docker_platform="linux/arm64" ;;
-            *) echo "Unexpected Arch architecture: ${arch_name}" >&2; exit 1 ;;
-          esac
-
-          # Build the Arch builder image (uses cached layers from docker/local-ci/arch-package.Dockerfile)
           docker build --platform "${docker_platform}" -t yams/ci-arch:latest -f docker/local-ci/arch-package.Dockerfile .
 
           mkdir -p "${build_dir}"
-
-          # Run the full Arch build inside the container
           docker run --rm \
             --platform "${docker_platform}" \
             -v "${GITHUB_WORKSPACE}:/workspace/yams" \
-            -v yams-arch-conan-cache:/root/.conan2 \
+            -v "yams-arch-conan-cache-${arch_name}:/root/.conan2" \
             -w /workspace \
             -e RELEASE_CHANNEL="${channel}" \
             -e GIT_REF="${git_ref_value}" \
@@ -361,18 +461,56 @@ jobs:
             yams/ci-arch:latest \
             bash -lc '/workspace/yams/scripts/build-arch-pkg.sh build'
 
-          if ls "${build_dir}"/yams-*.pkg.tar.zst >/dev/null 2>&1; then
-            cp -v "${build_dir}"/yams-*.pkg.tar.zst "${GITHUB_WORKSPACE}/"
-          else
-            echo "ERROR: no Arch package produced in ${build_dir}" >&2
+          shopt -s nullglob
+          packages=("${build_dir}"/yams-*-"${arch_name}".pkg.tar.zst)
+          shopt -u nullglob
+          if [ "${#packages[@]}" -ne 1 ]; then
+            echo "ERROR: expected exactly one ${arch_name} Arch package, found ${#packages[@]}" >&2
             exit 1
           fi
+          cp -v "${packages[0]}" "${GITHUB_WORKSPACE}/"
+          package_path="${GITHUB_WORKSPACE}/$(basename "${packages[0]}")"
 
           echo "Arch build complete. Artifacts in ${build_dir}:"
           find "${build_dir}" -maxdepth 4 -type f \( -name 'yams-*.pkg.tar.zst' -o -name 'yams.db' -o -name 'yams.files' \) -print
 
-          # Write BUILD_DIR for subsequent steps
-          echo "BUILD_DIR=${build_dir}" >> "${GITHUB_ENV}"
+          {
+            echo "BUILD_DIR=${build_dir}"
+            echo "ARCH_PKG_PATH=${package_path}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Inspect and install-validate Arch package natively
+        if: matrix.arch_container == true
+        shell: bash
+        env:
+          ARCH_DOCKER_PLATFORM: ${{ matrix.docker_platform }}
+        run: |
+          set -euo pipefail
+          : "${ARCH_PKG_PATH:?ARCH_PKG_PATH not set}"
+          expected_arch="${{ matrix.arch_name }}"
+          expected_host_arch="${{ matrix.expected_host_arch }}"
+          if [ "$(uname -m)" != "$expected_host_arch" ]; then
+            echo "ERROR: refusing non-native Arch validation for ${expected_host_arch}" >&2
+            exit 1
+          fi
+
+          package_name="$(basename "$ARCH_PKG_PATH")"
+          package_info="$(docker run --rm \
+            --platform "${ARCH_DOCKER_PLATFORM}" \
+            -v "${GITHUB_WORKSPACE}:/workspace/yams:ro" \
+            -w /workspace/yams \
+            yams/ci-arch:latest \
+            bsdtar -xOf "$package_name" .PKGINFO)"
+          metadata_arch="$(printf '%s\n' "$package_info" | sed -n 's/^arch = //p')"
+          if [ "$metadata_arch" != "$expected_arch" ]; then
+            echo "ERROR: package metadata architecture ${metadata_arch:-missing} != ${expected_arch}" >&2
+            exit 1
+          fi
+          printf '%s\n' "$package_info" | grep -F 'pkgname = yams' >/dev/null
+          echo "Validated package metadata architecture: ${metadata_arch}"
+
+          chmod +x scripts/local-ci/package-validate.sh
+          bash scripts/local-ci/package-validate.sh --only arch --arch "$ARCH_PKG_PATH"
 
       - name: Skip remaining steps for Arch container builds
         if: matrix.arch_container == true
@@ -1303,8 +1441,8 @@ jobs:
         shell: bash
         run: |
           # Only generate once to avoid artifact name collision across matrix entries.
-          # Current matrix total: 6 artifacts (5 native platform builds + 1 Arch package container).
-          echo '{"total": 6}' > matrix.json
+          # Current matrix total: 7 artifacts (5 native platform builds + 2 native Arch lanes).
+          echo '{"total": 7}' > matrix.json
 
       - name: Upload matrix metadata
         if: matrix.os == 'linux-hosted' && matrix.suffix == 'linux-x86_64' && matrix.arch_container != true && github.actor != 'nektos/act'
@@ -1312,26 +1450,6 @@ jobs:
         with:
           name: matrix-meta
           path: matrix.json
-          retention-days: 1
-
-      - name: Upload Release Artifacts
-        if: github.actor != 'nektos/act'
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-${{ matrix.os }}-${{ matrix.suffix }}-files${{ github.run_attempt > 1 && format('-a{0}', github.run_attempt) || '' }}
-          path: |
-            yams-*.tar.gz
-            yams-*.zip
-            yams-*.msi
-            yams-*.msi.sha256
-            ${{ env.BUILD_DIR }}/release_summary.md
-            ${{ env.BUILD_DIR }}/bench_results/*.json
-            yams-*.deb
-            yams-*.rpm
-            yams-*.AppImage
-            yams-*.pkg
-            yams-*.pkg.tar.zst
-            winget-manifests/**
           retention-days: 1
 
       - name: Verify Linux package artifacts
@@ -1367,8 +1485,8 @@ jobs:
 
           host_arch="$(uname -m)"
           if [ "${host_arch}" != "${expected_arch}" ]; then
-            echo "Runner arch (${host_arch}) != package arch (${expected_arch}); cannot run native systemd lane. Skipping." >&2
-            exit 0
+            echo "ERROR: runner arch (${host_arch}) != package arch (${expected_arch})" >&2
+            exit 1
           fi
 
           deb="$(find . -maxdepth 1 -type f -name "yams-*linux-${expected_arch}.deb" -print -quit | sed 's#^\./##')"
@@ -1384,6 +1502,27 @@ jobs:
 
           chmod +x scripts/local-ci/package-validate.sh
           bash scripts/local-ci/package-validate.sh --only linux "${args[@]}"
+
+      - name: Upload validated release artifacts
+        if: github.actor != 'nektos/act'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.os }}-${{ matrix.suffix }}-files${{ github.run_attempt > 1 && format('-a{0}', github.run_attempt) || '' }}
+          path: |
+            yams-*.tar.gz
+            yams-*.zip
+            yams-*.msi
+            yams-*.msi.sha256
+            ${{ env.BUILD_DIR }}/release_summary.md
+            ${{ env.BUILD_DIR }}/bench_results/*.json
+            yams-*.deb
+            yams-*.rpm
+            yams-*.AppImage
+            yams-*.pkg
+            yams-*.pkg.tar.zst
+            winget-manifests/**
+          retention-days: 1
+          if-no-files-found: error
 
   create-release:
     name: Create GitHub Release
@@ -1402,6 +1541,8 @@ jobs:
     permissions:
       contents: write
       actions: read
+      id-token: write
+      attestations: write
     outputs:
       channel: ${{ steps.meta.outputs.channel }}
       version: ${{ steps.meta.outputs.version }}
@@ -1446,16 +1587,27 @@ jobs:
           shopt -s nullglob
           rm -rf assets || true
           mkdir -p assets
-          # Collect all per-platform release artifacts
+          copy_unique_asset() {
+            local source="$1"
+            local destination
+            destination="assets/$(basename "$source")"
+            if [ -e "$destination" ]; then
+              echo "ERROR: duplicate release asset name: $(basename "$source")" >&2
+              exit 1
+            fi
+            cp -v "$source" "$destination"
+          }
+
+          # Collect all per-platform release artifacts without silently overwriting names.
           for dir in release-artifacts/release-*; do
             [ -d "$dir" ] || continue
             # Archives
             for file in "$dir"/*.tar.gz "$dir"/*.zip; do
-              cp -v "$file" assets/ 2>/dev/null || true
+              [ -f "$file" ] && copy_unique_asset "$file"
             done
             # Packages
             for file in "$dir"/*.deb "$dir"/*.rpm "$dir"/*.AppImage "$dir"/*.pkg.tar.zst "$dir"/*.msi; do
-              cp -v "$file" assets/ 2>/dev/null || true
+              [ -f "$file" ] && copy_unique_asset "$file"
             done
             # Arch repo metadata
             if [ -d "$dir/archrepo" ]; then
@@ -2189,34 +2341,67 @@ jobs:
           path: archrepo/
           retention-days: 7
 
-      - name: Generate latest manifest (latest.json)
+      - name: Generate and validate release manifest (latest.json)
         shell: bash
         run: |
           set -euo pipefail
-          VERSION="${{ steps.meta.outputs.version }}"
-          TAG="${{ steps.meta.outputs.tag }}"
-          CHANNEL="${{ steps.meta.outputs.channel }}"
-          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          mkdir -p assets
-          cd assets
-          if [ ! -f SHA256SUMS ]; then
-            echo "Missing SHA256SUMS file in assets/; cannot build manifest" >&2
-            ls -al >&2 || true
-            exit 1
-          fi
-          # Build assets array JSON using awk (avoid jq dependency); trim trailing comma
-          ASSETS_JSON=$(awk '{printf "{\"name\":\"%s\",\"sha256\":\"%s\"},", $2, $1}' SHA256SUMS | sed 's/,$//')
-          cat > latest.json <<LJSON
-          {
-            "version": "${VERSION}",
-            "tag": "${TAG}",
-            "channel": "${CHANNEL}",
-            "published_at": "${DATE}",
-            "assets": [${ASSETS_JSON}]
-          }
-          LJSON
+          published_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          release_run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+          python3 scripts/ci/generate_release_manifest.py \
+            --assets-dir assets \
+            --checksums assets/SHA256SUMS \
+            --output assets/latest.json \
+            --channel "${{ steps.meta.outputs.channel }}" \
+            --version "${{ steps.meta.outputs.version }}" \
+            --tag "${{ steps.meta.outputs.tag }}" \
+            --source-sha "${{ needs.resolve-release.outputs.source_sha }}" \
+            --source-ref "${{ needs.resolve-release.outputs.source_ref }}" \
+            --repository "${{ github.repository }}" \
+            --github-server-url "${{ github.server_url }}" \
+            --release-run-id "${{ github.run_id }}" \
+            --release-run-attempt "${{ github.run_attempt }}" \
+            --release-run-url "$release_run_url" \
+            --tests-run-id "${{ needs.resolve-release.outputs.tests_run_id }}" \
+            --tests-run-attempt "${{ needs.resolve-release.outputs.tests_run_attempt }}" \
+            --tests-run-url "${{ needs.resolve-release.outputs.tests_run_url }}" \
+            --ipc-protocol-header include/yams/daemon/ipc/ipc_protocol_envelope.h \
+            --p2p-protocol-header include/yams/daemon/p2p/p2p_protocol.h \
+            --published-at "$published_at"
+          python3 -m json.tool assets/latest.json >/dev/null
           echo "latest.json manifest (assets/latest.json):" >&2
-          sed 's/^/  /' latest.json >&2
+          sed 's/^/  /' assets/latest.json >&2
+
+      - name: Create exact-source provenance predicate
+        if: github.actor != 'nektos/act'
+        env:
+          SOURCE_SHA: ${{ needs.resolve-release.outputs.source_sha }}
+          SOURCE_REF: ${{ needs.resolve-release.outputs.source_ref }}
+          TESTS_RUN_ID: ${{ needs.resolve-release.outputs.tests_run_id }}
+          TESTS_RUN_ATTEMPT: ${{ needs.resolve-release.outputs.tests_run_attempt }}
+          TESTS_RUN_URL: ${{ needs.resolve-release.outputs.tests_run_url }}
+        shell: bash
+        run: |
+          jq -n \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg source_ref "$SOURCE_REF" \
+            --arg release_run_id "$GITHUB_RUN_ID" \
+            --arg release_run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --arg tests_run_id "$TESTS_RUN_ID" \
+            --arg tests_run_attempt "$TESTS_RUN_ATTEMPT" \
+            --arg tests_run_url "$TESTS_RUN_URL" \
+            '{source_sha: $source_sha, source_ref: $source_ref,
+              release_workflow: {run_id: $release_run_id, attempt: $release_run_attempt},
+              tests_workflow: {run_id: $tests_run_id, attempt: $tests_run_attempt,
+                               url: $tests_run_url}}' \
+            > release-provenance.json
+
+      - name: Attest validated release distributables to exact source
+        if: github.actor != 'nektos/act'
+        uses: actions/attest@11bbd243972067817e9ed160cb123cab3601f436 # v2
+        with:
+          subject-checksums: assets/SHA256SUMS
+          predicate-type: https://yamsmemory.ai/attestations/release-source/v1
+          predicate-path: release-provenance.json
 
       - name: Check existing release (stable only)
         id: existing_release

--- a/docs/source-mirroring.md
+++ b/docs/source-mirroring.md
@@ -1,0 +1,61 @@
+# Source mirroring
+
+GitHub (`github.com/trvon/yams`) is the canonical YAMS source repository. The
+Forgejo repository at `git.trevon.dev/trevon/yams` is a one-way availability
+mirror; it is not a second source of truth.
+
+## Mirrored refs
+
+The `Mirror source to Forgejo` GitHub workflow mirrors only:
+
+- `refs/heads/main`
+- `refs/heads/experimental`
+- release tags beginning with `v` or `yams-v`
+
+Each run fetches one approved GitHub ref into a temporary local ref, pushes one
+explicit source-to-destination refspec, and compares the Forgejo ref SHA with
+the fetched GitHub SHA. Runs are serialized. The workflow does not prune,
+force-update, or mirror every ref.
+
+A manual dispatch accepts only `main`, `experimental`, or an approved release
+tag. Use it to reconcile an allowed ref after a transient outage.
+
+## Required secrets
+
+Configure these GitHub Actions secrets in the canonical repository:
+
+- `FORGEJO_MIRROR_SSH_KEY`: private half of a dedicated Forgejo deploy key with
+  write access only to `trevon/yams`.
+- `FORGEJO_MIRROR_KNOWN_HOSTS`: a pinned `known_hosts` entry for
+  `[git.trevon.dev]:2222`.
+
+Verify the Forgejo SSH host-key fingerprint out of band before storing the
+`known_hosts` entry. Do not generate trust dynamically inside the workflow.
+The deploy key must not be reused for package publication, administration, or
+another repository.
+
+## Initial reconciliation
+
+1. Compare the approved GitHub and Forgejo branch SHAs.
+2. Confirm the Forgejo branch is an ancestor of, or equal to, the canonical
+   GitHub branch.
+3. Install the two secrets above.
+4. Dispatch one allowed branch at a time, starting with `main`.
+5. Confirm the workflow's post-push SHA verification succeeds.
+6. Reconcile approved release tags only after both branches are verified.
+
+The workflow must be present on GitHub's default branch before relying on its
+push and manual-dispatch triggers.
+
+## Failure recovery
+
+A rejected non-fast-forward update indicates drift; it is not permission to
+force-push. Stop automation and preserve both SHAs. Determine whether Forgejo
+contains unique commits, then restore it through an explicitly reviewed
+operator action. Never add automatic pruning or a repository-wide mirror push
+to recover from drift.
+
+If SSH authentication or host verification fails, rotate or correct the
+repository-scoped deploy key or pinned host entry, then manually dispatch the
+same approved ref. If the push succeeds but SHA verification fails, treat the
+run as failed and inspect the exact destination ref before retrying.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,8 @@ nav:
   - Benchmarks: benchmarks/index.md
   - Roadmap: roadmap.md
   - Newsletter: newsletter.md
+  - Operations:
+      - Source mirroring: source-mirroring.md
 
 theme:
   name: material

--- a/scripts/ci/generate_release_manifest.py
+++ b/scripts/ci/generate_release_manifest.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Generate and validate the immutable GitHub release manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import quote
+
+SCHEMA_VERSION = 1
+FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+NIGHTLY_TAG_RE = re.compile(r"^experimental-nightly-[0-9]{8}-[0-9a-f]{40}$")
+CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+[*]?([^\r\n]+)$")
+DISTRIBUTABLE_SUFFIXES = (
+    ".pkg.tar.zst",
+    ".tar.gz",
+    ".AppImage",
+    ".zip",
+    ".deb",
+    ".rpm",
+    ".pkg",
+    ".msi",
+)
+ARCHITECTURE_PATTERNS = {
+    "x86_64": (
+        re.compile(r"(?<![A-Za-z0-9])x86_64(?![A-Za-z0-9])", re.IGNORECASE),
+        re.compile(r"(?<![A-Za-z0-9])amd64(?![A-Za-z0-9])", re.IGNORECASE),
+        re.compile(r"(?<![A-Za-z0-9])x64(?![A-Za-z0-9])", re.IGNORECASE),
+    ),
+    "aarch64": (
+        re.compile(r"(?<![A-Za-z0-9])aarch64(?![A-Za-z0-9])", re.IGNORECASE),
+        re.compile(r"(?<![A-Za-z0-9])arm64(?![A-Za-z0-9])", re.IGNORECASE),
+        re.compile(r"(?<![A-Za-z0-9])armv8(?![A-Za-z0-9])", re.IGNORECASE),
+    ),
+}
+
+
+def positive_int(value: str | int, label: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{label} must be a positive integer") from error
+    if parsed <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+    return parsed
+
+
+def normalize_architecture(filename: str) -> str:
+    matches = {
+        architecture
+        for architecture, patterns in ARCHITECTURE_PATTERNS.items()
+        if any(pattern.search(filename) for pattern in patterns)
+    }
+    if not matches:
+        raise ValueError(f"unknown architecture in asset filename: {filename}")
+    if len(matches) != 1:
+        raise ValueError(f"ambiguous architecture in asset filename: {filename}")
+    return matches.pop()
+
+
+def read_checksums(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        raise ValueError(f"missing checksum manifest: {path}")
+
+    checksums: dict[str, str] = {}
+    for line_number, raw_line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not raw_line.strip():
+            continue
+        match = CHECKSUM_RE.fullmatch(raw_line)
+        if match is None:
+            raise ValueError(f"invalid SHA256SUMS line {line_number}")
+        digest, filename = match.groups()
+        if Path(filename).name != filename or filename in {".", ".."}:
+            raise ValueError(f"invalid asset name in SHA256SUMS: {filename}")
+        if filename in checksums:
+            raise ValueError(f"duplicate asset name in SHA256SUMS: {filename}")
+        checksums[filename] = digest.lower()
+
+    if not checksums:
+        raise ValueError("SHA256SUMS contains no distributable assets")
+    return checksums
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_run_url(url: str, repository: str, run_id: int, label: str) -> None:
+    expected = f"/repos/{repository}/actions/runs/{run_id}"
+    browser_expected = f"/{repository}/actions/runs/{run_id}"
+    if expected not in url and browser_expected not in url:
+        raise ValueError(f"{label} URL is not tied to exact run ID {run_id}: {url}")
+    if "/latest" in url or "/branches/" in url:
+        raise ValueError(f"{label} URL is mutable: {url}")
+
+
+def validate_published_at(value: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError("published_at must be an RFC 3339 timestamp") from error
+    if parsed.tzinfo is None:
+        raise ValueError("published_at must include a timezone")
+    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def release_asset_url(
+    github_server_url: str, repository: str, tag: str, filename: str
+) -> str:
+    if not github_server_url.startswith("https://"):
+        raise ValueError("GitHub server URL must use HTTPS")
+    if repository.count("/") != 1 or any(part == "" for part in repository.split("/")):
+        raise ValueError(f"invalid GitHub repository: {repository}")
+    if tag.lower() in {"latest", "nightly", "stable"} or "/" in tag:
+        raise ValueError(f"mutable release tag is not allowed: {tag}")
+    url = (
+        f"{github_server_url.rstrip('/')}/{repository}/releases/download/"
+        f"{quote(tag, safe='._-')}/{quote(filename, safe='._-')}"
+    )
+    if "/releases/latest" in url or "/releases/download/latest/" in url:
+        raise ValueError(f"mutable release URL is not allowed: {url}")
+    return url
+
+
+def build_manifest(
+    *,
+    assets_dir: Path,
+    checksums_path: Path,
+    channel: str,
+    version: str,
+    tag: str,
+    source_sha: str,
+    source_ref: str,
+    repository: str,
+    github_server_url: str,
+    release_run_id: str | int,
+    release_run_attempt: str | int,
+    release_run_url: str,
+    tests_run_id: str | int | None,
+    tests_run_attempt: str | int | None,
+    tests_run_url: str | None,
+    ipc_protocol_version: str | int,
+    p2p_protocol_version: str | int,
+    published_at: str,
+) -> dict[str, object]:
+    if FULL_SHA_RE.fullmatch(source_sha) is None:
+        raise ValueError("source_sha must be a full 40-character source SHA")
+    if not source_ref.startswith("refs/"):
+        raise ValueError("source_ref must be a full refs/... reference")
+    if channel == "nightly" and NIGHTLY_TAG_RE.fullmatch(tag) is None:
+        raise ValueError(
+            "nightly tag must match experimental-nightly-YYYYMMDD-<full source SHA>"
+        )
+    if channel == "nightly" and not tag.endswith(source_sha):
+        raise ValueError("nightly tag source SHA does not match source_sha")
+
+    run_id = positive_int(release_run_id, "release workflow run ID")
+    run_attempt = positive_int(release_run_attempt, "release workflow run attempt")
+    validate_run_url(release_run_url, repository, run_id, "release workflow")
+
+    tests_workflow: dict[str, object] | None = None
+    if channel != "stable":
+        if (
+            tests_run_id is None
+            or tests_run_id == ""
+            or tests_run_attempt is None
+            or tests_run_attempt == ""
+            or not tests_run_url
+        ):
+            raise ValueError("non-stable manifest requires an exact Tests workflow run")
+        tests_id = positive_int(tests_run_id, "Tests workflow run ID")
+        tests_attempt = positive_int(tests_run_attempt, "Tests workflow run attempt")
+        validate_run_url(tests_run_url, repository, tests_id, "Tests workflow")
+        if not tests_run_url.endswith(f"/attempts/{tests_attempt}"):
+            raise ValueError("Tests workflow URL must identify the exact run attempt")
+        tests_workflow = {
+            "run_id": tests_id,
+            "run_attempt": tests_attempt,
+            "url": tests_run_url,
+        }
+
+    checksums = read_checksums(checksums_path)
+    distributables = {
+        path.name
+        for path in assets_dir.iterdir()
+        if path.is_file() and path.name.endswith(DISTRIBUTABLE_SUFFIXES)
+    }
+    unchecksummed = sorted(distributables - checksums.keys())
+    if unchecksummed:
+        raise ValueError(
+            "distributable assets missing from SHA256SUMS: " + ", ".join(unchecksummed)
+        )
+    unexpected = sorted(checksums.keys() - distributables)
+    if unexpected:
+        missing = [name for name in unexpected if not (assets_dir / name).is_file()]
+        if missing:
+            raise ValueError(
+                "missing asset referenced by SHA256SUMS: " + ", ".join(missing)
+            )
+        raise ValueError(
+            "SHA256SUMS includes non-distributable assets: " + ", ".join(unexpected)
+        )
+
+    assets: list[dict[str, object]] = []
+    for filename, expected_digest in sorted(checksums.items()):
+        path = assets_dir / filename
+        if not path.is_file():
+            raise ValueError(f"missing asset referenced by SHA256SUMS: {filename}")
+        actual_digest = sha256_file(path)
+        if actual_digest != expected_digest:
+            raise ValueError(
+                f"checksum mismatch for {filename}: expected {expected_digest}, "
+                f"got {actual_digest}"
+            )
+        assets.append(
+            {
+                "name": filename,
+                "filename": filename,
+                "size_bytes": path.stat().st_size,
+                "architecture": normalize_architecture(filename),
+                "sha256": actual_digest,
+                "url": release_asset_url(github_server_url, repository, tag, filename),
+            }
+        )
+
+    ipc_version = positive_int(ipc_protocol_version, "IPC protocol version")
+    p2p_version = positive_int(p2p_protocol_version, "P2P protocol version")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "channel": channel,
+        "version": version,
+        "tag": tag,
+        "published_at": validate_published_at(published_at),
+        "source_sha": source_sha,
+        "source_ref": source_ref,
+        "release_workflow_run_id": run_id,
+        "release_workflow_run_attempt": run_attempt,
+        "release_workflow_run_url": release_run_url,
+        "tests_workflow_run_id": (
+            tests_workflow["run_id"] if tests_workflow is not None else None
+        ),
+        "tests_workflow_run_attempt": (
+            tests_workflow["run_attempt"] if tests_workflow is not None else None
+        ),
+        "tests_workflow_run_url": (
+            tests_workflow["url"] if tests_workflow is not None else None
+        ),
+        "ipc_protocol_version": ipc_version,
+        "p2p_protocol_version": p2p_version,
+        "assets": assets,
+    }
+
+
+def read_protocol_version(path: Path, symbol: str) -> int:
+    if not path.is_file():
+        raise ValueError(f"protocol header does not exist: {path}")
+    pattern = re.compile(rf"\b{re.escape(symbol)}\b\s*=\s*([0-9]+)\s*;")
+    matches = pattern.findall(path.read_text(encoding="utf-8"))
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {symbol} definition in {path}")
+    return positive_int(matches[0], symbol)
+
+
+def write_manifest(output: Path, manifest: dict[str, object]) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--assets-dir", type=Path, required=True)
+    parser.add_argument("--checksums", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--channel", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--source-ref", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--github-server-url", default="https://github.com")
+    parser.add_argument("--release-run-id", required=True)
+    parser.add_argument("--release-run-attempt", required=True)
+    parser.add_argument("--release-run-url", required=True)
+    parser.add_argument("--tests-run-id", default="")
+    parser.add_argument("--tests-run-attempt", default="")
+    parser.add_argument("--tests-run-url", default="")
+    parser.add_argument("--ipc-protocol-header", type=Path, required=True)
+    parser.add_argument("--p2p-protocol-header", type=Path, required=True)
+    parser.add_argument("--published-at", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        manifest = build_manifest(
+            assets_dir=args.assets_dir,
+            checksums_path=args.checksums,
+            channel=args.channel,
+            version=args.version,
+            tag=args.tag,
+            source_sha=args.source_sha,
+            source_ref=args.source_ref,
+            repository=args.repository,
+            github_server_url=args.github_server_url,
+            release_run_id=args.release_run_id,
+            release_run_attempt=args.release_run_attempt,
+            release_run_url=args.release_run_url,
+            tests_run_id=args.tests_run_id,
+            tests_run_attempt=args.tests_run_attempt,
+            tests_run_url=args.tests_run_url,
+            ipc_protocol_version=read_protocol_version(
+                args.ipc_protocol_header, "PROTOCOL_VERSION"
+            ),
+            p2p_protocol_version=read_protocol_version(
+                args.p2p_protocol_header, "kP2pProtocolVersion"
+            ),
+            published_at=args.published_at,
+        )
+        write_manifest(args.output, manifest)
+    except (OSError, ValueError) as error:
+        print(f"release manifest error: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -46,6 +46,13 @@ portability_policy_script = files('scripts/check_portability.py')
 portability_policy_tests = files('scripts/test_check_portability.py')
 portability_allowlist = files('scripts/portability_allowlist.txt')
 repository_metadata_policy_script = files('scripts/check_repository_metadata.py')
+forgejo_mirror_policy_script = files('scripts/check_forgejo_mirror_workflow.py')
+test('forgejo_mirror_policy',
+  python_exe,
+  args: [forgejo_mirror_policy_script, '--root', meson.project_source_root()],
+  suite: ['unit', 'policy', 'repository'],
+  timeout: 30,
+)
 test('repository_metadata_policy',
   python_exe,
   args: [repository_metadata_policy_script, '--root', meson.project_source_root()],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -47,6 +47,13 @@ portability_policy_tests = files('scripts/test_check_portability.py')
 portability_allowlist = files('scripts/portability_allowlist.txt')
 repository_metadata_policy_script = files('scripts/check_repository_metadata.py')
 forgejo_mirror_policy_script = files('scripts/check_forgejo_mirror_workflow.py')
+experimental_release_source_policy_script = files('scripts/check_experimental_release_source.py')
+test('experimental_release_source_policy',
+  python_exe,
+  args: [experimental_release_source_policy_script, '--root', meson.project_source_root()],
+  suite: ['unit', 'policy', 'release'],
+  timeout: 30,
+)
 test('forgejo_mirror_policy',
   python_exe,
   args: [forgejo_mirror_policy_script, '--root', meson.project_source_root()],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -48,6 +48,13 @@ portability_allowlist = files('scripts/portability_allowlist.txt')
 repository_metadata_policy_script = files('scripts/check_repository_metadata.py')
 forgejo_mirror_policy_script = files('scripts/check_forgejo_mirror_workflow.py')
 experimental_release_source_policy_script = files('scripts/check_experimental_release_source.py')
+release_manifest_unit_tests = files('scripts/test_generate_release_manifest.py')
+test('release_manifest_unit',
+  python_exe,
+  args: [release_manifest_unit_tests],
+  suite: ['unit', 'release'],
+  timeout: 30,
+)
 test('experimental_release_source_policy',
   python_exe,
   args: [experimental_release_source_policy_script, '--root', meson.project_source_root()],

--- a/tests/scripts/check_experimental_release_source.py
+++ b/tests/scripts/check_experimental_release_source.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Static and scenario checks for immutable experimental release sources."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Scenario:
+    event: str
+    channel: str
+    event_sha: str
+    experimental_sha: str
+    expected_sha: str
+    expected_channel: str
+
+
+def resolve_source(scenario: Scenario) -> tuple[str, str]:
+    channel = scenario.channel or "nightly"
+    use_experimental = scenario.event == "schedule" or (
+        scenario.event == "workflow_dispatch" and channel != "stable"
+    )
+    source_sha = scenario.experimental_sha if use_experimental else scenario.event_sha
+    effective_channel = (
+        "stable"
+        if scenario.event == "push"
+        else channel
+        if channel in {"stable", "weekly", "nightly"}
+        else "nightly"
+    )
+    return source_sha, effective_channel
+
+
+def scenario_failures() -> list[str]:
+    cases = (
+        Scenario("schedule", "", "main-sha", "exp-sha", "exp-sha", "nightly"),
+        Scenario(
+            "workflow_dispatch",
+            "nightly",
+            "selected-sha",
+            "exp-sha",
+            "exp-sha",
+            "nightly",
+        ),
+        Scenario(
+            "workflow_dispatch",
+            "",
+            "selected-sha",
+            "exp-sha",
+            "exp-sha",
+            "nightly",
+        ),
+        Scenario(
+            "workflow_dispatch",
+            "weekly",
+            "selected-sha",
+            "exp-sha",
+            "exp-sha",
+            "weekly",
+        ),
+        Scenario(
+            "workflow_dispatch", "stable", "tag-sha", "exp-sha", "tag-sha", "stable"
+        ),
+        Scenario("push", "", "tag-sha", "exp-sha", "tag-sha", "stable"),
+        # Divergent history is intentionally reduced to exact SHA inequality; ancestry is irrelevant.
+        Scenario(
+            "schedule",
+            "",
+            "divergent-main",
+            "divergent-exp",
+            "divergent-exp",
+            "nightly",
+        ),
+    )
+    failures = []
+    for case in cases:
+        actual = resolve_source(case)
+        expected = (case.expected_sha, case.expected_channel)
+        if actual != expected:
+            failures.append(
+                f"scenario failed: {case}: expected {expected}, got {actual}"
+            )
+
+    def should_release(
+        last_sha: str, current_sha: str, compare_available: bool
+    ) -> bool:
+        del (
+            compare_available
+        )  # Comparison enriches logs; SHA inequality is authoritative.
+        return last_sha != current_sha
+
+    if not should_release("divergent-last", "divergent-exp", compare_available=False):
+        failures.append("divergent histories must release when exact SHAs differ")
+    if should_release("same", "same", compare_available=False):
+        failures.append("equal release SHAs must not publish again")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+    root = args.root.resolve()
+    release = (root / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    warm = (root / ".github/workflows/matrix-warm.yml").read_text(encoding="utf-8")
+
+    failures = scenario_failures()
+    required_release = (
+        "name: Resolve immutable release source",
+        "ref: 'heads/experimental'",
+        "needs: [resolve-release, check-commits]",
+        "needs: [resolve-release, warm]",
+        "needs: [resolve-release, check-commits, build-release]",
+        "ref: ${{ needs.resolve-release.outputs.source_sha }}",
+        "target_commitish: ${{ needs.resolve-release.outputs.source_sha }}",
+        "group: release-publish-${{ needs.resolve-release.outputs.channel }}-${{ needs.resolve-release.outputs.source_sha }}",
+        "cancel-in-progress: false",
+        "if (lastSha !== currentSha)",
+        "comparison was unavailable",
+    )
+    required_warm = (
+        "checkout_ref:",
+        "ref: ${{ inputs.checkout_ref || github.sha }}",
+    )
+    failures.extend(
+        f"release workflow missing control: {value}"
+        for value in required_release
+        if value not in release
+    )
+    failures.extend(
+        f"warm workflow missing control: {value}"
+        for value in required_warm
+        if value not in warm
+    )
+
+    if release.count("ref: 'heads/experimental'") != 1:
+        failures.append("experimental branch must be resolved exactly once")
+    if "ref: 'heads/main'" in release:
+        failures.append("nightly freshness must not resolve main")
+    if release.count("DATE_COMPACT=$(date -u +%Y%m%d)") != 1:
+        failures.append("nightly metadata must be derived exactly once")
+    if release.count("YEAR=$(date -u +%G)") != 1:
+        failures.append("weekly metadata must be derived exactly once")
+    if release.count('VERSION="${TAG#yams-v}"') != 1:
+        failures.append("stable metadata must be derived exactly once")
+    if release.count('BASE_NUMERIC_VERSION="$(git describe') != 1:
+        failures.append("base version must be derived exactly once")
+    if "github.event.workflow_run.head_sha || github.ref" in release:
+        failures.append("release checkout still permits mutable ref drift")
+
+    if failures:
+        print("\n".join(failures))
+        return 1
+
+    print("experimental release source policy: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/check_experimental_release_source.py
+++ b/tests/scripts/check_experimental_release_source.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -32,6 +33,14 @@ def resolve_source(scenario: Scenario) -> tuple[str, str]:
         else "nightly"
     )
     return source_sha, effective_channel
+
+
+def nightly_tag(date: str, source_sha: str) -> str:
+    if re.fullmatch(r"[0-9a-f]{40}", source_sha) is None:
+        raise ValueError("nightly tags require a full source SHA")
+    if re.fullmatch(r"[0-9]{8}", date) is None:
+        raise ValueError("nightly tags require a compact UTC date")
+    return f"experimental-nightly-{date}-{source_sha}"
 
 
 def scenario_failures() -> list[str]:
@@ -96,6 +105,17 @@ def scenario_failures() -> list[str]:
         failures.append("divergent histories must release when exact SHAs differ")
     if should_release("same", "same", compare_available=False):
         failures.append("equal release SHAs must not publish again")
+
+    source_sha = "a" * 40
+    if nightly_tag("20260101", source_sha) != (
+        "experimental-nightly-20260101-" + source_sha
+    ):
+        failures.append("nightly tag is not immutable")
+    try:
+        nightly_tag("20260101", "aaaaaaa")
+        failures.append("short SHA was accepted for an immutable nightly tag")
+    except ValueError:
+        pass
     return failures
 
 
@@ -120,6 +140,35 @@ def main() -> int:
         "cancel-in-progress: false",
         "if (lastSha !== currentSha)",
         "comparison was unavailable",
+        'TAG_OUT="experimental-nightly-${DATE_COMPACT}-${SOURCE_SHA}"',
+        "immutableNightly = /^experimental-nightly-[0-9]{8}-[0-9a-f]{40}$/",
+        "Nightly tag ${tagName} did not resolve safely to a commit",
+        "name: Require successful Tests run for exact experimental source",
+        "workflow_id: 'tests.yml'",
+        "run.status === 'completed'",
+        "run.conclusion === 'success'",
+        "run.head_sha === sourceSha",
+        "tests_run_id: ${{ steps.tests.outputs.tests_run_id }}",
+        "tests_run_attempt: ${{ steps.tests.outputs.tests_run_attempt }}",
+        "tests_run_url: ${{ steps.tests.outputs.tests_run_url }}",
+        "runs_on: ubuntu-24.04-arm",
+        "arch_name: x86_64",
+        "arch_name: aarch64",
+        "docker_platform: linux/amd64",
+        "docker_platform: linux/arm64",
+        "name: Inspect and install-validate Arch package natively",
+        'bash scripts/local-ci/package-validate.sh --only arch --arch "$ARCH_PKG_PATH"',
+        "name: Generate and validate release manifest (latest.json)",
+        "scripts/ci/generate_release_manifest.py",
+        '--source-sha "${{ needs.resolve-release.outputs.source_sha }}"',
+        '--tests-run-id "${{ needs.resolve-release.outputs.tests_run_id }}"',
+        '--tests-run-attempt "${{ needs.resolve-release.outputs.tests_run_attempt }}"',
+        "subject-checksums: assets/SHA256SUMS",
+        "uses: actions/attest@11bbd243972067817e9ed160cb123cab3601f436",
+        "predicate-type: https://yamsmemory.ai/attestations/release-source/v1",
+        "predicate-path: release-provenance.json",
+        "id-token: write",
+        "attestations: write",
     )
     required_warm = (
         "checkout_ref:",
@@ -142,6 +191,11 @@ def main() -> int:
         failures.append("nightly freshness must not resolve main")
     if release.count("DATE_COMPACT=$(date -u +%Y%m%d)") != 1:
         failures.append("nightly metadata must be derived exactly once")
+    if (
+        release.count('TAG_OUT="experimental-nightly-${DATE_COMPACT}-${SOURCE_SHA}"')
+        != 1
+    ):
+        failures.append("nightly tag must be derived exactly once from the full SHA")
     if release.count("YEAR=$(date -u +%G)") != 1:
         failures.append("weekly metadata must be derived exactly once")
     if release.count('VERSION="${TAG#yams-v}"') != 1:
@@ -150,6 +204,45 @@ def main() -> int:
         failures.append("base version must be derived exactly once")
     if "github.event.workflow_run.head_sha || github.ref" in release:
         failures.append("release checkout still permits mutable ref drift")
+
+    arch_x86 = release.find("- os: arch-linux-hosted-x86_64")
+    arch_arm = release.find("- os: arch-linux-hosted-aarch64")
+    upload = release.find("- name: Upload validated release artifacts")
+    arch_validation = release.find(
+        "- name: Inspect and install-validate Arch package natively"
+    )
+    linux_validation = release.find("- name: Validate Linux package install")
+    if min(arch_x86, arch_arm, arch_validation, linux_validation, upload) < 0:
+        failures.append("release package lane ordering controls are incomplete")
+    elif not (arch_x86 < arch_arm < arch_validation < linux_validation < upload):
+        failures.append("package validation must complete before artifact upload")
+
+    manifest = release.find("- name: Generate and validate release manifest")
+    attestation = release.find(
+        "- name: Attest validated release distributables to exact source"
+    )
+    draft_release = release.find("- name: Create or update GitHub Release")
+    publish_release = release.find("- name: Publish GitHub Release")
+    if min(manifest, attestation, draft_release, publish_release) < 0:
+        failures.append("manifest, attestation, or release publication step missing")
+    elif not (manifest < attestation < draft_release < publish_release):
+        failures.append(
+            "attestation must follow manifest and precede release publication"
+        )
+
+    create_release = release[release.find("  create-release:") :]
+    if create_release.count("id-token: write") != 1:
+        failures.append("create-release must own the only id-token:write grant")
+    if release[: release.find("  create-release:")].count("id-token: write") != 0:
+        failures.append("id-token:write must not be granted outside create-release")
+    if re.search(r"actions/attest(?:-build-provenance)?@(?:v|main|master)", release):
+        failures.append("provenance action must be pinned to a full commit SHA")
+    if "actions/attest-build-provenance@" in release:
+        failures.append(
+            "default event-SHA provenance must not describe experimental assets"
+        )
+    if re.search(r"\bqemu\b|emulat", release, re.IGNORECASE):
+        failures.append("Arch lanes must not claim or configure emulation")
 
     if failures:
         print("\n".join(failures))

--- a/tests/scripts/check_forgejo_mirror_workflow.py
+++ b/tests/scripts/check_forgejo_mirror_workflow.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Static safety policy for the GitHub-to-Forgejo mirror workflow."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+REQUIRED = (
+    "contents: read",
+    "group: forgejo-source-mirror",
+    "cancel-in-progress: false",
+    "refs/heads/main",
+    "refs/heads/experimental",
+    "refs/tags/v[0-9]*",
+    "refs/tags/yams-v[0-9]*",
+    "FORGEJO_MIRROR_SSH_KEY",
+    "FORGEJO_MIRROR_KNOWN_HOSTS",
+    "StrictHostKeyChecking=yes",
+    'git push forgejo "refs/mirror/source:${SOURCE_REF}"',
+    'git ls-remote --exit-code forgejo "${SOURCE_REF}"',
+    '"${actual_sha}" != "${EXPECTED_SHA}"',
+)
+
+FORBIDDEN = (
+    "-" + "-mirror",
+    "-" + "-prune",
+    "-" + "-force",
+    "git push " + "-f ",
+    "git push " + "--delete",
+    "ssh-keyscan",
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+    workflow = args.root.resolve() / ".github/workflows/mirror-forgejo.yml"
+
+    if not workflow.is_file():
+        print(f"missing workflow: {workflow}")
+        return 1
+
+    text = workflow.read_text(encoding="utf-8")
+    failures = [
+        f"missing required control: {value}" for value in REQUIRED if value not in text
+    ]
+    failures.extend(
+        f"forbidden mirror operation: {value}" for value in FORBIDDEN if value in text
+    )
+
+    if text.count("git push forgejo") != 1:
+        failures.append("workflow must contain exactly one explicit Forgejo push")
+    if "pull_request:" in text:
+        failures.append("mirror workflow must not receive credentials on pull requests")
+
+    if failures:
+        print("\n".join(failures))
+        return 1
+
+    print("Forgejo mirror workflow policy: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_generate_release_manifest.py
+++ b/tests/scripts/test_generate_release_manifest.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Unit tests for the release manifest generator."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "scripts/ci/generate_release_manifest.py"
+SPEC = importlib.util.spec_from_file_location("generate_release_manifest", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+manifest_module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(manifest_module)
+
+FULL_SHA = "a" * 40
+
+
+class ReleaseManifestTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.assets_dir = Path(self.temp_dir.name) / "assets"
+        self.assets_dir.mkdir()
+        self.asset = self.assets_dir / "yams-nightly-linux-x86_64.tar.gz"
+        self.asset.write_bytes(b"release payload")
+        self.digest = hashlib.sha256(self.asset.read_bytes()).hexdigest()
+        self.checksums = self.assets_dir / "SHA256SUMS"
+        self.checksums.write_text(
+            f"{self.digest}  {self.asset.name}\n", encoding="utf-8"
+        )
+
+    def build(self, **overrides: object) -> dict[str, Any]:
+        arguments: dict[str, object] = {
+            "assets_dir": self.assets_dir,
+            "checksums_path": self.checksums,
+            "channel": "nightly",
+            "version": "nightly-20260101-aaaaaaa",
+            "tag": f"experimental-nightly-20260101-{FULL_SHA}",
+            "source_sha": FULL_SHA,
+            "source_ref": "refs/heads/experimental",
+            "repository": "trvon/yams",
+            "github_server_url": "https://github.com",
+            "release_run_id": "123",
+            "release_run_attempt": "2",
+            "release_run_url": "https://github.com/trvon/yams/actions/runs/123/attempts/2",
+            "tests_run_id": "99",
+            "tests_run_attempt": "3",
+            "tests_run_url": "https://github.com/trvon/yams/actions/runs/99/attempts/3",
+            "ipc_protocol_version": 2,
+            "p2p_protocol_version": 4,
+            "published_at": "2026-01-01T00:00:00Z",
+        }
+        arguments.update(overrides)
+        return manifest_module.build_manifest(**arguments)
+
+    def test_manifest_records_immutable_provenance_and_asset_metadata(self) -> None:
+        manifest = self.build()
+
+        self.assertEqual(manifest["schema_version"], 1)
+        self.assertEqual(manifest["source_sha"], FULL_SHA)
+        self.assertEqual(manifest["source_ref"], "refs/heads/experimental")
+        self.assertEqual(manifest["release_workflow_run_attempt"], 2)
+        self.assertEqual(manifest["tests_workflow_run_id"], 99)
+        self.assertEqual(manifest["tests_workflow_run_attempt"], 3)
+        self.assertEqual(manifest["ipc_protocol_version"], 2)
+        self.assertEqual(manifest["p2p_protocol_version"], 4)
+        self.assertEqual(len(manifest["assets"]), 1)
+        asset = manifest["assets"][0]
+        self.assertEqual(asset["name"], self.asset.name)
+        self.assertEqual(asset["filename"], self.asset.name)
+        self.assertEqual(asset["size_bytes"], len(b"release payload"))
+        self.assertEqual(asset["architecture"], "x86_64")
+        self.assertEqual(asset["sha256"], self.digest)
+        self.assertEqual(
+            asset["url"],
+            "https://github.com/trvon/yams/releases/download/"
+            f"experimental-nightly-20260101-{FULL_SHA}/{self.asset.name}",
+        )
+
+    def test_stable_manifest_does_not_require_tests_run(self) -> None:
+        manifest = self.build(
+            channel="stable",
+            version="1.2.3",
+            tag="v1.2.3",
+            source_ref="refs/tags/v1.2.3",
+            tests_run_id="",
+            tests_run_attempt="",
+            tests_run_url="",
+        )
+        self.assertIsNone(manifest["tests_workflow_run_id"])
+        self.assertIsNone(manifest["tests_workflow_run_url"])
+
+    def test_rejects_non_full_source_sha(self) -> None:
+        with self.assertRaisesRegex(ValueError, "full 40-character source SHA"):
+            self.build(source_sha="abc1234")
+
+    def test_rejects_missing_experimental_tests_run(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Tests workflow run"):
+            self.build(tests_run_id="", tests_run_attempt="", tests_run_url="")
+
+    def test_rejects_mutable_tests_attempt_url(self) -> None:
+        with self.assertRaisesRegex(ValueError, "exact run attempt"):
+            self.build(tests_run_url="https://github.com/trvon/yams/actions/runs/99")
+
+    def test_rejects_unknown_or_ambiguous_architecture(self) -> None:
+        unknown = self.assets_dir / "yams-nightly-linux-ppc64le.tar.gz"
+        self.asset.rename(unknown)
+        self.checksums.write_text(f"{self.digest}  {unknown.name}\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "unknown architecture"):
+            self.build()
+
+        unknown.unlink()
+        ambiguous = self.assets_dir / "yams-linux-x86_64-aarch64.tar.gz"
+        ambiguous.write_bytes(b"release payload")
+        self.checksums.write_text(
+            f"{self.digest}  {ambiguous.name}\n", encoding="utf-8"
+        )
+        with self.assertRaisesRegex(ValueError, "ambiguous architecture"):
+            self.build()
+
+    def test_rejects_duplicate_checksum_names(self) -> None:
+        self.checksums.write_text(
+            f"{self.digest}  {self.asset.name}\n{self.digest}  {self.asset.name}\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "duplicate asset name"):
+            self.build()
+
+    def test_rejects_checksum_mismatch_and_missing_assets(self) -> None:
+        self.checksums.write_text(f"{'0' * 64}  {self.asset.name}\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "checksum mismatch"):
+            self.build()
+
+        self.asset.unlink()
+        with self.assertRaisesRegex(ValueError, "missing asset"):
+            self.build()
+
+    def test_rejects_unchecksummed_distributables_and_mutable_urls(self) -> None:
+        extra = self.assets_dir / "yams-nightly-macos-arm64.zip"
+        extra.write_bytes(b"extra")
+        with self.assertRaisesRegex(ValueError, "missing from SHA256SUMS"):
+            self.build()
+
+        extra.unlink()
+        with self.assertRaisesRegex(ValueError, "mutable release tag"):
+            self.build(channel="stable", tag="latest")
+
+    def test_write_manifest_is_stable_json(self) -> None:
+        output = self.assets_dir / "latest.json"
+        manifest_module.write_manifest(output, self.build())
+        loaded = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(loaded["schema_version"], 1)
+        self.assertTrue(output.read_text(encoding="utf-8").endswith("\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This consolidates the already reviewed release-infrastructure stack directly onto current `experimental` after the architecture stack merged:

1. mirror approved GitHub refs to Forgejo with explicit, verified refspecs
2. resolve experimental release source and metadata once at an immutable SHA
3. require exact-SHA Tests evidence and publish full-SHA experimental manifests/attestations
4. add native Arch x86_64 and aarch64 package build/install-validation lanes

## Safety properties

- GitHub remains canonical; Forgejo receives only approved explicit refs
- no force, prune, deletion, or repository-wide mirror push
- nightly tags use `experimental-nightly-<date>-<full-sha>`
- non-stable publication fails closed without a successful Tests run for the exact SHA and attempt
- package metadata/install validation precedes artifact upload
- manifests record full source identity, workflow evidence, IPC/P2P protocol versions, byte sizes, architectures, checksums, and immutable URLs
- signed custom attestations bind distributable checksums to the resolved source SHA
- stable release metadata behavior remains unchanged

## Stack repair

This PR supersedes #95. PR #92 was merged into its already-merged parent branch and did not reach `experimental`; this branch reapplies its reviewed commit together with the subsequent release commits onto current `experimental`.
