### PR TITLE
ci: isolate experimental package repositories

### DIFF
--- a/.github/workflows/act-sanity.yml
+++ b/.github/workflows/act-sanity.yml
@@ -77,7 +77,7 @@ jobs:
           set -euo pipefail
           grep -q "run_id:" .github/workflows/publish-repos.yml
           grep -q "workflow_runs" .github/workflows/publish-repos.yml
-          grep -q -- "--content-type" scripts/ci/publish_repository.py
+          grep -q '"ContentType"' scripts/ci/publish_repository.py
           grep -q "Get-MsiProperty" packaging/windows/generate-winget-manifest.ps1
           grep -q "ProductCode: '\$productCode'" packaging/windows/generate-winget-manifest.ps1
 

--- a/.github/workflows/act-sanity.yml
+++ b/.github/workflows/act-sanity.yml
@@ -77,7 +77,7 @@ jobs:
           set -euo pipefail
           grep -q "run_id:" .github/workflows/publish-repos.yml
           grep -q "workflow_runs" .github/workflows/publish-repos.yml
-          grep -q -- "--content-type" .github/workflows/publish-repos.yml
+          grep -q -- "--content-type" scripts/ci/publish_repository.py
           grep -q "Get-MsiProperty" packaging/windows/generate-winget-manifest.ps1
           grep -q "ProductCode: '\$productCode'" packaging/windows/generate-winget-manifest.ps1
 

--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -123,9 +123,11 @@ jobs:
 
       - name: Publish validated channel to R2
         env:
-          STABLE_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.R2_SECRET_ACCESS_KEY }}
+          STABLE_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          STABLE_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           STABLE_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          EXPERIMENTAL_CLOUDFLARE_API_TOKEN: ${{ secrets.EXPERIMENTAL_CLOUDFLARE_API_TOKEN }}
+          EXPERIMENTAL_R2_ACCESS_KEY_ID: ${{ secrets.EXPERIMENTAL_R2_ACCESS_KEY_ID }}
+          EXPERIMENTAL_R2_SECRET_ACCESS_KEY: ${{ secrets.EXPERIMENTAL_R2_SECRET_ACCESS_KEY }}
           EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID }}
           STABLE_GPG_PUBLIC_KEY_B64: ${{ secrets.GPG_PUBLIC_KEY_B64 || '' }}
           EXPERIMENTAL_GPG_PUBLIC_KEY_B64: ${{ secrets.EXPERIMENTAL_GPG_PUBLIC_KEY_B64 || '' }}
@@ -134,29 +136,27 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$REQUESTED_CHANNEL" = stable ]; then
-            CLOUDFLARE_API_TOKEN="$STABLE_CLOUDFLARE_API_TOKEN"
+            AWS_ACCESS_KEY_ID="$STABLE_R2_ACCESS_KEY_ID"
+            AWS_SECRET_ACCESS_KEY="$STABLE_R2_SECRET_ACCESS_KEY"
             CLOUDFLARE_ACCOUNT_ID="$STABLE_CLOUDFLARE_ACCOUNT_ID"
             GPG_PUBLIC_KEY_B64="$STABLE_GPG_PUBLIC_KEY_B64"
           else
-            CLOUDFLARE_API_TOKEN="$EXPERIMENTAL_CLOUDFLARE_API_TOKEN"
+            AWS_ACCESS_KEY_ID="$EXPERIMENTAL_R2_ACCESS_KEY_ID"
+            AWS_SECRET_ACCESS_KEY="$EXPERIMENTAL_R2_SECRET_ACCESS_KEY"
             CLOUDFLARE_ACCOUNT_ID="$EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID"
             GPG_PUBLIC_KEY_B64="$EXPERIMENTAL_GPG_PUBLIC_KEY_B64"
           fi
-          export CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID
-          unset STABLE_CLOUDFLARE_API_TOKEN STABLE_CLOUDFLARE_ACCOUNT_ID
-          unset EXPERIMENTAL_CLOUDFLARE_API_TOKEN EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID
+          export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+          unset STABLE_R2_ACCESS_KEY_ID STABLE_R2_SECRET_ACCESS_KEY
+          unset EXPERIMENTAL_R2_ACCESS_KEY_ID EXPERIMENTAL_R2_SECRET_ACCESS_KEY
+          unset STABLE_CLOUDFLARE_ACCOUNT_ID EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID
           unset STABLE_GPG_PUBLIC_KEY_B64 EXPERIMENTAL_GPG_PUBLIC_KEY_B64
-          if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
-            echo "Missing channel-specific Cloudflare R2 authority" >&2
+          if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || \
+             [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "Missing channel-specific Cloudflare R2 S3 authority" >&2
             exit 1
           fi
-
-          WRANGLER_ROOT="${RUNNER_TEMP:-/tmp}/wrangler-cli"
-          WRANGLER_BIN="$WRANGLER_ROOT/node_modules/.bin/wrangler"
-          if [ ! -x "$WRANGLER_BIN" ]; then
-            npm install --prefix "$WRANGLER_ROOT" wrangler@4.69.0 >/dev/null
-          fi
-          "$WRANGLER_BIN" --version >&2
+          python3 -m pip install --disable-pip-version-check boto3==1.40.76 >/dev/null
 
           public_key_args=()
           if [ -n "$GPG_PUBLIC_KEY_B64" ]; then
@@ -170,6 +170,6 @@ jobs:
             --selected-run-id "${{ steps.resolve-run.outputs.run_id }}" \
             --selected-run-attempt "${{ steps.resolve-run.outputs.run_attempt }}" \
             --bucket yams-repository \
-            --wrangler "$WRANGLER_BIN" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
             "${public_key_args[@]}"
           echo "Published $REQUESTED_CHANNEL without pruning any channel objects." >&2

--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -1,10 +1,18 @@
 name: Publish Package Repositories
 
-on:
+"on":
   workflow_dispatch:
     inputs:
+      channel:
+        description: "Repository channel expected from the trusted release manifest"
+        type: choice
+        options:
+          - stable
+          - experimental
+        required: true
+        default: stable
       run_id:
-        description: "Release run ID to publish (leave empty for latest successful stable)"
+        description: "Exact successful Release run ID (required for experimental)"
         required: false
         default: ""
 
@@ -17,181 +25,151 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: Checkout (shallow)
+      - name: Checkout publication policy
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          submodules: false # Publishing does not require submodule contents
+          submodules: false
 
-      - name: Validate and resolve artifact source run
+      - name: Validate and resolve trusted Release run
         id: resolve-run
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTED_CHANNEL: ${{ inputs.channel }}
+          REQUESTED_RUN_ID: ${{ inputs.run_id }}
         run: |
           set -euo pipefail
-          if [ -n "${{ inputs.run_id }}" ]; then
-            RUN_ID="${{ inputs.run_id }}"
-            echo "Validating provided run_id: $RUN_ID"
-            RUN_INFO=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}" \
-              --jq '{conclusion: .conclusion, head_branch: .head_branch, event: .event}')
-            CONCLUSION=$(echo "$RUN_INFO" | jq -r '.conclusion')
-            BRANCH=$(echo "$RUN_INFO" | jq -r '.head_branch')
-            EVENT=$(echo "$RUN_INFO" | jq -r '.event')
-            if [[ "$CONCLUSION" != "success" ]]; then
-              echo "::warning::Run $RUN_ID did not succeed (conclusion=$CONCLUSION); using explicit run_id for repo artifact republish"
-            fi
-            if [[ "$BRANCH" != "main" ]]; then
-              echo "::warning::Run $RUN_ID is from branch '$BRANCH', not main"
-            fi
-            if [[ "$EVENT" == "pull_request" ]]; then
-              echo "::error::Run $RUN_ID is a pull_request run; refusing artifact from untrusted source"
-              exit 1
-            fi
-            echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
-          else
-            # Find latest successful release.yml run on main (stable tag push)
-            RUN_ID=$(gh api "repos/${{ github.repository }}/actions/workflows/release.yml/runs?per_page=20&branch=main" \
-              --jq '.workflow_runs[] | select(.conclusion=="success" and (.event=="push" or .event=="workflow_dispatch")) | .id' | head -1)
-            if [ -z "$RUN_ID" ]; then
-              echo "::error::No successful Release workflow run found on main"
-              exit 1
-            fi
-            echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
-            echo "Resolved latest successful Release run on main: $RUN_ID"
+          if [ "$REQUESTED_CHANNEL" != stable ] && [ "$REQUESTED_CHANNEL" != experimental ]; then
+            echo "::error::Missing or unsupported repository channel: $REQUESTED_CHANNEL"
+            exit 1
+          fi
+          if [ "$REQUESTED_CHANNEL" = experimental ] && [ -z "$REQUESTED_RUN_ID" ]; then
+            echo "::error::Experimental publication requires an exact Release run ID"
+            exit 1
           fi
 
-      - name: Download repo artifacts (apt-repo)
+          RUN_ID="$REQUESTED_RUN_ID"
+          if [ -z "$RUN_ID" ]; then
+            RUN_ID=$(gh api "repos/${{ github.repository }}/actions/workflows/release.yml/runs?per_page=100" \
+              --jq '.workflow_runs[] | select(.conclusion == "success" and .event == "push") | .id' | head -1)
+            if [ -z "$RUN_ID" ]; then
+              echo "::error::No successful tag-triggered Release workflow run found"
+              exit 1
+            fi
+          fi
+          if ! [[ "$RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::run_id must be a positive numeric Actions run ID"
+            exit 1
+          fi
+
+          RUN_INFO=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}" \
+            --jq '{conclusion: .conclusion, status: .status, event: .event, path: .path, run_attempt: .run_attempt}')
+          CONCLUSION=$(jq -r '.conclusion' <<<"$RUN_INFO")
+          STATUS=$(jq -r '.status' <<<"$RUN_INFO")
+          EVENT=$(jq -r '.event' <<<"$RUN_INFO")
+          WORKFLOW_PATH=$(jq -r '.path' <<<"$RUN_INFO")
+          RUN_ATTEMPT=$(jq -r '.run_attempt' <<<"$RUN_INFO")
+          if [ "$STATUS" != completed ] || [ "$CONCLUSION" != success ]; then
+            echo "::error::Release run $RUN_ID is not a completed success"
+            exit 1
+          fi
+          if [ "$EVENT" = pull_request ] || [ "$EVENT" = pull_request_target ]; then
+            echo "::error::Refusing repository artifacts from a pull-request run"
+            exit 1
+          fi
+          if [ "$WORKFLOW_PATH" != ".github/workflows/release.yml" ]; then
+            echo "::error::Run $RUN_ID belongs to $WORKFLOW_PATH, not release.yml"
+            exit 1
+          fi
+          if ! [[ "$RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Release run has invalid attempt metadata"
+            exit 1
+          fi
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "run_attempt=$RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+
+      - name: Download trusted release manifest
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ steps.resolve-run.outputs.run_id }}
+          name: release-manifest
+          path: trusted-manifest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download APT repository artifact
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ steps.resolve-run.outputs.run_id }}
           name: apt-repo
-          path: repo-artifacts/apt-repo
+          path: repository-input/aptrepo
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download repo artifacts (yum-repo)
+      - name: Download YUM repository artifact
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ steps.resolve-run.outputs.run_id }}
           name: yum-repo
-          path: repo-artifacts/yum-repo
+          path: repository-input/yumrepo
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download repo artifacts (arch-repo)
+      - name: Download Arch repository artifact
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ steps.resolve-run.outputs.run_id }}
           name: arch-repo
-          path: repo-artifacts/arch-repo
+          path: repository-input/archrepo
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepare upload set
-        id: prep
+      - name: Publish validated channel to R2
+        env:
+          STABLE_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.R2_SECRET_ACCESS_KEY }}
+          STABLE_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          EXPERIMENTAL_CLOUDFLARE_API_TOKEN: ${{ secrets.EXPERIMENTAL_CLOUDFLARE_API_TOKEN }}
+          EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID }}
+          STABLE_GPG_PUBLIC_KEY_B64: ${{ secrets.GPG_PUBLIC_KEY_B64 || '' }}
+          EXPERIMENTAL_GPG_PUBLIC_KEY_B64: ${{ secrets.EXPERIMENTAL_GPG_PUBLIC_KEY_B64 || '' }}
+          REQUESTED_CHANNEL: ${{ inputs.channel }}
         shell: bash
         run: |
           set -euo pipefail
-          ls -1 repo-artifacts || true
-          # Expect artifacts named: apt-repo, yum-repo, homebrew-formula, etc.
-          if [ -d repo-artifacts/apt-repo ]; then
-            mv repo-artifacts/apt-repo aptrepo
-          fi
-          if [ -d repo-artifacts/yum-repo ]; then
-            mv repo-artifacts/yum-repo yumrepo
-          fi
-          if [ -d repo-artifacts/arch-repo ]; then
-            mv repo-artifacts/arch-repo archrepo
-          fi
-          # latest.json is inside assets attached to release; we attempt fetch from GitHub release API.
-          TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName') || TAG=""
-          if [ -z "$TAG" ]; then
-            echo "Could not determine latest tag; skipping manifest fetch" >&2
+          if [ "$REQUESTED_CHANNEL" = stable ]; then
+            CLOUDFLARE_API_TOKEN="$STABLE_CLOUDFLARE_API_TOKEN"
+            CLOUDFLARE_ACCOUNT_ID="$STABLE_CLOUDFLARE_ACCOUNT_ID"
+            GPG_PUBLIC_KEY_B64="$STABLE_GPG_PUBLIC_KEY_B64"
           else
-            echo "Latest tag: $TAG" >&2
-            gh release download "$TAG" --pattern latest.json --dir . || echo "No latest.json asset yet"
+            CLOUDFLARE_API_TOKEN="$EXPERIMENTAL_CLOUDFLARE_API_TOKEN"
+            CLOUDFLARE_ACCOUNT_ID="$EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID"
+            GPG_PUBLIC_KEY_B64="$EXPERIMENTAL_GPG_PUBLIC_KEY_B64"
           fi
-          # Summaries
-          {
-            echo "HAS_APT=$([ -d aptrepo ] && echo 1 || echo 0)"
-            echo "HAS_YUM=$([ -d yumrepo ] && echo 1 || echo 0)"
-            echo "HAS_ARCH=$([ -d archrepo ] && echo 1 || echo 0)"
-          } >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to R2
-        if: ${{ steps.prep.outputs.HAS_APT == '1' || steps.prep.outputs.HAS_YUM == '1' || steps.prep.outputs.HAS_ARCH == '1' }}
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.R2_SECRET_ACCESS_KEY }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          GPG_PUBLIC_KEY_B64: ${{ secrets.GPG_PUBLIC_KEY_B64 || '' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
-            echo "Cloudflare API token/account missing; aborting publish." >&2
+          export CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID
+          unset STABLE_CLOUDFLARE_API_TOKEN STABLE_CLOUDFLARE_ACCOUNT_ID
+          unset EXPERIMENTAL_CLOUDFLARE_API_TOKEN EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID
+          unset STABLE_GPG_PUBLIC_KEY_B64 EXPERIMENTAL_GPG_PUBLIC_KEY_B64
+          if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "Missing channel-specific Cloudflare R2 authority" >&2
             exit 1
           fi
+
           WRANGLER_ROOT="${RUNNER_TEMP:-/tmp}/wrangler-cli"
           WRANGLER_BIN="$WRANGLER_ROOT/node_modules/.bin/wrangler"
           if [ ! -x "$WRANGLER_BIN" ]; then
             npm install --prefix "$WRANGLER_ROOT" wrangler@4.69.0 >/dev/null
           fi
           "$WRANGLER_BIN" --version >&2
-          upload_file() {
-            local src="$1"; shift
-            local key="$1"; shift
-            local ct="application/octet-stream"
-            case "$key" in
-              *.json) ct="application/json" ;;
-              *.key) ct="text/plain" ;;
-              *.txt) ct="text/plain" ;;
-              *.xml) ct="application/xml" ;;
-              *.gz) ct="application/gzip" ;;
-              *.deb) ct="application/vnd.debian.binary-package" ;;
-              *.rpm) ct="application/x-rpm" ;;
-              *.pkg.tar.zst) ct="application/zstd" ;;
-              *.db|*.files) ct="application/gzip" ;;
-              *.asc) ct="application/pgp-signature" ;;
-            esac
-            echo "-- Upload $key" >&2
-            for attempt in 1 2 3 4 5; do
-              if "$WRANGLER_BIN" r2 object put "yams-repository/$key" \
-                --remote \
-                --file "$src" \
-                --content-type "$ct"; then
-                return 0
-              fi
-              if [ "$attempt" -eq 5 ]; then
-                echo "R2 upload failed after ${attempt} attempts: $key" >&2
-                return 1
-              fi
-              sleep $((attempt * 5))
-            done
-          }
-          if [ -n "${GPG_PUBLIC_KEY_B64:-}" ]; then
-            echo "$GPG_PUBLIC_KEY_B64" | base64 -d > gpg.key
-            upload_file gpg.key gpg.key
-          fi
-          if [ -d aptrepo ]; then
-            find aptrepo -type f -print0 | while IFS= read -r -d '' f; do
-              rel="${f#aptrepo/}"; upload_file "$f" "aptrepo/$rel";
-            done
-          fi
-          if [ -d yumrepo ]; then
-            find yumrepo -type f -print0 | while IFS= read -r -d '' f; do
-              rel="${f#yumrepo/}"; upload_file "$f" "yumrepo/$rel";
-            done
-          fi
-          if [ -d archrepo ]; then
-            find archrepo -type f -print0 | while IFS= read -r -d '' f; do
-              rel="${f#archrepo/}"; upload_file "$f" "archrepo/$rel";
-            done
-          fi
-          if [ -f latest.json ]; then
-            upload_file latest.json latest.json
-          fi
-          echo "Publish complete." >&2
 
-      - name: Warn if nothing to publish
-        if: ${{ steps.prep.outputs.HAS_APT != '1' && steps.prep.outputs.HAS_YUM != '1' && steps.prep.outputs.HAS_ARCH != '1' }}
-        run: echo "No repo artifacts found to publish." >&2
+          public_key_args=()
+          if [ -n "$GPG_PUBLIC_KEY_B64" ]; then
+            echo "$GPG_PUBLIC_KEY_B64" | base64 -d > channel-gpg.key
+            public_key_args=(--public-key channel-gpg.key)
+          fi
+          python3 scripts/ci/publish_repository.py \
+            --repo-root repository-input \
+            --manifest trusted-manifest/latest.json \
+            --expected-channel "$REQUESTED_CHANNEL" \
+            --selected-run-id "${{ steps.resolve-run.outputs.run_id }}" \
+            --selected-run-attempt "${{ steps.resolve-run.outputs.run_attempt }}" \
+            --bucket yams-repository \
+            --wrangler "$WRANGLER_BIN" \
+            "${public_key_args[@]}"
+          echo "Published $REQUESTED_CHANNEL without pruning any channel objects." >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,11 @@ jobs:
             if (context.eventName === 'schedule') {
               channel = 'nightly';
             } else if (context.eventName === 'workflow_dispatch') {
-              channel = ['stable', 'weekly', 'nightly'].includes(requestedChannel)
-                ? requestedChannel
-                : 'nightly';
+              if (!['stable', 'weekly', 'nightly'].includes(requestedChannel)) {
+                core.setFailed(`Unsupported release channel: ${requestedChannel}`);
+                return;
+              }
+              channel = requestedChannel;
             }
             core.setOutput('channel', channel);
 
@@ -1654,14 +1656,27 @@ jobs:
             touch SHA256SUMS
           fi
 
-      - name: (Optional) Import GPG key and sign checksums
-        if: env.GPG_PRIVATE_KEY && env.GPG_PRIVATE_KEY != ''
+      - name: (Optional) Import channel GPG key and sign checksums
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY || '' }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE || '' }}
+          STABLE_GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY || '' }}
+          STABLE_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE || '' }}
+          EXPERIMENTAL_GPG_PRIVATE_KEY: ${{ secrets.EXPERIMENTAL_GPG_PRIVATE_KEY || '' }}
+          EXPERIMENTAL_GPG_PASSPHRASE: ${{ secrets.EXPERIMENTAL_GPG_PASSPHRASE || '' }}
         shell: bash
         run: |
           set -euo pipefail
+          if [ "${{ steps.meta.outputs.channel }}" = stable ]; then
+            GPG_PRIVATE_KEY="$STABLE_GPG_PRIVATE_KEY"
+            GPG_PASSPHRASE="$STABLE_GPG_PASSPHRASE"
+          else
+            GPG_PRIVATE_KEY="$EXPERIMENTAL_GPG_PRIVATE_KEY"
+            GPG_PASSPHRASE="$EXPERIMENTAL_GPG_PASSPHRASE"
+          fi
+          unset STABLE_GPG_PRIVATE_KEY STABLE_GPG_PASSPHRASE EXPERIMENTAL_GPG_PRIVATE_KEY EXPERIMENTAL_GPG_PASSPHRASE
+          if [ -z "$GPG_PRIVATE_KEY" ]; then
+            echo "No channel signing key configured; leaving SHA256SUMS unsigned" >&2
+            exit 0
+          fi
           cd assets
           echo "GPG key present: generating detached signature for SHA256SUMS" >&2
           echo "$GPG_PRIVATE_KEY" | base64 -d | gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --import
@@ -2095,23 +2110,38 @@ jobs:
           fi
           popd >/dev/null
 
-      - name: Build APT repository metadata (stable only, linux .deb present)
-        if: steps.meta.outputs.channel == 'stable'
+      - name: Build APT repository metadata (linux .deb present)
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY || '' }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE || '' }}
+          STABLE_GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY || '' }}
+          STABLE_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE || '' }}
+          EXPERIMENTAL_GPG_PRIVATE_KEY: ${{ secrets.EXPERIMENTAL_GPG_PRIVATE_KEY || '' }}
+          EXPERIMENTAL_GPG_PASSPHRASE: ${{ secrets.EXPERIMENTAL_GPG_PASSPHRASE || '' }}
+          REPOSITORY_CHANNEL: ${{ steps.meta.outputs.channel == 'stable' && 'stable' || 'experimental' }}
+          REPOSITORY_VERSION: ${{ steps.meta.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
+          if [ "$REPOSITORY_CHANNEL" = stable ]; then
+            GPG_PRIVATE_KEY="$STABLE_GPG_PRIVATE_KEY"
+            GPG_PASSPHRASE="$STABLE_GPG_PASSPHRASE"
+          else
+            GPG_PRIVATE_KEY="$EXPERIMENTAL_GPG_PRIVATE_KEY"
+            GPG_PASSPHRASE="$EXPERIMENTAL_GPG_PASSPHRASE"
+          fi
+          unset STABLE_GPG_PRIVATE_KEY STABLE_GPG_PASSPHRASE EXPERIMENTAL_GPG_PRIVATE_KEY EXPERIMENTAL_GPG_PASSPHRASE
           # Require at least one .deb in assets
           if ! ls assets/*.deb >/dev/null 2>&1; then
             echo "No .deb found; skipping APT repo generation" >&2
             exit 0
           fi
           BASE_VERSION="${{ steps.meta.outputs.base_version }}"
+          PACKAGE_FILENAME_VERSION="$BASE_VERSION"
+          if [ "$REPOSITORY_CHANNEL" = experimental ]; then
+            PACKAGE_FILENAME_VERSION="$REPOSITORY_VERSION"
+          fi
           REPO_ROOT="aptrepo"
           POOL_DIR="$REPO_ROOT/pool/main/y/yams"
-          DIST=stable
+          DIST="$REPOSITORY_CHANNEL"
           COMPONENT=main
           mkdir -p "$POOL_DIR"
 
@@ -2123,11 +2153,11 @@ jobs:
             deb_name="$(basename "$deb")"
             case "$deb_name" in
               *-linux-x86_64.deb)
-                target_name="yams_${BASE_VERSION}_amd64.deb"
+                target_name="yams_${PACKAGE_FILENAME_VERSION}_amd64.deb"
                 seen_amd64=1
                 ;;
               *-linux-aarch64.deb|*-linux-arm64.deb)
-                target_name="yams_${BASE_VERSION}_arm64.deb"
+                target_name="yams_${PACKAGE_FILENAME_VERSION}_arm64.deb"
                 seen_arm64=1
                 ;;
               *)
@@ -2141,7 +2171,7 @@ jobs:
           ARCHES=()
           [ "$seen_amd64" -eq 1 ] && ARCHES+=(amd64)
           [ "$seen_arm64" -eq 1 ] && ARCHES+=(arm64)
-          if [ ${#ARCHES[@]} -eq 0 ]; then
+          if [ "${#ARCHES[@]}" -eq 0 ]; then
             echo "No recognized .deb package architectures found in assets; skipping APT metadata generation" >&2
             exit 0
           fi
@@ -2156,7 +2186,7 @@ jobs:
           mkdir -p "dists/$DIST/$COMPONENT"
 
           # Scan pool once, then split package stanzas per architecture.
-          dpkg-scanpackages --multiversion pool > dists/$DIST/$COMPONENT/Packages.all
+          dpkg-scanpackages --multiversion pool > "dists/$DIST/$COMPONENT/Packages.all"
           for ARCH in "${ARCHES[@]}"; do
             mkdir -p "dists/$DIST/$COMPONENT/binary-$ARCH"
             awk -v arch="$ARCH" '
@@ -2182,15 +2212,15 @@ jobs:
             for ARCH in "${ARCHES[@]}"; do
               for f in "$COMPONENT/binary-$ARCH/Packages" "$COMPONENT/binary-$ARCH/Packages.gz"; do
                 if [ -f "dists/$DIST/$f" ]; then
-                  hash=$(sha256sum "dists/$DIST/$f" | awk '{print $1}')
-                  size=$(stat --format='%s' "dists/$DIST/$f" 2>/dev/null || stat -f '%z' "dists/$DIST/$f")
+                  hash="$(sha256sum "dists/$DIST/$f" | awk '{print $1}')"
+                  size="$(stat --format='%s' "dists/$DIST/$f" 2>/dev/null || stat -f '%z' "dists/$DIST/$f")"
                   printf " %s %16d %s\n" "$hash" "$size" "$f"
                 fi
               done
             done
-          } > dists/$DIST/Release
+          } > "dists/$DIST/Release"
           if [ -z "${GPG_PRIVATE_KEY:-}" ]; then
-            echo "ERROR: Missing GPG_PRIVATE_KEY; refusing to publish unsigned stable APT metadata" >&2
+            echo "ERROR: Missing channel-specific GPG_PRIVATE_KEY; refusing unsigned APT metadata" >&2
             exit 1
           fi
           GPG_ARGS=(--batch --yes --pinentry-mode loopback)
@@ -2198,37 +2228,50 @@ jobs:
             GPG_ARGS+=(--passphrase "$GPG_PASSPHRASE")
           fi
           echo "$GPG_PRIVATE_KEY" | base64 -d | gpg "${GPG_ARGS[@]}" --import
-          gpg "${GPG_ARGS[@]}" -abs -o dists/$DIST/Release.gpg dists/$DIST/Release
-          gpg "${GPG_ARGS[@]}" --clearsign -o dists/$DIST/InRelease dists/$DIST/Release
+          gpg "${GPG_ARGS[@]}" -abs -o "dists/$DIST/Release.gpg" "dists/$DIST/Release"
+          gpg "${GPG_ARGS[@]}" --clearsign -o "dists/$DIST/InRelease" "dists/$DIST/Release"
           popd >/dev/null
           tree "$REPO_ROOT" || find "$REPO_ROOT" -maxdepth 4 -type f -print
+          if [ "$REPOSITORY_CHANNEL" = stable ]; then
+            repository_url="https://repo.yamsmemory.ai/aptrepo"
+            public_key_url="https://repo.yamsmemory.ai/gpg.key"
+          else
+            repository_url="https://repo.yamsmemory.ai/experimental/aptrepo"
+            public_key_url="https://repo.yamsmemory.ai/experimental/aptrepo/gpg.key"
+          fi
           printf '%s\n' \
             'Add this APT repo (signed):' \
-            '  curl -fsSL https://repo.yamsmemory.ai/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/yams.gpg' \
-            '  echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/yams.gpg] https://repo.yamsmemory.ai/aptrepo stable main" | sudo tee /etc/apt/sources.list.d/yams.list' \
-            '  sudo apt-get update && sudo apt-get install yams' \
-            '' \
-            'If unsigned (temporary/testing):' \
-            '  echo "deb [arch=amd64,arm64 trusted=yes] https://repo.yamsmemory.ai/aptrepo stable main" | sudo tee /etc/apt/sources.list.d/yams.list' \
+            "  curl -fsSL $public_key_url | sudo gpg --dearmor -o /usr/share/keyrings/yams-$REPOSITORY_CHANNEL.gpg" \
+            "  echo \"deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/yams-$REPOSITORY_CHANNEL.gpg] $repository_url $REPOSITORY_CHANNEL main\" | sudo tee /etc/apt/sources.list.d/yams-$REPOSITORY_CHANNEL.list" \
             '  sudo apt-get update && sudo apt-get install yams' \
             > "$REPO_ROOT/USAGE.txt"
 
       - name: Upload APT repo artifact
-        if: steps.meta.outputs.channel == 'stable' && always()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: apt-repo
           path: aptrepo/
           retention-days: 7
 
-      - name: Build YUM repository metadata (stable only, rpm present)
-        if: steps.meta.outputs.channel == 'stable'
+      - name: Build YUM repository metadata (rpm present)
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY || '' }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE || '' }}
+          STABLE_GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY || '' }}
+          STABLE_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE || '' }}
+          EXPERIMENTAL_GPG_PRIVATE_KEY: ${{ secrets.EXPERIMENTAL_GPG_PRIVATE_KEY || '' }}
+          EXPERIMENTAL_GPG_PASSPHRASE: ${{ secrets.EXPERIMENTAL_GPG_PASSPHRASE || '' }}
+          REPOSITORY_PREFIX: ${{ steps.meta.outputs.channel == 'stable' && '' || 'experimental/' }}
         shell: bash
         run: |
           set -euo pipefail
+          if [ "${{ steps.meta.outputs.channel }}" = stable ]; then
+            GPG_PRIVATE_KEY="$STABLE_GPG_PRIVATE_KEY"
+            GPG_PASSPHRASE="$STABLE_GPG_PASSPHRASE"
+          else
+            GPG_PRIVATE_KEY="$EXPERIMENTAL_GPG_PRIVATE_KEY"
+            GPG_PASSPHRASE="$EXPERIMENTAL_GPG_PASSPHRASE"
+          fi
+          unset STABLE_GPG_PRIVATE_KEY STABLE_GPG_PASSPHRASE EXPERIMENTAL_GPG_PRIVATE_KEY EXPERIMENTAL_GPG_PASSPHRASE
           if ! ls assets/*.rpm >/dev/null 2>&1; then
             echo "No .rpm found; skipping YUM repo generation" >&2
             exit 0
@@ -2256,7 +2299,7 @@ jobs:
             '  sudo tee /etc/yum.repos.d/yams.repo <<REPO' \
             '  [yams]' \
             '  name=YAMS Repository' \
-            '  baseurl=https://repo.yamsmemory.ai/yumrepo/' \
+            "  baseurl=https://repo.yamsmemory.ai/${REPOSITORY_PREFIX}yumrepo/" \
             '  enabled=1' \
             '  gpgcheck=0' \
             '  repo_gpgcheck=0' \
@@ -2270,15 +2313,16 @@ jobs:
             > "$YUM_ROOT/USAGE.txt"
 
       - name: Upload YUM repo artifact
-        if: steps.meta.outputs.channel == 'stable' && always()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: yum-repo
           path: yumrepo/
           retention-days: 7
 
-      - name: Build Arch repository metadata (stable only, arch packages present)
-        if: steps.meta.outputs.channel == 'stable'
+      - name: Build Arch repository metadata (arch packages present)
+        env:
+          REPOSITORY_PREFIX: ${{ steps.meta.outputs.channel == 'stable' && '' || 'experimental/' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -2325,7 +2369,7 @@ jobs:
             '  sudo tee /etc/pacman.d/yams.conf <<REPO' \
             '  [yams]' \
             '  SigLevel = Optional TrustAll' \
-            "  Server = https://repo.yamsmemory.ai/archrepo/os/\$arch" \
+            "  Server = https://repo.yamsmemory.ai/${REPOSITORY_PREFIX}archrepo/os/\$arch" \
             '  REPO' \
             '' \
             'Then install:' \
@@ -2334,7 +2378,7 @@ jobs:
           tree "${ARCH_ROOT}" 2>/dev/null || find "${ARCH_ROOT}" -maxdepth 3 -type f -print
 
       - name: Upload Arch repo artifact
-        if: steps.meta.outputs.channel == 'stable' && always()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: arch-repo
@@ -2370,6 +2414,14 @@ jobs:
           python3 -m json.tool assets/latest.json >/dev/null
           echo "latest.json manifest (assets/latest.json):" >&2
           sed 's/^/  /' assets/latest.json >&2
+
+      - name: Upload trusted release manifest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-manifest
+          path: assets/latest.json
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Create exact-source provenance predicate
         if: github.actor != 'nektos/act'
@@ -2666,17 +2718,35 @@ jobs:
           verify_asset_url "$(basename "${arm64_candidates[0]}")"
           verify_asset_url "$(basename "${x86_64_candidates[0]}")"
 
-      - name: Publish APT/YUM/Arch/latest.json to R2 (stable only)
-        if: ${{ steps.meta.outputs.channel == 'stable' && github.actor != 'nektos/act' }}
+      - name: Publish channel package repositories to R2
+        if: ${{ github.actor != 'nektos/act' }}
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.R2_SECRET_ACCESS_KEY }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          GPG_PUBLIC_KEY_B64: ${{ secrets.GPG_PUBLIC_KEY_B64 || '' }}
+          STABLE_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.R2_SECRET_ACCESS_KEY }}
+          STABLE_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          EXPERIMENTAL_CLOUDFLARE_API_TOKEN: ${{ secrets.EXPERIMENTAL_CLOUDFLARE_API_TOKEN }}
+          EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID }}
+          STABLE_GPG_PUBLIC_KEY_B64: ${{ secrets.GPG_PUBLIC_KEY_B64 || '' }}
+          EXPERIMENTAL_GPG_PUBLIC_KEY_B64: ${{ secrets.EXPERIMENTAL_GPG_PUBLIC_KEY_B64 || '' }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
-            echo "Cloudflare API token/account missing; aborting R2 publish." >&2
+          if [ "${{ steps.meta.outputs.channel }}" = stable ]; then
+            PUBLICATION_CHANNEL=stable
+            CLOUDFLARE_API_TOKEN="$STABLE_CLOUDFLARE_API_TOKEN"
+            CLOUDFLARE_ACCOUNT_ID="$STABLE_CLOUDFLARE_ACCOUNT_ID"
+            GPG_PUBLIC_KEY_B64="$STABLE_GPG_PUBLIC_KEY_B64"
+          else
+            PUBLICATION_CHANNEL=experimental
+            CLOUDFLARE_API_TOKEN="$EXPERIMENTAL_CLOUDFLARE_API_TOKEN"
+            CLOUDFLARE_ACCOUNT_ID="$EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID"
+            GPG_PUBLIC_KEY_B64="$EXPERIMENTAL_GPG_PUBLIC_KEY_B64"
+          fi
+          export CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID
+          unset STABLE_CLOUDFLARE_API_TOKEN STABLE_CLOUDFLARE_ACCOUNT_ID
+          unset EXPERIMENTAL_CLOUDFLARE_API_TOKEN EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID
+          unset STABLE_GPG_PUBLIC_KEY_B64 EXPERIMENTAL_GPG_PUBLIC_KEY_B64
+          if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "Missing channel-specific Cloudflare R2 authority" >&2
             exit 1
           fi
           WRANGLER_ROOT="${RUNNER_TEMP:-/tmp}/wrangler-cli"
@@ -2685,60 +2755,21 @@ jobs:
             npm install --prefix "$WRANGLER_ROOT" wrangler@4.69.0 >/dev/null
           fi
           "$WRANGLER_BIN" --version >&2
-          upload_file() {
-            local src="$1"; shift
-            local key="$1"; shift
-            local ct="application/octet-stream"
-            case "$key" in
-              *.json) ct="application/json" ;;
-              *.key) ct="text/plain" ;;
-              *.txt) ct="text/plain" ;;
-              *.xml) ct="application/xml" ;;
-              *.gz) ct="application/gzip" ;;
-              *.deb) ct="application/vnd.debian.binary-package" ;;
-              *.rpm) ct="application/x-rpm" ;;
-              *.pkg.tar.zst) ct="application/zstd" ;;
-              *.db|*.files) ct="application/gzip" ;;
-              *.asc) ct="application/pgp-signature" ;;
-            esac
-            echo "-- Upload $key" >&2
-            for attempt in 1 2 3 4 5; do
-              if "$WRANGLER_BIN" r2 object put "yams-repository/$key" \
-                --remote \
-                --file "$src" \
-                --content-type "$ct"; then
-                return 0
-              fi
-              if [ "$attempt" -eq 5 ]; then
-                echo "R2 upload failed after ${attempt} attempts: $key" >&2
-                return 1
-              fi
-              sleep $((attempt * 5))
-            done
-          }
-          if [ -n "${GPG_PUBLIC_KEY_B64:-}" ]; then
-            echo "$GPG_PUBLIC_KEY_B64" | base64 -d > gpg.key
-            upload_file gpg.key gpg.key
+          public_key_args=()
+          if [ -n "$GPG_PUBLIC_KEY_B64" ]; then
+            echo "$GPG_PUBLIC_KEY_B64" | base64 -d > channel-gpg.key
+            public_key_args=(--public-key channel-gpg.key)
           fi
-          if [ -d aptrepo ]; then
-            find aptrepo -type f -print0 | while IFS= read -r -d '' f; do
-              rel="${f#aptrepo/}"; upload_file "$f" "aptrepo/$rel";
-            done
-          fi
-          if [ -d yumrepo ]; then
-            find yumrepo -type f -print0 | while IFS= read -r -d '' f; do
-              rel="${f#yumrepo/}"; upload_file "$f" "yumrepo/$rel";
-            done
-          fi
-          if [ -d archrepo ]; then
-            find archrepo -type f -print0 | while IFS= read -r -d '' f; do
-              rel="${f#archrepo/}"; upload_file "$f" "archrepo/$rel";
-            done
-          fi
-          if [ -f assets/latest.json ]; then
-            upload_file assets/latest.json latest.json
-          fi
-          echo "R2 publish complete." >&2
+          python3 scripts/ci/publish_repository.py \
+            --repo-root . \
+            --manifest assets/latest.json \
+            --expected-channel "$PUBLICATION_CHANNEL" \
+            --selected-run-id "${{ github.run_id }}" \
+            --selected-run-attempt "${{ github.run_attempt }}" \
+            --bucket yams-repository \
+            --wrangler "$WRANGLER_BIN" \
+            "${public_key_args[@]}"
+          echo "R2 $PUBLICATION_CHANNEL publication complete; no objects were pruned." >&2
 
       - name: List release assets (post-upload)
         if: ${{ github.actor != 'nektos/act' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2721,9 +2721,11 @@ jobs:
       - name: Publish channel package repositories to R2
         if: ${{ github.actor != 'nektos/act' }}
         env:
-          STABLE_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.R2_SECRET_ACCESS_KEY }}
+          STABLE_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          STABLE_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           STABLE_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          EXPERIMENTAL_CLOUDFLARE_API_TOKEN: ${{ secrets.EXPERIMENTAL_CLOUDFLARE_API_TOKEN }}
+          EXPERIMENTAL_R2_ACCESS_KEY_ID: ${{ secrets.EXPERIMENTAL_R2_ACCESS_KEY_ID }}
+          EXPERIMENTAL_R2_SECRET_ACCESS_KEY: ${{ secrets.EXPERIMENTAL_R2_SECRET_ACCESS_KEY }}
           EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID }}
           STABLE_GPG_PUBLIC_KEY_B64: ${{ secrets.GPG_PUBLIC_KEY_B64 || '' }}
           EXPERIMENTAL_GPG_PUBLIC_KEY_B64: ${{ secrets.EXPERIMENTAL_GPG_PUBLIC_KEY_B64 || '' }}
@@ -2732,29 +2734,28 @@ jobs:
           set -euo pipefail
           if [ "${{ steps.meta.outputs.channel }}" = stable ]; then
             PUBLICATION_CHANNEL=stable
-            CLOUDFLARE_API_TOKEN="$STABLE_CLOUDFLARE_API_TOKEN"
+            AWS_ACCESS_KEY_ID="$STABLE_R2_ACCESS_KEY_ID"
+            AWS_SECRET_ACCESS_KEY="$STABLE_R2_SECRET_ACCESS_KEY"
             CLOUDFLARE_ACCOUNT_ID="$STABLE_CLOUDFLARE_ACCOUNT_ID"
             GPG_PUBLIC_KEY_B64="$STABLE_GPG_PUBLIC_KEY_B64"
           else
             PUBLICATION_CHANNEL=experimental
-            CLOUDFLARE_API_TOKEN="$EXPERIMENTAL_CLOUDFLARE_API_TOKEN"
+            AWS_ACCESS_KEY_ID="$EXPERIMENTAL_R2_ACCESS_KEY_ID"
+            AWS_SECRET_ACCESS_KEY="$EXPERIMENTAL_R2_SECRET_ACCESS_KEY"
             CLOUDFLARE_ACCOUNT_ID="$EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID"
             GPG_PUBLIC_KEY_B64="$EXPERIMENTAL_GPG_PUBLIC_KEY_B64"
           fi
-          export CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID
-          unset STABLE_CLOUDFLARE_API_TOKEN STABLE_CLOUDFLARE_ACCOUNT_ID
-          unset EXPERIMENTAL_CLOUDFLARE_API_TOKEN EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID
+          export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+          unset STABLE_R2_ACCESS_KEY_ID STABLE_R2_SECRET_ACCESS_KEY
+          unset EXPERIMENTAL_R2_ACCESS_KEY_ID EXPERIMENTAL_R2_SECRET_ACCESS_KEY
+          unset STABLE_CLOUDFLARE_ACCOUNT_ID EXPERIMENTAL_CLOUDFLARE_ACCOUNT_ID
           unset STABLE_GPG_PUBLIC_KEY_B64 EXPERIMENTAL_GPG_PUBLIC_KEY_B64
-          if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
-            echo "Missing channel-specific Cloudflare R2 authority" >&2
+          if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || \
+             [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "Missing channel-specific Cloudflare R2 S3 authority" >&2
             exit 1
           fi
-          WRANGLER_ROOT="${RUNNER_TEMP:-/tmp}/wrangler-cli"
-          WRANGLER_BIN="$WRANGLER_ROOT/node_modules/.bin/wrangler"
-          if [ ! -x "$WRANGLER_BIN" ]; then
-            npm install --prefix "$WRANGLER_ROOT" wrangler@4.69.0 >/dev/null
-          fi
-          "$WRANGLER_BIN" --version >&2
+          python3 -m pip install --disable-pip-version-check boto3==1.40.76 >/dev/null
           public_key_args=()
           if [ -n "$GPG_PUBLIC_KEY_B64" ]; then
             echo "$GPG_PUBLIC_KEY_B64" | base64 -d > channel-gpg.key
@@ -2767,7 +2768,7 @@ jobs:
             --selected-run-id "${{ github.run_id }}" \
             --selected-run-attempt "${{ github.run_attempt }}" \
             --bucket yams-repository \
-            --wrangler "$WRANGLER_BIN" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
             "${public_key_args[@]}"
           echo "R2 $PUBLICATION_CHANNEL publication complete; no objects were pruned." >&2
 

--- a/scripts/ci/generate_release_manifest.py
+++ b/scripts/ci/generate_release_manifest.py
@@ -154,10 +154,18 @@ def build_manifest(
     p2p_protocol_version: str | int,
     published_at: str,
 ) -> dict[str, object]:
+    if channel not in {"stable", "nightly", "weekly"}:
+        raise ValueError("channel must be stable, nightly, or weekly")
     if FULL_SHA_RE.fullmatch(source_sha) is None:
         raise ValueError("source_sha must be a full 40-character source SHA")
     if not source_ref.startswith("refs/"):
         raise ValueError("source_ref must be a full refs/... reference")
+    if channel == "stable" and source_ref != f"refs/tags/{tag}":
+        raise ValueError("stable manifest source_ref must match its immutable tag")
+    if channel != "stable" and source_ref != "refs/heads/experimental":
+        raise ValueError(
+            "non-stable manifest source_ref must be refs/heads/experimental"
+        )
     if channel == "nightly" and NIGHTLY_TAG_RE.fullmatch(tag) is None:
         raise ValueError(
             "nightly tag must match experimental-nightly-YYYYMMDD-<full source SHA>"

--- a/scripts/ci/publish_repository.py
+++ b/scripts/ci/publish_repository.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Publish one validated package-repository channel to R2 in fail-closed order."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+RELEASE_CHANNELS = frozenset({"stable", "nightly", "weekly"})
+PACKAGE_SUFFIXES = (".deb", ".rpm", ".pkg.tar.zst")
+REPOSITORY_DIRS = ("aptrepo", "yumrepo", "archrepo")
+MISSING_OBJECT_RE = re.compile(
+    r"(?:404|object[^\n]*not found|key[^\n]*does not exist|specified key does not exist)",
+    re.IGNORECASE,
+)
+
+
+class PublicationError(RuntimeError):
+    """A publication precondition or storage operation failed."""
+
+
+@dataclass(frozen=True)
+class PublicationObject:
+    source: Path
+    key: str
+    immutable: bool
+    phase: str
+    content_type: str
+
+
+@dataclass(frozen=True)
+class ValidatedManifest:
+    release_channel: str
+    publication_channel: str
+    release_run_id: int
+    release_run_attempt: int
+
+
+class ObjectStore(Protocol):
+    def get(self, key: str) -> bytes | None:
+        raise NotImplementedError
+
+    def put(self, key: str, source: Path, content_type: str) -> None:
+        raise NotImplementedError
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def content_type(key: str) -> str:
+    suffixes = (
+        (".json", "application/json"),
+        (".key", "application/pgp-keys"),
+        (".txt", "text/plain"),
+        (".xml", "application/xml"),
+        (".gz", "application/gzip"),
+        (".deb", "application/vnd.debian.binary-package"),
+        (".rpm", "application/x-rpm"),
+        (".pkg.tar.zst", "application/zstd"),
+        (".db", "application/gzip"),
+        (".files", "application/gzip"),
+        (".asc", "application/pgp-signature"),
+    )
+    for suffix, value in suffixes:
+        if key.endswith(suffix):
+            return value
+    return "application/octet-stream"
+
+
+def validate_manifest(
+    manifest_path: Path,
+    expected_channel: str,
+    selected_run_id: int,
+    selected_run_attempt: int,
+) -> ValidatedManifest:
+    if expected_channel not in {"stable", "experimental"}:
+        raise PublicationError("expected channel must be stable or experimental")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise PublicationError(f"missing release manifest: {manifest_path}") from error
+    except json.JSONDecodeError as error:
+        raise PublicationError(f"invalid release manifest JSON: {error}") from error
+    if not isinstance(manifest, dict):
+        raise PublicationError("release manifest must be a JSON object")
+
+    release_channel = manifest.get("channel")
+    if release_channel not in RELEASE_CHANNELS:
+        raise PublicationError("release manifest has missing or invalid channel")
+    publication_channel = "stable" if release_channel == "stable" else "experimental"
+    if publication_channel != expected_channel:
+        raise PublicationError(
+            f"release manifest channel {release_channel!r} does not match "
+            f"requested {expected_channel!r} publication"
+        )
+
+    run_id = manifest.get("release_workflow_run_id")
+    if isinstance(run_id, bool) or not isinstance(run_id, int) or run_id <= 0:
+        raise PublicationError(
+            "release manifest has missing or invalid workflow run ID"
+        )
+    if run_id != selected_run_id:
+        raise PublicationError(
+            f"release manifest run ID {run_id} does not match selected run {selected_run_id}"
+        )
+    run_attempt = manifest.get("release_workflow_run_attempt")
+    if (
+        isinstance(run_attempt, bool)
+        or not isinstance(run_attempt, int)
+        or run_attempt <= 0
+    ):
+        raise PublicationError(
+            "release manifest has missing or invalid workflow run attempt"
+        )
+    if run_attempt != selected_run_attempt:
+        raise PublicationError(
+            f"release manifest run attempt {run_attempt} does not match selected "
+            f"attempt {selected_run_attempt}"
+        )
+
+    source_sha = manifest.get("source_sha")
+    source_ref = manifest.get("source_ref")
+    if (
+        not isinstance(source_sha, str)
+        or re.fullmatch(r"[0-9a-f]{40}", source_sha) is None
+    ):
+        raise PublicationError("release manifest has invalid source SHA")
+    if not isinstance(source_ref, str):
+        raise PublicationError("release manifest has missing source ref")
+    if (
+        publication_channel == "experimental"
+        and source_ref != "refs/heads/experimental"
+    ):
+        raise PublicationError(
+            "experimental manifest must come from refs/heads/experimental"
+        )
+    if publication_channel == "stable" and not source_ref.startswith("refs/tags/"):
+        raise PublicationError("stable manifest must come from a tag ref")
+
+    return ValidatedManifest(release_channel, publication_channel, run_id, run_attempt)
+
+
+def _safe_relative_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    if not root.is_dir():
+        return files
+    resolved_root = root.resolve()
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            resolved = path.resolve()
+            if resolved_root not in resolved.parents or not resolved.is_file():
+                raise PublicationError(
+                    f"refusing unsafe symlink in repository artifact: {path}"
+                )
+        if path.is_file():
+            files.append(path)
+    return sorted(files)
+
+
+def build_publication_plan(
+    repo_root: Path,
+    manifest_path: Path,
+    expected_channel: str,
+    selected_run_id: int,
+    selected_run_attempt: int,
+    public_key_path: Path | None = None,
+) -> list[PublicationObject]:
+    validated = validate_manifest(
+        manifest_path, expected_channel, selected_run_id, selected_run_attempt
+    )
+    prefix = "" if validated.publication_channel == "stable" else "experimental/"
+    objects: list[PublicationObject] = []
+
+    for directory in REPOSITORY_DIRS:
+        root = repo_root / directory
+        for path in _safe_relative_files(root):
+            relative = path.relative_to(root).as_posix()
+            key = f"{prefix}{directory}/{relative}"
+            is_package = key.endswith(PACKAGE_SUFFIXES)
+            objects.append(
+                PublicationObject(
+                    source=path,
+                    key=key,
+                    immutable=is_package,
+                    phase="payload" if is_package else "metadata",
+                    content_type=content_type(key),
+                )
+            )
+
+    if not objects:
+        raise PublicationError("no package repository objects were found")
+
+    if public_key_path is not None:
+        if not public_key_path.is_file():
+            raise PublicationError(f"missing public signing key: {public_key_path}")
+        key = (
+            "gpg.key"
+            if validated.publication_channel == "stable"
+            else ("experimental/aptrepo/gpg.key")
+        )
+        objects.append(
+            PublicationObject(
+                source=public_key_path,
+                key=key,
+                immutable=False,
+                phase="metadata",
+                content_type=content_type(key),
+            )
+        )
+
+    latest_key = (
+        "latest.json"
+        if validated.publication_channel == "stable"
+        else ("experimental/latest.json")
+    )
+    objects.append(
+        PublicationObject(
+            source=manifest_path,
+            key=latest_key,
+            immutable=False,
+            phase="latest",
+            content_type="application/json",
+        )
+    )
+
+    phase_order = {"payload": 0, "metadata": 1, "latest": 2}
+    return sorted(objects, key=lambda item: (phase_order[item.phase], item.key))
+
+
+def publish(plan: list[PublicationObject], store: ObjectStore) -> None:
+    latest_seen = False
+    for item in plan:
+        if latest_seen:
+            raise PublicationError(
+                "publication plan contains objects after latest.json"
+            )
+        if item.phase == "latest":
+            latest_seen = True
+
+        if item.immutable:
+            existing = store.get(item.key)
+            if existing is not None:
+                existing_digest = sha256_bytes(existing)
+                source_digest = sha256_file(item.source)
+                if existing_digest == source_digest:
+                    print(f"immutable object already matches; skipping {item.key}")
+                    continue
+                raise PublicationError(
+                    f"immutable object conflict for {item.key}: "
+                    f"existing sha256={existing_digest}, source sha256={source_digest}"
+                )
+        store.put(item.key, item.source, item.content_type)
+
+    if not latest_seen:
+        raise PublicationError("publication plan did not contain latest.json")
+
+
+class WranglerObjectStore:
+    def __init__(self, wrangler: Path, bucket: str) -> None:
+        self.wrangler = wrangler
+        self.bucket = bucket
+
+    def _target(self, key: str) -> str:
+        return f"{self.bucket}/{key}"
+
+    def get(self, key: str) -> bytes | None:
+        with tempfile.NamedTemporaryFile(delete=False) as temporary:
+            output = Path(temporary.name)
+        try:
+            result = subprocess.run(
+                [
+                    str(self.wrangler),
+                    "r2",
+                    "object",
+                    "get",
+                    self._target(key),
+                    "--remote",
+                    "--file",
+                    str(output),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                return output.read_bytes()
+            diagnostic = f"{result.stdout}\n{result.stderr}".strip()
+            if MISSING_OBJECT_RE.search(diagnostic):
+                return None
+            raise PublicationError(
+                f"failed to check immutable object {key!r}; refusing overwrite: {diagnostic}"
+            )
+        finally:
+            output.unlink(missing_ok=True)
+
+    def put(self, key: str, source: Path, content_type: str) -> None:
+        print(f"uploading {key}", file=sys.stderr)
+        result = subprocess.run(
+            [
+                str(self.wrangler),
+                "r2",
+                "object",
+                "put",
+                self._target(key),
+                "--remote",
+                "--file",
+                str(source),
+                "--content-type",
+                content_type,
+                "--force",
+            ],
+            check=False,
+        )
+        if result.returncode != 0:
+            raise PublicationError(f"R2 upload failed for {key}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument(
+        "--expected-channel", choices=("stable", "experimental"), required=True
+    )
+    parser.add_argument("--selected-run-id", type=int, required=True)
+    parser.add_argument("--selected-run-attempt", type=int, required=True)
+    parser.add_argument("--bucket", default="yams-repository")
+    parser.add_argument("--wrangler", type=Path, required=True)
+    parser.add_argument("--public-key", type=Path)
+    parser.add_argument("--plan-only", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        plan = build_publication_plan(
+            args.repo_root,
+            args.manifest,
+            args.expected_channel,
+            args.selected_run_id,
+            args.selected_run_attempt,
+            args.public_key,
+        )
+        if args.plan_only:
+            print(
+                json.dumps(
+                    [
+                        {
+                            "key": item.key,
+                            "immutable": item.immutable,
+                            "phase": item.phase,
+                            "content_type": item.content_type,
+                        }
+                        for item in plan
+                    ],
+                    indent=2,
+                )
+            )
+            return 0
+        if not os.environ.get("CLOUDFLARE_API_TOKEN") or not os.environ.get(
+            "CLOUDFLARE_ACCOUNT_ID"
+        ):
+            raise PublicationError("Cloudflare API token/account missing")
+        publish(plan, WranglerObjectStore(args.wrangler, args.bucket))
+    except (OSError, PublicationError) as error:
+        print(f"repository publication error: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/publish_repository.py
+++ b/scripts/ci/publish_repository.py
@@ -5,23 +5,18 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib
 import json
 import os
 import re
-import subprocess
 import sys
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 RELEASE_CHANNELS = frozenset({"stable", "nightly", "weekly"})
 PACKAGE_SUFFIXES = (".deb", ".rpm", ".pkg.tar.zst")
 REPOSITORY_DIRS = ("aptrepo", "yumrepo", "archrepo")
-MISSING_OBJECT_RE = re.compile(
-    r"(?:404|object[^\n]*not found|key[^\n]*does not exist|specified key does not exist)",
-    re.IGNORECASE,
-)
 
 
 class PublicationError(RuntimeError):
@@ -46,11 +41,21 @@ class ValidatedManifest:
 
 
 class ObjectStore(Protocol):
-    def get(self, key: str) -> bytes | None:
-        raise NotImplementedError
+    def sha256(self, key: str) -> str | None:
+        return None
 
-    def put(self, key: str, source: Path, content_type: str) -> None:
-        raise NotImplementedError
+    def put(
+        self, key: str, source: Path, content_type: str, *, overwrite: bool
+    ) -> None:
+        return None
+
+
+class S3Client(Protocol):
+    def get_object(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def put_object(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
 
 
 def sha256_bytes(data: bytes) -> str:
@@ -256,9 +261,8 @@ def publish(plan: list[PublicationObject], store: ObjectStore) -> None:
             latest_seen = True
 
         if item.immutable:
-            existing = store.get(item.key)
-            if existing is not None:
-                existing_digest = sha256_bytes(existing)
+            existing_digest = store.sha256(item.key)
+            if existing_digest is not None:
                 source_digest = sha256_file(item.source)
                 if existing_digest == source_digest:
                     print(f"immutable object already matches; skipping {item.key}")
@@ -267,70 +271,83 @@ def publish(plan: list[PublicationObject], store: ObjectStore) -> None:
                     f"immutable object conflict for {item.key}: "
                     f"existing sha256={existing_digest}, source sha256={source_digest}"
                 )
-        store.put(item.key, item.source, item.content_type)
+        store.put(
+            item.key,
+            item.source,
+            item.content_type,
+            overwrite=not item.immutable,
+        )
 
     if not latest_seen:
         raise PublicationError("publication plan did not contain latest.json")
 
 
-class WranglerObjectStore:
-    def __init__(self, wrangler: Path, bucket: str) -> None:
-        self.wrangler = wrangler
+def _storage_error_code(error: Exception) -> str:
+    response = getattr(error, "response", None)
+    if not isinstance(response, dict):
+        return ""
+    details = response.get("Error", {})
+    metadata = response.get("ResponseMetadata", {})
+    code = details.get("Code") if isinstance(details, dict) else ""
+    status = metadata.get("HTTPStatusCode") if isinstance(metadata, dict) else ""
+    return str(code or status)
+
+
+class S3ObjectStore:
+    def __init__(self, client: S3Client, bucket: str) -> None:
+        self.client = client
         self.bucket = bucket
 
-    def _target(self, key: str) -> str:
-        return f"{self.bucket}/{key}"
-
-    def get(self, key: str) -> bytes | None:
-        with tempfile.NamedTemporaryFile(delete=False) as temporary:
-            output = Path(temporary.name)
+    def sha256(self, key: str) -> str | None:
         try:
-            result = subprocess.run(
-                [
-                    str(self.wrangler),
-                    "r2",
-                    "object",
-                    "get",
-                    self._target(key),
-                    "--remote",
-                    "--file",
-                    str(output),
-                ],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode == 0:
-                return output.read_bytes()
-            diagnostic = f"{result.stdout}\n{result.stderr}".strip()
-            if MISSING_OBJECT_RE.search(diagnostic):
+            response = self.client.get_object(Bucket=self.bucket, Key=key)
+        except Exception as error:
+            if _storage_error_code(error) in {"404", "NoSuchKey", "NotFound"}:
                 return None
             raise PublicationError(
-                f"failed to check immutable object {key!r}; refusing overwrite: {diagnostic}"
-            )
-        finally:
-            output.unlink(missing_ok=True)
+                f"failed to check immutable object {key!r}; refusing overwrite"
+            ) from error
 
-    def put(self, key: str, source: Path, content_type: str) -> None:
+        body = response.get("Body") if isinstance(response, dict) else None
+        if body is None or not hasattr(body, "read"):
+            raise PublicationError(f"R2 returned no body for immutable object {key!r}")
+        digest = hashlib.sha256()
+        try:
+            while chunk := body.read(1024 * 1024):
+                digest.update(chunk)
+        finally:
+            close = getattr(body, "close", None)
+            if callable(close):
+                close()
+        return digest.hexdigest()
+
+    def put(
+        self, key: str, source: Path, content_type: str, *, overwrite: bool
+    ) -> None:
         print(f"uploading {key}", file=sys.stderr)
-        result = subprocess.run(
-            [
-                str(self.wrangler),
-                "r2",
-                "object",
-                "put",
-                self._target(key),
-                "--remote",
-                "--file",
-                str(source),
-                "--content-type",
-                content_type,
-                "--force",
-            ],
-            check=False,
-        )
-        if result.returncode != 0:
-            raise PublicationError(f"R2 upload failed for {key}")
+        arguments = {
+            "Bucket": self.bucket,
+            "Key": key,
+            "ContentType": content_type,
+        }
+        if not overwrite:
+            arguments["IfNoneMatch"] = "*"
+        try:
+            with source.open("rb") as stream:
+                self.client.put_object(Body=stream, **arguments)
+        except Exception as error:
+            if not overwrite:
+                conflict_codes = {
+                    "409",
+                    "412",
+                    "ConditionalRequestConflict",
+                    "PreconditionFailed",
+                }
+                if _storage_error_code(error) in conflict_codes:
+                    raise PublicationError(
+                        f"immutable object appeared during upload: {key}"
+                    ) from error
+            raise PublicationError(f"R2 upload failed for {key}") from error
 
 
 def parse_args() -> argparse.Namespace:
@@ -343,7 +360,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--selected-run-id", type=int, required=True)
     parser.add_argument("--selected-run-attempt", type=int, required=True)
     parser.add_argument("--bucket", default="yams-repository")
-    parser.add_argument("--wrangler", type=Path, required=True)
+    parser.add_argument("--endpoint-url", required=True)
     parser.add_argument("--public-key", type=Path)
     parser.add_argument("--plan-only", action="store_true")
     return parser.parse_args()
@@ -376,11 +393,16 @@ def main() -> int:
                 )
             )
             return 0
-        if not os.environ.get("CLOUDFLARE_API_TOKEN") or not os.environ.get(
-            "CLOUDFLARE_ACCOUNT_ID"
+        if not os.environ.get("AWS_ACCESS_KEY_ID") or not os.environ.get(
+            "AWS_SECRET_ACCESS_KEY"
         ):
-            raise PublicationError("Cloudflare API token/account missing")
-        publish(plan, WranglerObjectStore(args.wrangler, args.bucket))
+            raise PublicationError("R2 S3 access key/secret missing")
+        try:
+            boto3 = importlib.import_module("boto3")
+        except ImportError as error:
+            raise PublicationError("boto3 is required for R2 publication") from error
+        client = boto3.client("s3", endpoint_url=args.endpoint_url, region_name="auto")
+        publish(plan, S3ObjectStore(client, args.bucket))
     except (OSError, PublicationError) as error:
         print(f"repository publication error: {error}", file=sys.stderr)
         return 2

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -49,10 +49,17 @@ repository_metadata_policy_script = files('scripts/check_repository_metadata.py'
 forgejo_mirror_policy_script = files('scripts/check_forgejo_mirror_workflow.py')
 experimental_release_source_policy_script = files('scripts/check_experimental_release_source.py')
 release_manifest_unit_tests = files('scripts/test_generate_release_manifest.py')
+repository_publication_unit_tests = files('scripts/test_publish_repository.py')
 test('release_manifest_unit',
   python_exe,
   args: [release_manifest_unit_tests],
   suite: ['unit', 'release'],
+  timeout: 30,
+)
+test('repository_publication_unit',
+  python_exe,
+  args: [repository_publication_unit_tests],
+  suite: ['unit', 'policy', 'release', 'repository'],
   timeout: 30,
 )
 test('experimental_release_source_policy',

--- a/tests/scripts/test_generate_release_manifest.py
+++ b/tests/scripts/test_generate_release_manifest.py
@@ -96,6 +96,21 @@ class ReleaseManifestTest(unittest.TestCase):
         self.assertIsNone(manifest["tests_workflow_run_id"])
         self.assertIsNone(manifest["tests_workflow_run_url"])
 
+    def test_rejects_unknown_release_channel(self) -> None:
+        with self.assertRaisesRegex(ValueError, "channel must be"):
+            self.build(channel="preview")
+
+    def test_rejects_channel_source_ref_mismatch(self) -> None:
+        with self.assertRaisesRegex(ValueError, "refs/heads/experimental"):
+            self.build(source_ref="refs/heads/main")
+        with self.assertRaisesRegex(ValueError, "immutable tag"):
+            self.build(
+                channel="stable",
+                version="1.2.3",
+                tag="v1.2.3",
+                source_ref="refs/tags/v1.2.2",
+            )
+
     def test_rejects_non_full_source_sha(self) -> None:
         with self.assertRaisesRegex(ValueError, "full 40-character source SHA"):
             self.build(source_sha="abc1234")
@@ -149,7 +164,7 @@ class ReleaseManifestTest(unittest.TestCase):
 
         extra.unlink()
         with self.assertRaisesRegex(ValueError, "mutable release tag"):
-            self.build(channel="stable", tag="latest")
+            self.build(channel="stable", tag="latest", source_ref="refs/tags/latest")
 
     def test_write_manifest_is_stable_json(self) -> None:
         output = self.assets_dir / "latest.json"

--- a/tests/scripts/test_publish_repository.py
+++ b/tests/scripts/test_publish_repository.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Tests for fail-closed stable/experimental repository publication."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "scripts" / "ci" / "publish_repository.py"
+SPEC = importlib.util.spec_from_file_location("publish_repository", MODULE_PATH)
+assert SPEC and SPEC.loader
+publish_repository = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = publish_repository
+SPEC.loader.exec_module(publish_repository)
+
+PublicationError = publish_repository.PublicationError
+
+
+class FakeStore:
+    def __init__(
+        self, existing: dict[str, bytes] | None = None, fail_on: str | None = None
+    ):
+        self.objects = dict(existing or {})
+        self.fail_on = fail_on
+        self.puts: list[str] = []
+
+    def get(self, key: str) -> bytes | None:
+        return self.objects.get(key)
+
+    def put(self, key: str, source: Path, content_type: str) -> None:
+        del content_type
+        if key == self.fail_on:
+            raise PublicationError(f"injected failure for {key}")
+        self.objects[key] = source.read_bytes()
+        self.puts.append(key)
+
+
+class RepositoryPublicationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        for directory in publish_repository.REPOSITORY_DIRS:
+            (self.root / directory).mkdir()
+        (self.root / "aptrepo" / "pool").mkdir()
+        (self.root / "aptrepo" / "dists").mkdir()
+        (self.root / "aptrepo" / "pool" / "yams.deb").write_bytes(b"deb-payload")
+        (self.root / "aptrepo" / "dists" / "Release").write_bytes(b"apt-metadata")
+        (self.root / "yumrepo" / "yams.rpm").write_bytes(b"rpm-payload")
+        (self.root / "yumrepo" / "repomd.xml").write_bytes(b"yum-metadata")
+        (self.root / "archrepo" / "yams.pkg.tar.zst").write_bytes(b"arch-payload")
+        (self.root / "archrepo" / "yams.db").write_bytes(b"arch-metadata")
+        self.public_key = self.root / "public.key"
+        self.public_key.write_bytes(b"public-key")
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def manifest(self, channel: str, run_id: int = 42) -> Path:
+        path = self.root / "latest.json"
+        source_ref = (
+            "refs/tags/v1.2.3" if channel == "stable" else "refs/heads/experimental"
+        )
+        path.write_text(
+            json.dumps(
+                {
+                    "channel": channel,
+                    "release_workflow_run_id": run_id,
+                    "release_workflow_run_attempt": 3,
+                    "source_sha": "a" * 40,
+                    "source_ref": source_ref,
+                }
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def plan(self, channel: str, release_channel: str | None = None):
+        return publish_repository.build_publication_plan(
+            self.root,
+            self.manifest(release_channel or channel),
+            channel,
+            42,
+            3,
+            self.public_key,
+        )
+
+    def test_stable_keys_remain_unprefixed(self) -> None:
+        keys = [item.key for item in self.plan("stable")]
+        self.assertIn("aptrepo/pool/yams.deb", keys)
+        self.assertIn("yumrepo/yams.rpm", keys)
+        self.assertIn("archrepo/yams.pkg.tar.zst", keys)
+        self.assertIn("gpg.key", keys)
+        self.assertEqual(keys[-1], "latest.json")
+        self.assertFalse(any(key.startswith("experimental/") for key in keys))
+
+    def test_experimental_keys_are_strictly_channel_prefixed(self) -> None:
+        plan = self.plan("experimental", "nightly")
+        allowed = (
+            "experimental/aptrepo/",
+            "experimental/yumrepo/",
+            "experimental/archrepo/",
+        )
+        for item in plan:
+            self.assertTrue(
+                item.key == "experimental/latest.json" or item.key.startswith(allowed)
+            )
+        self.assertIn("experimental/aptrepo/gpg.key", [item.key for item in plan])
+        self.assertEqual(plan[-1].key, "experimental/latest.json")
+
+    def test_stable_and_experimental_plans_share_no_object_keys(self) -> None:
+        stable_keys = {item.key for item in self.plan("stable")}
+        experimental_keys = {item.key for item in self.plan("experimental", "nightly")}
+        self.assertTrue(stable_keys.isdisjoint(experimental_keys))
+
+    def test_missing_manifest_channel_is_rejected(self) -> None:
+        manifest = self.manifest("nightly")
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        del data["channel"]
+        manifest.write_text(json.dumps(data), encoding="utf-8")
+        with self.assertRaisesRegex(PublicationError, "missing or invalid channel"):
+            publish_repository.build_publication_plan(
+                self.root, manifest, "experimental", 42, 3, self.public_key
+            )
+
+    def test_wrong_channel_is_rejected(self) -> None:
+        with self.assertRaisesRegex(PublicationError, "does not match"):
+            self.plan("stable", "nightly")
+
+    def test_wrong_run_id_is_rejected(self) -> None:
+        manifest = self.manifest("stable", run_id=41)
+        with self.assertRaisesRegex(PublicationError, "does not match selected run"):
+            publish_repository.build_publication_plan(
+                self.root, manifest, "stable", 42, 3, self.public_key
+            )
+
+    def test_wrong_run_attempt_is_rejected(self) -> None:
+        manifest = self.manifest("stable")
+        with self.assertRaisesRegex(
+            PublicationError, "does not match selected attempt"
+        ):
+            publish_repository.build_publication_plan(
+                self.root, manifest, "stable", 42, 2, self.public_key
+            )
+
+    def test_experimental_manifest_with_nonexperimental_ref_is_rejected(self) -> None:
+        manifest = self.manifest("nightly")
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        data["source_ref"] = "refs/heads/main"
+        manifest.write_text(json.dumps(data), encoding="utf-8")
+        with self.assertRaisesRegex(PublicationError, "refs/heads/experimental"):
+            publish_repository.build_publication_plan(
+                self.root, manifest, "experimental", 42, 3, self.public_key
+            )
+
+    def test_identical_immutable_put_is_idempotent(self) -> None:
+        plan = self.plan("experimental", "weekly")
+        package = next(item for item in plan if item.key.endswith("yams.deb"))
+        store = FakeStore({package.key: package.source.read_bytes()})
+        publish_repository.publish(plan, store)
+        self.assertNotIn(package.key, store.puts)
+        self.assertEqual(store.puts[-1], "experimental/latest.json")
+
+    def test_conflicting_immutable_put_fails_before_metadata_and_latest(self) -> None:
+        plan = self.plan("experimental", "nightly")
+        package = next(item for item in plan if item.key.endswith("yams.deb"))
+        store = FakeStore({package.key: b"different bytes"})
+        with self.assertRaisesRegex(PublicationError, "immutable object conflict"):
+            publish_repository.publish(plan, store)
+        self.assertFalse(any("dists/" in key for key in store.puts))
+        self.assertNotIn("experimental/latest.json", store.puts)
+
+    def test_interrupted_metadata_publication_does_not_advance_latest(self) -> None:
+        plan = self.plan("stable")
+        metadata = next(item for item in plan if item.phase == "metadata")
+        store = FakeStore(fail_on=metadata.key)
+        with self.assertRaisesRegex(PublicationError, "injected failure"):
+            publish_repository.publish(plan, store)
+        self.assertNotIn("latest.json", store.puts)
+
+    def test_interrupted_latest_write_recovers_on_idempotent_rerun(self) -> None:
+        plan = self.plan("experimental", "nightly")
+        latest_key = "experimental/latest.json"
+        store = FakeStore(fail_on=latest_key)
+        with self.assertRaisesRegex(PublicationError, "injected failure"):
+            publish_repository.publish(plan, store)
+        self.assertNotIn(latest_key, store.objects)
+
+        store.fail_on = None
+        store.puts.clear()
+        publish_repository.publish(plan, store)
+        self.assertEqual(store.puts[-1], latest_key)
+        self.assertEqual(
+            store.objects[latest_key], self.manifest("nightly").read_bytes()
+        )
+
+    def test_payloads_then_metadata_then_latest(self) -> None:
+        plan = self.plan("stable")
+        phases = [item.phase for item in plan]
+        order = {"payload": 0, "metadata": 1, "latest": 2}
+        self.assertEqual(phases, sorted(phases, key=lambda phase: order[phase]))
+        store = FakeStore()
+        publish_repository.publish(plan, store)
+        self.assertEqual(store.puts[-1], "latest.json")
+
+    def test_symlink_is_rejected(self) -> None:
+        target = self.root / "outside"
+        target.write_bytes(b"outside")
+        symlink = self.root / "aptrepo" / "escape.deb"
+        try:
+            symlink.symlink_to(target)
+        except OSError:
+            self.skipTest("symlinks unavailable")
+        with self.assertRaisesRegex(PublicationError, "unsafe symlink"):
+            self.plan("stable")
+
+    def test_wrangler_get_uses_remote_file_semantics(self) -> None:
+        result = publish_repository.subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="The specified key does not exist",
+        )
+        store = publish_repository.WranglerObjectStore(Path("/wrangler"), "bucket")
+        with mock.patch.object(
+            publish_repository.subprocess, "run", return_value=result
+        ) as run:
+            self.assertIsNone(store.get("experimental/aptrepo/pkg.deb"))
+
+        command = run.call_args.args[0]
+        self.assertEqual(
+            command[:5],
+            [
+                "/wrangler",
+                "r2",
+                "object",
+                "get",
+                "bucket/experimental/aptrepo/pkg.deb",
+            ],
+        )
+        self.assertIn("--remote", command)
+        self.assertIn("--file", command)
+
+    def test_wrangler_put_uses_noninteractive_remote_file_semantics(self) -> None:
+        source = self.root / "payload.deb"
+        source.write_bytes(b"payload")
+        result = publish_repository.subprocess.CompletedProcess(args=[], returncode=0)
+        store = publish_repository.WranglerObjectStore(Path("/wrangler"), "bucket")
+        with mock.patch.object(
+            publish_repository.subprocess, "run", return_value=result
+        ) as run:
+            store.put("aptrepo/payload.deb", source, "application/octet-stream")
+
+        command = run.call_args.args[0]
+        self.assertEqual(
+            command[:5],
+            [
+                "/wrangler",
+                "r2",
+                "object",
+                "put",
+                "bucket/aptrepo/payload.deb",
+            ],
+        )
+        self.assertIn("--remote", command)
+        self.assertEqual(command[command.index("--file") + 1], str(source))
+        self.assertEqual(
+            command[command.index("--content-type") + 1],
+            "application/octet-stream",
+        )
+        self.assertIn("--force", command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_publish_repository.py
+++ b/tests/scripts/test_publish_repository.py
@@ -8,8 +8,8 @@ import json
 import sys
 import tempfile
 import unittest
+from io import BytesIO
 from pathlib import Path
-from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "scripts" / "ci" / "publish_repository.py"
@@ -30,13 +30,18 @@ class FakeStore:
         self.fail_on = fail_on
         self.puts: list[str] = []
 
-    def get(self, key: str) -> bytes | None:
-        return self.objects.get(key)
+    def sha256(self, key: str) -> str | None:
+        data = self.objects.get(key)
+        return None if data is None else publish_repository.sha256_bytes(data)
 
-    def put(self, key: str, source: Path, content_type: str) -> None:
+    def put(
+        self, key: str, source: Path, content_type: str, *, overwrite: bool
+    ) -> None:
         del content_type
         if key == self.fail_on:
             raise PublicationError(f"injected failure for {key}")
+        if key in self.objects and not overwrite:
+            raise PublicationError(f"immutable object appeared during upload: {key}")
         self.objects[key] = source.read_bytes()
         self.puts.append(key)
 
@@ -219,61 +224,54 @@ class RepositoryPublicationTests(unittest.TestCase):
         with self.assertRaisesRegex(PublicationError, "unsafe symlink"):
             self.plan("stable")
 
-    def test_wrangler_get_uses_remote_file_semantics(self) -> None:
-        result = publish_repository.subprocess.CompletedProcess(
-            args=[],
-            returncode=1,
-            stdout="",
-            stderr="The specified key does not exist",
-        )
-        store = publish_repository.WranglerObjectStore(Path("/wrangler"), "bucket")
-        with mock.patch.object(
-            publish_repository.subprocess, "run", return_value=result
-        ) as run:
-            self.assertIsNone(store.get("experimental/aptrepo/pkg.deb"))
+    def test_s3_sha256_streams_remote_body(self) -> None:
+        class Client:
+            def get_object(self, **kwargs):
+                self.arguments = kwargs
+                return {"Body": BytesIO(b"payload")}
 
-        command = run.call_args.args[0]
+        client = Client()
+        store = publish_repository.S3ObjectStore(client, "bucket")
         self.assertEqual(
-            command[:5],
-            [
-                "/wrangler",
-                "r2",
-                "object",
-                "get",
-                "bucket/experimental/aptrepo/pkg.deb",
-            ],
+            store.sha256("experimental/aptrepo/pkg.deb"),
+            publish_repository.sha256_bytes(b"payload"),
         )
-        self.assertIn("--remote", command)
-        self.assertIn("--file", command)
+        self.assertEqual(
+            client.arguments,
+            {"Bucket": "bucket", "Key": "experimental/aptrepo/pkg.deb"},
+        )
 
-    def test_wrangler_put_uses_noninteractive_remote_file_semantics(self) -> None:
+    def test_s3_mutable_put_allows_overwrite(self) -> None:
+        class Client:
+            def put_object(self, **kwargs):
+                self.body = kwargs.pop("Body").read()
+                self.arguments = kwargs
+
+        source = self.root / "Release"
+        source.write_bytes(b"metadata")
+        client = Client()
+        store = publish_repository.S3ObjectStore(client, "bucket")
+        store.put("aptrepo/Release", source, "text/plain", overwrite=True)
+        self.assertNotIn("IfNoneMatch", client.arguments)
+        self.assertEqual(client.body, b"metadata")
+
+    def test_s3_immutable_put_is_atomic_create_only(self) -> None:
+        class Client:
+            def put_object(self, **kwargs):
+                self.body = kwargs.pop("Body").read()
+                self.arguments = kwargs
+
         source = self.root / "payload.deb"
         source.write_bytes(b"payload")
-        result = publish_repository.subprocess.CompletedProcess(args=[], returncode=0)
-        store = publish_repository.WranglerObjectStore(Path("/wrangler"), "bucket")
-        with mock.patch.object(
-            publish_repository.subprocess, "run", return_value=result
-        ) as run:
-            store.put("aptrepo/payload.deb", source, "application/octet-stream")
-
-        command = run.call_args.args[0]
-        self.assertEqual(
-            command[:5],
-            [
-                "/wrangler",
-                "r2",
-                "object",
-                "put",
-                "bucket/aptrepo/payload.deb",
-            ],
-        )
-        self.assertIn("--remote", command)
-        self.assertEqual(command[command.index("--file") + 1], str(source))
-        self.assertEqual(
-            command[command.index("--content-type") + 1],
+        client = Client()
+        store = publish_repository.S3ObjectStore(client, "bucket")
+        store.put(
+            "aptrepo/payload.deb",
+            source,
             "application/octet-stream",
+            overwrite=False,
         )
-        self.assertIn("--force", command)
+        self.assertEqual(client.arguments["IfNoneMatch"], "*")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- isolate experimental APT, RPM, and Arch repositories under dedicated object prefixes
- require trusted release-manifest channel and workflow-run identity before publication
- publish immutable payloads first, signed repository metadata second, and `experimental/latest.json` last
- fail closed on conflicting immutable objects while allowing byte-identical retries
- use separate stable and experimental Cloudflare and GPG credentials
- pin `external/yams-repo` to the remotely reachable Worker routing/cache-isolation commit

## Dependencies

Stacked on #96. Merge #96 first; then retarget this PR to `experimental` and reverify the exact diff and checks before merge.

No Worker deployment, release dispatch, secret access, or R2 mutation was performed.
