### PR TITLE
ci: use direct Forgejo SSH host

### DIFF
--- a/.github/workflows/mirror-forgejo.yml
+++ b/.github/workflows/mirror-forgejo.yml
@@ -88,7 +88,7 @@ jobs:
           printf '%s\n' "${MIRROR_SSH_KEY}" >"${HOME}/.ssh/forgejo_mirror"
           git config core.sshCommand \
             "ssh -i ${HOME}/.ssh/forgejo_mirror -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-          git remote add forgejo ssh://git@git.trevon.dev:2222/trevon/yams.git
+          git remote add forgejo ssh://git@ssh.git.trevon.dev:2222/trevon/yams.git
 
       - name: Push one explicit ref
         env:

--- a/docs/source-mirroring.md
+++ b/docs/source-mirroring.md
@@ -27,9 +27,11 @@ Configure this GitHub Actions secret in the canonical repository:
 - `FORGEJO_MIRROR_SSH_KEY`: private half of a dedicated Forgejo deploy key with
   write access only to `trevon/yams`.
 
-The workflow currently disables SSH host-key verification, so possession of the
-deploy key authenticates GitHub Actions to Forgejo but the runner does not
-authenticate the Forgejo endpoint. This accepts DNS/network man-in-the-middle
+The mirror connects through the DNS-only SSH endpoint
+`ssh.git.trevon.dev:2222`; the browser-facing `git.trevon.dev` remains behind
+Cloudflare. The workflow currently disables SSH host-key verification, so
+possession of the deploy key authenticates GitHub Actions to Forgejo but the
+runner does not authenticate the Forgejo endpoint. This accepts DNS/network man-in-the-middle
 risk and should be replaced with a pinned host key if that risk changes. The
 deploy key must not be reused for package publication, administration, or
 another repository.

--- a/tests/scripts/check_forgejo_mirror_workflow.py
+++ b/tests/scripts/check_forgejo_mirror_workflow.py
@@ -17,6 +17,7 @@ REQUIRED = (
     "FORGEJO_MIRROR_SSH_KEY",
     "StrictHostKeyChecking=no",
     "UserKnownHostsFile=/dev/null",
+    "ssh://git@ssh.git.trevon.dev:2222/trevon/yams.git",
     'git push forgejo "refs/mirror/source:${SOURCE_REF}"',
     'git ls-remote --exit-code forgejo "${SOURCE_REF}"',
     '"${actual_sha}" != "${EXPECTED_SHA}"',


### PR DESCRIPTION
## Summary

- route source mirroring through the DNS-only Forgejo SSH hostname
- keep the browser-facing Forgejo hostname behind Cloudflare
- statically require the direct endpoint in mirror policy validation

## Validation

- direct endpoint resolves to the origin and completes an SSH handshake on port 2222
- Forgejo mirror policy: passed
- Actionlint: passed
- normal pre-push gate: cross-compile, macOS ASan, and macOS TSan passed

No mirror write, force-push, pruning, or deployment was performed by this branch.