### PR TITLE
fix(metadata): keep replica derivation readiness local

### DIFF
--- a/include/yams/metadata/metadata_repository.h
+++ b/include/yams/metadata/metadata_repository.h
@@ -613,6 +613,7 @@ public:
     Result<void> updateDocument(const DocumentInfo& info) override;
     /// Replace one sync-selected document winner and its complete metadata map atomically.
     /// The document row and metadata keys either commit together or remain unchanged.
+    /// Receiver-local extraction and repair status are preserved, not replicated.
     Result<void>
     replaceDocumentAndMetadata(const DocumentInfo& info,
                                const std::vector<std::pair<std::string, MetadataValue>>& metadata);

--- a/include/yams/metadata/metadata_sync_adapter.h
+++ b/include/yams/metadata/metadata_sync_adapter.h
@@ -198,11 +198,7 @@ private:
                lhs.fileExtension == rhs.fileExtension && lhs.fileSize == rhs.fileSize &&
                lhs.sha256Hash == rhs.sha256Hash && lhs.mimeType == rhs.mimeType &&
                lhs.createdTime == rhs.createdTime && lhs.modifiedTime == rhs.modifiedTime &&
-               lhs.indexedTime == rhs.indexedTime && lhs.contentExtracted == rhs.contentExtracted &&
-               lhs.extractionStatus == rhs.extractionStatus &&
-               lhs.extractionError == rhs.extractionError && lhs.repairStatus == rhs.repairStatus &&
-               lhs.repairAttemptedAt == rhs.repairAttemptedAt &&
-               lhs.repairAttempts == rhs.repairAttempts;
+               lhs.indexedTime == rhs.indexedTime;
     }
 
     static bool
@@ -232,12 +228,9 @@ private:
         record.createdTime = info.createdTime.time_since_epoch().count();
         record.modifiedTime = info.modifiedTime.time_since_epoch().count();
         record.indexedTime = info.indexedTime.time_since_epoch().count();
-        record.contentExtracted = info.contentExtracted;
-        record.extractionStatus = static_cast<std::int32_t>(info.extractionStatus);
-        record.extractionError = info.extractionError;
-        record.repairStatus = static_cast<std::int32_t>(info.repairStatus);
-        record.repairAttemptedAt = info.repairAttemptedAt.time_since_epoch().count();
-        record.repairAttempts = info.repairAttempts;
+        // Retain neutral legacy wire fields, not replica-local operational state.
+        // Otherwise two peers with different extractor availability repeatedly
+        // republish the same portable metadata with different payload hashes.
         for (const auto& [key, value] : tags) {
             record.metadata[key] = memory_sync::MetadataValueRecord{
                 .value = value.value,
@@ -258,13 +251,13 @@ private:
         item.info.setCreatedTime(record.createdTime);
         item.info.setModifiedTime(record.modifiedTime);
         item.info.setIndexedTime(record.indexedTime);
-        item.info.contentExtracted = record.contentExtracted;
-        item.info.extractionStatus = static_cast<ExtractionStatus>(record.extractionStatus);
-        item.info.extractionError = record.extractionError;
-        item.info.repairStatus = static_cast<RepairStatus>(record.repairStatus);
-        item.info.repairAttemptedAt =
-            std::chrono::sys_seconds{std::chrono::seconds{record.repairAttemptedAt}};
-        item.info.repairAttempts = record.repairAttempts;
+        // Sender readiness is not evidence of receiver-local content/FTS or repair
+        // completion. Keep the wire fields readable for compatibility, but new
+        // local documents must derive their own indexes. Existing local status is
+        // preserved atomically by replaceDocumentAndMetadata.
+        item.info.contentExtracted = false;
+        item.info.extractionStatus = ExtractionStatus::Pending;
+        item.info.repairStatus = RepairStatus::Pending;
         populatePathDerivedFields(item.info);
         for (const auto& [key, value] : record.metadata) {
             MetadataValue mv;

--- a/src/metadata/repository/document_crud_ops.cpp
+++ b/src/metadata/repository/document_crud_ops.cpp
@@ -950,6 +950,8 @@ Result<std::optional<DocumentInfo>> MetadataRepository::getDocumentByHash(const 
 }
 
 // Sync winner replacement owns one SQLite transaction for row and metadata state.
+// Do not update local derivation status: copying a pre-transaction snapshot here
+// could overwrite an extraction/repair completion racing the remote apply.
 Result<void> MetadataRepository::replaceDocumentAndMetadata(
     const DocumentInfo& info, const std::vector<std::pair<std::string, MetadataValue>>& metadata) {
     std::string priorFilePath;
@@ -975,19 +977,14 @@ Result<void> MetadataRepository::replaceDocumentAndMetadata(
                 file_path = ?, file_name = ?, file_extension = ?,
                 file_size = ?, sha256_hash = ?, mime_type = ?,
                 created_time = ?, modified_time = ?, indexed_time = ?,
-                content_extracted = ?, extraction_status = ?,
-                extraction_error = ?, repair_status = ?, repair_attempted_at = ?,
-                repair_attempts = ?, path_prefix = ?, reverse_path = ?,
+                path_prefix = ?, reverse_path = ?,
                 path_hash = ?, parent_hash = ?, path_depth = ?
             WHERE id = ?
         )"));
         YAMS_TRY(updateStmt.bindAll(
             info.filePath, info.fileName, info.fileExtension, info.fileSize, info.sha256Hash,
-            info.mimeType, info.createdTime, info.modifiedTime, info.indexedTime,
-            info.contentExtracted ? 1 : 0, ExtractionStatusUtils::toString(info.extractionStatus),
-            info.extractionError, RepairStatusUtils::toString(info.repairStatus),
-            info.repairAttemptedAt, info.repairAttempts, info.pathPrefix, info.reversePath,
-            info.pathHash, info.parentHash, info.pathDepth, info.id));
+            info.mimeType, info.createdTime, info.modifiedTime, info.indexedTime, info.pathPrefix,
+            info.reversePath, info.pathHash, info.parentHash, info.pathDepth, info.id));
         YAMS_TRY(updateStmt.execute());
 
         YAMS_TRY_UNWRAP(deleteStmt, db.prepare("DELETE FROM metadata WHERE document_id = ?"));

--- a/tests/unit/metadata/metadata_sync_adapter_catch2_test.cpp
+++ b/tests/unit/metadata/metadata_sync_adapter_catch2_test.cpp
@@ -114,6 +114,61 @@ DocumentInfo makeDocument(const std::string& path, const std::string& hash) {
 
 } // namespace
 
+TEST_CASE("metadata sync payload is independent of local derivation readiness",
+          "[metadata][memory-sync][freshness]") {
+    TempDirGuard temp;
+    RepoFixture repo("meta_sync_local_readiness_");
+    MemorySyncService writer{makeBackend(temp.path / "sync"), MemorySyncConfig{"A", 50}};
+    MetadataSyncAdapter adapter{*repo.repository_, writer};
+    auto info = makeDocument("/corpus/source.md", std::string(kDocHash));
+    REQUIRE(adapter.publish(info, {}).has_value());
+    REQUIRE(writer.syncOnce().has_value());
+    const auto completedPayload = writer.readCached("document/" + std::string(kDocHash));
+    REQUIRE(completedPayload.has_value());
+
+    info.contentExtracted = false;
+    info.extractionStatus = ExtractionStatus::Failed;
+    info.extractionError = "receiver-specific extractor failure";
+    info.repairStatus = RepairStatus::Failed;
+    info.repairAttempts = 12;
+    info.repairAttemptedAt = std::chrono::sys_seconds{std::chrono::seconds{2000}};
+    REQUIRE(adapter.publish(info, {}).has_value());
+    REQUIRE(writer.syncOnce().has_value());
+    const auto failedPayload = writer.readCached("document/" + std::string(kDocHash));
+    REQUIRE(failedPayload.has_value());
+    CHECK(failedPayload.value() == completedPayload.value());
+}
+
+TEST_CASE("legacy sender completion does not certify receiver indexes",
+          "[metadata][memory-sync][freshness]") {
+    TempDirGuard temp;
+    RepoFixture repo("meta_sync_legacy_readiness_");
+    MemorySyncService writer{makeBackend(temp.path / "sync"), MemorySyncConfig{"A", 50}};
+    MemorySyncService reader{makeBackend(temp.path / "sync"), MemorySyncConfig{"B", 50}};
+    MetadataSyncAdapter adapter{*repo.repository_, reader};
+    MetadataDocumentRecord record;
+    record.documentId = kDocHash;
+    record.contentHash = kDocHash;
+    record.filePath = "/corpus/legacy.md";
+    record.contentExtracted = true;
+    record.extractionStatus = static_cast<int>(ExtractionStatus::Success);
+    record.repairStatus = static_cast<int>(RepairStatus::Completed);
+    record.repairAttempts = 8;
+    record.repairAttemptedAt = 2000;
+    REQUIRE(
+        writer.publish("document/" + std::string(kDocHash), bytes(nlohmann::json(record).dump()))
+            .has_value());
+    REQUIRE(adapter.apply().has_value());
+    auto imported = repo.repository_->getDocumentByHash(std::string(kDocHash));
+    REQUIRE(imported.has_value());
+    REQUIRE(imported.value().has_value());
+    CHECK_FALSE(imported.value()->contentExtracted);
+    CHECK(imported.value()->extractionStatus == ExtractionStatus::Pending);
+    CHECK(imported.value()->repairStatus == RepairStatus::Pending);
+    CHECK(imported.value()->repairAttempts == 0);
+    CHECK(imported.value()->repairAttemptedAt.time_since_epoch().count() == 0);
+}
+
 TEST_CASE("metadata sync adapter rejects payload identity mismatches before mutation",
           "[metadata][memory-sync][identity]") {
     TempDirGuard temp;
@@ -244,8 +299,19 @@ TEST_CASE("metadata sync adapter converges a committed document from A to B",
     CHECK(after.value()->id > 0);
     CHECK(after.value()->filePath == info.filePath);
     CHECK(after.value()->mimeType == "text/markdown");
-    CHECK(after.value()->repairStatus == RepairStatus::Completed);
-    CHECK(after.value()->repairAttempts == 1);
+    CHECK_FALSE(after.value()->contentExtracted);
+    CHECK(after.value()->extractionStatus == ExtractionStatus::Pending);
+    CHECK(after.value()->repairStatus == RepairStatus::Pending);
+    CHECK(after.value()->repairAttempts == 0);
+
+    // Local derivation completion is not portable metadata. A remote winner must
+    // neither certify absent indexes nor overwrite successful local work.
+    auto locallyDerived = *after.value();
+    locallyDerived.contentExtracted = true;
+    locallyDerived.extractionStatus = ExtractionStatus::Success;
+    locallyDerived.repairStatus = RepairStatus::Completed;
+    locallyDerived.repairAttempts = 2;
+    REQUIRE(repoB.repository_->updateDocument(locallyDerived).has_value());
 
     auto stage = repoB.repository_->getMetadata(after.value()->id, "stage");
     REQUIRE(stage.has_value());
@@ -278,8 +344,11 @@ TEST_CASE("metadata sync adapter converges a committed document from A to B",
     REQUIRE(afterAgain.value().has_value());
     CHECK(afterAgain.value()->id == after.value()->id);
     CHECK(afterAgain.value()->filePath == updatedInfo.filePath);
-    CHECK(afterAgain.value()->extractionStatus == ExtractionStatus::Failed);
-    CHECK(afterAgain.value()->extractionError == "remote failure");
+    CHECK(afterAgain.value()->contentExtracted);
+    CHECK(afterAgain.value()->extractionStatus == ExtractionStatus::Success);
+    CHECK(afterAgain.value()->extractionError.empty());
+    CHECK(afterAgain.value()->repairStatus == RepairStatus::Completed);
+    CHECK(afterAgain.value()->repairAttempts == 2);
     const auto finalStage = repoB.repository_->getMetadata(afterAgain.value()->id, "stage");
     REQUIRE(finalStage.has_value());
     REQUIRE(finalStage.value().has_value());


### PR DESCRIPTION
Stack 1/8.

Summary:
- keep replicated content facts separate from node-local extraction and embedding readiness
- prevent a replica from advertising derivations that do not exist on the receiving node
- add repository and sync-adapter coverage for local readiness semantics

Validation:
- metadata sync adapter: 155 assertions / 8 cases
- exact rebased release build passed
- commit quality hooks passed