### PR TITLE
fix(retrieval): make content identity and hydration reliable

### DIFF
--- a/include/yams/app/services/services.hpp
+++ b/include/yams/app/services/services.hpp
@@ -432,6 +432,7 @@ struct GrepFileResult {
     // Search method used for this file
     std::string searchMethod;      // how this file was searched
     bool wasSemanticSearch{false}; // true if semantic search was used
+    std::string hash;              // Immutable stored source revision, empty when unknown.
 };
 
 struct GrepResponse {

--- a/include/yams/cli/content_reference.h
+++ b/include/yams/cli/content_reference.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <algorithm>
+#include <string>
+#include <string_view>
+
+namespace yams::cli {
+
+// Machine-readable identity is independent of human hash-display preferences.
+// References are local to the selected corpus; a hash alone grants no access.
+inline void addContentReference(nlohmann::json& item, std::string_view hash) {
+    item["hash"] = hash.empty() ? nlohmann::json(nullptr) : nlohmann::json(hash);
+    item["hydration"] = nullptr;
+    const bool fullHash =
+        hash.size() == 64 && std::all_of(hash.begin(), hash.end(), [](char c) {
+            return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+        });
+    if (fullHash) {
+        item["hydration"] = {
+            {"method", "cat"}, {"hash", hash}, {"raw", true}, {"scope", "current_corpus"}};
+    }
+}
+
+} // namespace yams::cli

--- a/include/yams/cli/result_renderer.h
+++ b/include/yams/cli/result_renderer.h
@@ -13,6 +13,7 @@
 #include <string_view>
 #include <vector>
 #include <yams/metadata/document_metadata.h>
+#include <yams/cli/content_reference.h>
 #include <yams/search/search_results.h>
 
 namespace yams::cli {
@@ -357,9 +358,7 @@ private:
         for (const auto& adapter : filtered_results) {
             json item;
             item["id"] = adapter.id();
-            if (!adapter.hash().empty()) {
-                item["hash"] = adapter.hash();
-            }
+            addContentReference(item, adapter.hash());
             item["title"] = adapter.title();
             item["path"] = adapter.path();
             if (adapter.size() > 0) {

--- a/include/yams/daemon/ipc/ipc_protocol_responses.h
+++ b/include/yams/daemon/ipc/ipc_protocol_responses.h
@@ -2423,6 +2423,10 @@ struct GrepMatch {
     double confidence = 1.0;         // Match confidence (1.0 for regex, variable for semantic)
     std::string diff;
 
+    // Encoded as an additive protobuf field and a GrepResponse legacy trailer,
+    // preserving the layout of individual matches in the legacy wire format.
+    std::string hash;
+
     template <typename Serializer>
     requires IsSerializer<Serializer>
     void serialize(Serializer& ser) const {
@@ -2490,6 +2494,11 @@ struct GrepResponse {
             it.serialize(ser);
         ser << totalMatches << filesSearched << regexMatches << semanticMatches << executionTimeMs
             << queryInfo << searchStats << filesWith << filesWithout << pathsOnly;
+        std::vector<std::string> hashes;
+        hashes.reserve(matches.size());
+        for (const auto& match : matches)
+            hashes.push_back(match.hash);
+        ser << hashes;
     }
 
     template <typename Deserializer>
@@ -2549,6 +2558,13 @@ struct GrepResponse {
         auto pathsOnly_ = deser.readStringVector();
         if (pathsOnly_)
             r.pathsOnly = pathsOnly_.value();
+
+        // Older peers omit this trailer; their results retain unknown identity.
+        auto hashes = deser.readStringVector();
+        if (hashes && hashes.value().size() == r.matches.size()) {
+            for (size_t i = 0; i < r.matches.size(); ++i)
+                r.matches[i].hash = std::move(hashes.value()[i]);
+        }
 
         return r;
     }

--- a/include/yams/daemon/ipc/proto/ipc_envelope.proto
+++ b/include/yams/daemon/ipc/proto/ipc_envelope.proto
@@ -539,6 +539,7 @@ message GrepMatch {
   repeated bytes context_after = 5;   // Changed from string to bytes
   string match_type = 6;
   double confidence = 7;
+  string hash = 8; // Immutable stored source revision; absent on older peers.
 }
 
 message GrepResponse {

--- a/include/yams/mcp/tool_registry.h
+++ b/include/yams/mcp/tool_registry.h
@@ -482,6 +482,7 @@ struct MCPGrepResponse {
         double confidence = 1.0;
         std::string matchId;
         size_t fileMatches = 0;
+        std::string hash;
     };
 
     std::string output;

--- a/src/app/services/document_service.cpp
+++ b/src/app/services/document_service.cpp
@@ -2048,7 +2048,10 @@ public:
         std::optional<metadata::DocumentInfo> foundDoc;
         if (ctx_.metadataRepo) {
             auto docResult = ctx_.metadataRepo->getDocumentByHash(resolvedHash);
-            if (docResult && docResult.value()) {
+            if (!docResult) {
+                return docResult.error();
+            }
+            if (docResult.value()) {
                 foundDoc = docResult.value();
             }
             if (!foundDoc) {

--- a/src/app/services/grep_service.cpp
+++ b/src/app/services/grep_service.cpp
@@ -901,6 +901,7 @@ public:
 
                     GrepFileResult fileResult;
                     fileResult.file = doc.filePath;
+                    fileResult.hash = doc.sha256Hash;
                     fileResult.fileName = std::filesystem::path(doc.filePath).filename().string();
                     fileResult.matchCount = 0;
                     size_t ln_counter = 0;
@@ -1358,6 +1359,7 @@ public:
                                     continue;
                                 GrepFileResult fr;
                                 fr.file = path;
+                                fr.hash = r.document.sha256Hash;
                                 fr.fileName = std::filesystem::path(path).filename().string();
                                 GrepMatch gm;
                                 gm.matchType = "semantic";

--- a/src/cli/commands/cat_command.cpp
+++ b/src/cli/commands/cat_command.cpp
@@ -39,9 +39,17 @@ public:
 
         auto* cmd = app.add_subcommand("cat", getDescription());
 
-        cmd->add_option("target", target_, "Document hash or path to display")
-            ->type_name("HASH|PATH")
-            ->required();
+        auto* selector = cmd->add_option_group("Content selector");
+        selector->require_option(1, 1);
+        selector->add_option("target", target_, "Document hash or path to display")
+            ->type_name("HASH|PATH");
+        selector->add_option("--hash", hash_, "Document hash or unambiguous hash prefix")
+            ->check(CLI::Validator(
+                [](const std::string& value) {
+                    return looksLikeHashPrefix(value) ? std::string{}
+                                                      : "Expected 6 to 64 hexadecimal characters";
+                },
+                "HASH"));
         // Disambiguation flags: select newest/oldest when multiple matches exist
         cmd->add_flag(
             "--latest", getLatest_,

--- a/src/cli/commands/file_history_json.h
+++ b/src/cli/commands/file_history_json.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <filesystem>
+#include <yams/cli/content_reference.h>
+#include <yams/daemon/ipc/ipc_protocol.h>
+
+namespace yams::cli {
+
+inline nlohmann::json fileHistoryToJson(const daemon::FileHistoryResponse& history) {
+    auto documents = nlohmann::json::array();
+    for (const auto& version : history.versions) {
+        nlohmann::json item = {
+            {"path", history.filepath},
+            {"name", std::filesystem::path(history.filepath).filename().string()},
+            {"snapshot_id", version.snapshotId},
+            {"size", version.size},
+            {"indexed", version.indexedTimestamp}};
+        addContentReference(item, version.hash);
+        documents.push_back(std::move(item));
+    }
+    return {{"documents", std::move(documents)},
+            {"total", history.versions.size()},
+            {"total_versions", history.totalVersions},
+            {"path", history.filepath},
+            {"found", history.found},
+            {"message", history.message}};
+}
+
+} // namespace yams::cli

--- a/src/cli/commands/grep_command.cpp
+++ b/src/cli/commands/grep_command.cpp
@@ -18,6 +18,7 @@
 #endif
 #include <vector>
 #include <yams/cli/command.h>
+#include <yams/cli/content_reference.h>
 #include <yams/cli/graph_helpers.h>
 #include <yams/cli/session_store.h>
 #include <yams/cli/ui_helpers.hpp>
@@ -502,6 +503,7 @@ public:
                         for (const auto& match : resp.matches) {
                             nlohmann::json m;
                             m["file"] = match.file;
+                            addContentReference(m, match.hash);
                             m["line_number"] = match.lineNumber;
                             m["line"] = match.line;
                             m["match_type"] = match.matchType;

--- a/src/cli/commands/list_command.cpp
+++ b/src/cli/commands/list_command.cpp
@@ -1,4 +1,5 @@
 #include <spdlog/spdlog.h>
+#include "file_history_json.h"
 #include <yams/app/services/factory.hpp>
 #include <yams/app/services/list_input_resolver.hpp>
 #include <yams/app/services/retrieval_service.h>
@@ -209,7 +210,7 @@ public:
         try {
             const bool cliOneShot = yams::cli::cli_one_shot_enabled();
 
-            if (jsonFlag_)
+            if (jsonFlag_ || (cli_ && cli_->getJsonOutput()))
                 format_ = "json";
             if (!metadataValuesRaw_.empty()) {
                 return listMetadataValues();
@@ -674,6 +675,11 @@ private:
             }
 
             const auto& history = response.value();
+
+            if (format_ == "json") {
+                std::cout << fileHistoryToJson(history).dump(2) << '\n';
+                return Result<void>();
+            }
 
             // Extract filename for display
             std::filesystem::path p(history.filepath);
@@ -1713,7 +1719,7 @@ private:
 
         for (const auto& doc : documents) {
             json d;
-            d["hash"] = doc.info.sha256Hash;
+            addContentReference(d, doc.info.sha256Hash);
             d["name"] = doc.info.fileName;
             d["path"] = doc.info.filePath;
             d["extension"] = doc.info.fileExtension;

--- a/src/cli/commands/search_command.cpp
+++ b/src/cli/commands/search_command.cpp
@@ -281,8 +281,7 @@ private:
             doc["title"] = item.title;
         if (!item.path.empty())
             doc["path"] = item.path;
-        if (showHash_ && !item.hash.empty())
-            doc["hash"] = item.hash;
+        addContentReference(doc, item.hash);
         doc["score"] = item.score;
         if (auto snippet = buildSnippet(item, 200))
             doc["snippet"] = *snippet;
@@ -1079,6 +1078,7 @@ public:
 
         try {
             invocationCwd_ = std::filesystem::current_path();
+            jsonOutput_ = jsonOutput_ || (cli_ && cli_->getJsonOutput());
             // Resolve base query from flags/stdin/file
             if (query_.empty()) {
                 if (!queryFile_.empty() && queryFile_ != "-") {
@@ -1369,6 +1369,7 @@ public:
     }
 
     boost::asio::awaitable<Result<void>> executeAsync() override {
+        jsonOutput_ = jsonOutput_ || (cli_ && cli_->getJsonOutput());
         const bool cliOneShot = yams::cli::cli_one_shot_enabled();
 
         // Build normalized arguments (copy of execute() preamble)

--- a/src/daemon/client/in_process_transport.cpp
+++ b/src/daemon/client/in_process_transport.cpp
@@ -77,14 +77,6 @@ Response make_stream_header(const Request& request) {
     return SuccessResponse{"Streaming response"};
 }
 
-bool is_control_request(const Request& request) {
-    return std::holds_alternative<ShutdownRequest>(request) ||
-           std::holds_alternative<PingRequest>(request) ||
-           std::holds_alternative<StatusRequest>(request) ||
-           std::holds_alternative<GetStatsRequest>(request) ||
-           std::holds_alternative<PrepareSessionRequest>(request);
-}
-
 } // namespace
 
 Result<std::shared_ptr<IClientTransport>>
@@ -167,11 +159,11 @@ boost::asio::awaitable<Result<void>> InProcessTransport::send_request_streaming(
 
                 auto immediate = co_await processor->process_streaming(request);
                 if (immediate.has_value()) {
+                    // Match the socket transport's non-chunked response contract:
+                    // the header carries the complete response, followed by completion.
+                    // Sending it again as a chunk duplicates content/results in collectors.
                     if (onHeader) {
                         onHeader(immediate.value());
-                    }
-                    if (onChunk && !is_control_request(request)) {
-                        (void)onChunk(immediate.value(), true);
                     }
                     if (onComplete) {
                         onComplete();

--- a/src/daemon/components/grep_result_window.cpp
+++ b/src/daemon/components/grep_result_window.cpp
@@ -45,6 +45,7 @@ bool isBinaryLike(const app::services::GrepMatch& match) {
 
 struct MatchIdentity {
     std::string file;
+    std::string hash;
     std::size_t lineNumber{0};
     std::string line;
 
@@ -57,6 +58,7 @@ struct MatchIdentityHash {
             return seed ^ (value + 0x9e3779b9U + (seed << 6U) + (seed >> 2U));
         };
         auto hash = std::hash<std::string>{}(identity.file);
+        hash = combine(hash, std::hash<std::string>{}(identity.hash));
         hash = combine(hash, std::hash<std::size_t>{}(identity.lineNumber));
         return combine(hash, std::hash<std::string>{}(identity.line));
     }
@@ -66,6 +68,7 @@ GrepMatch toDaemonMatch(const app::services::GrepFileResult& fileResult,
                         const app::services::GrepMatch& match) {
     GrepMatch output;
     output.file = fileResult.file;
+    output.hash = fileResult.hash;
     output.lineNumber = match.lineNumber;
     output.line = match.line;
     output.contextBefore = match.before;
@@ -90,6 +93,7 @@ Selection select(const std::vector<app::services::GrepFileResult>& fileResults,
             }
             MatchIdentity identity{
                 .file = fileResult.file,
+                .hash = fileResult.hash,
                 .lineNumber = match.lineNumber,
                 .line = normalizeLine(match.line),
             };

--- a/src/daemon/ipc/proto_serializer.cpp
+++ b/src/daemon/ipc/proto_serializer.cpp
@@ -2053,6 +2053,7 @@ template <> struct ProtoBinding<GrepResponse> {
             }
             m->set_match_type(match.matchType);
             m->set_confidence(match.confidence);
+            m->set_hash(match.hash);
         }
         o->set_total_matches(r.totalMatches);
         o->set_files_searched(r.filesSearched);
@@ -2083,6 +2084,7 @@ template <> struct ProtoBinding<GrepResponse> {
             }
             match.matchType = m.match_type();
             match.confidence = m.confidence();
+            match.hash = m.hash();
             r.matches.push_back(std::move(match));
         }
         r.totalMatches = i.total_matches();

--- a/src/mcp/mcp_server_handlers.cpp
+++ b/src/mcp/mcp_server_handlers.cpp
@@ -381,8 +381,8 @@ MCPServer::handleSearchDocuments(const MCPSearchRequest& req) {
             out.paths.push_back(std::move(path));
         }
         out.total = out.paths.size();
-        sendProgress("search", 100.0, "done");
-        co_return out;
+        // Retain compact result identities alongside paths for JSON hydration.
+        // The serializer omits snippets and scores in this mode.
     }
     // Full result objects (with robust path fallback)
     auto parseMetaFloat = [](const std::map<std::string, std::string>& md,
@@ -455,7 +455,7 @@ MCPServer::handleSearchDocuments(const MCPSearchRequest& req) {
     }
     // Optional diff parity: when includeDiff=true and pathPattern is a local file, attach a
     // structured diff to the matching search result.
-    if (req.includeDiff && !req.pathPattern.empty()) {
+    if (!req.pathsOnly && req.includeDiff && !req.pathPattern.empty()) {
         auto resolved = yams::app::services::resolveNameToPatternIfLocalFile(req.pathPattern);
         if (resolved.isLocalFile && resolved.absPath.has_value()) {
             try {
@@ -682,10 +682,20 @@ MCPServer::handleSearchDocuments(const MCPSearchRequest& req) {
                 if (!p.empty()) {
                     oss_ << "[S] " << p << "\n";
                 }
+                MCPGrepResponse::Match match;
+                match.file = p;
+                if (const auto hash = item.metadata.find("hash"); hash != item.metadata.end()) {
+                    match.hash = hash->second;
+                }
+                match.lineText = item.snippet;
+                match.matchType = "semantic";
+                match.confidence = item.score;
+                early.matches.push_back(std::move(match));
             }
             early.output = oss_.str();
             early.matchCount = 0;
             early.fileCount = sr.results.size();
+            early.semanticMatches = early.matches.size();
             co_return early;
         }
         // If semantic burst failed, fall through to standard grep
@@ -756,6 +766,7 @@ MCPServer::handleSearchDocuments(const MCPSearchRequest& req) {
 
         MCPGrepResponse::Match sm;
         sm.file = m.file;
+        sm.hash = m.hash;
         sm.lineNumber = m.lineNumber;
         sm.lineText = m.line;
         sm.contextBefore = m.contextBefore;

--- a/src/mcp/tool_registry.cpp
+++ b/src/mcp/tool_registry.cpp
@@ -1,8 +1,22 @@
+#include <algorithm>
 #include <yams/mcp/tool_registry.h>
 
 namespace yams::mcp {
 
 namespace {
+void addRetrievalReference(json& item, const std::string& hash) {
+    item["hash"] = hash.empty() ? json(nullptr) : json(hash);
+    item["hydration"] = nullptr;
+    if (hash.size() == 64 && std::all_of(hash.begin(), hash.end(), [](char c) {
+            return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+        })) {
+        item["hydration"] = {{"method", "get"},
+                             {"hash", hash},
+                             {"include_content", true},
+                             {"scope", "current_corpus"}};
+    }
+}
+
 // Tolerant numeric parsing: accept number, numeric-like string; ignore empty string
 static int parse_int_tolerant(const json& j, const char* key, int def) {
     if (!j.contains(key) || j[key].is_null())
@@ -164,7 +178,8 @@ MCPSearchResponse MCPSearchResponse::fromJson(const json& j) {
         for (const auto& result : j["results"]) {
             MCPSearchResponse::Result r;
             r.id = result.value("id", std::string{});
-            r.hash = result.value("hash", std::string{});
+            if (auto hash = result.find("hash"); hash != result.end() && hash->is_string())
+                r.hash = hash->get<std::string>();
             r.title = result.value("title", std::string{});
             r.path = result.value("path", std::string{});
             r.score = result.value("score", 0.0f);
@@ -227,19 +242,21 @@ json MCPSearchResponse::toJson() const {
 
     if (pathsOnly || !paths.empty()) {
         j["paths"] = paths;
-        return j; // paths_only mode
     }
 
     json results_array = json::array();
     for (const auto& result : results) {
         json r;
         r["id"] = result.id;
-        if (!result.hash.empty())
-            r["hash"] = result.hash;
+        addRetrievalReference(r, result.hash);
         if (!result.title.empty())
             r["title"] = result.title;
         if (!result.path.empty())
             r["path"] = result.path;
+        if (pathsOnly || !paths.empty()) {
+            results_array.push_back(std::move(r));
+            continue;
+        }
         r["score"] = result.score;
         if (!result.snippet.empty())
             r["snippet"] = result.snippet;
@@ -378,6 +395,8 @@ MCPGrepResponse MCPGrepResponse::fromJson(const json& j) {
         for (const auto& m : j["matches"]) {
             MCPGrepResponse::Match gm;
             gm.file = m.value("file", std::string{});
+            if (m.contains("hash") && m["hash"].is_string())
+                gm.hash = m["hash"].get<std::string>();
             gm.lineNumber = m.value("line_number", size_t{0});
             gm.lineText = m.value("line_text", std::string{});
             detail::readStringArray(m, "context_before", gm.contextBefore);
@@ -421,6 +440,7 @@ json MCPGrepResponse::toJson() const {
                 jm["match_id"] = m.matchId;
             if (m.fileMatches > 0)
                 jm["file_matches"] = m.fileMatches;
+            addRetrievalReference(jm, m.hash);
             arr.push_back(std::move(jm));
         }
         j["matches"] = std::move(arr);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -427,6 +427,16 @@ endif
 
 if catch2_dep.found()
 
+  catch2_retrieval_json_exe = executable('catch2_retrieval_json',
+    files('unit/cli/retrieval_json_catch2_test.cpp'),
+    include_directories: incs,
+    dependencies: [catch2_dep, catch2_main_dep, dependency('nlohmann_json')],
+    cpp_args: test_cpp_noerror_args,
+    install: false,
+  )
+  test('retrieval_json', catch2_retrieval_json_exe,
+    suite: ['catch2', 'unit', 'cli'], timeout: 30)
+
 #Daemon Test Suites(6 consolidated executables)
 #-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1711,6 +1711,7 @@ if catch2_dep.found()
       'unit/cli/cli_test_cleanup_listener.cpp',
       'unit/cli/add_command_stdin_catch2_test.cpp',
       'unit/cli/command_registry_catch2_test.cpp',
+      'unit/cli/content_roundtrip_catch2_test.cpp',
       'unit/cli/completion_command_catch2_test.cpp',
       'unit/cli/delete_command_catch2_test.cpp',
       'unit/cli/download_command_catch2_test.cpp',

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -108,8 +108,8 @@ src/cli/commands/model_command.cpp:1341:portability/env-read # reviewed raw envi
 src/cli/commands/model_command.cpp:1343:portability/env-read # reviewed raw environment read
 src/cli/commands/model_command.cpp:1344:portability/env-read # reviewed raw environment read
 src/cli/commands/repair_command.cpp:284:portability/env-read # reviewed raw environment read
-src/cli/commands/search_command.cpp:1054:portability/env-read # reviewed raw environment read
-src/cli/commands/search_command.cpp:1062:portability/env-read # reviewed raw environment read
+src/cli/commands/search_command.cpp:1053:portability/env-read # reviewed raw environment read
+src/cli/commands/search_command.cpp:1061:portability/env-read # reviewed raw environment read
 src/cli/commands/session_command.cpp:39:portability/env-read # reviewed raw environment read
 src/cli/commands/session_command.cpp:40:portability/env-read # reviewed raw environment read
 src/cli/commands/session_command.cpp:578:portability/env-read # reviewed raw environment read

--- a/tests/unit/app/services/document_service_test.cpp
+++ b/tests/unit/app/services/document_service_test.cpp
@@ -728,6 +728,19 @@ TEST_CASE("DocumentService - Listing", "[document][service][listing]") {
 TEST_CASE("DocumentService - Retrieval", "[document][service][retrieval]") {
     DocumentFixture fixture;
 
+    SECTION("Metadata lookup failures are not reported as missing documents") {
+        fixture.pool_->shutdown();
+        auto metadataResult = fixture.metadataRepo_->getDocumentByHash(fixture.testHash1_);
+        REQUIRE_FALSE(metadataResult);
+        RetrieveDocumentRequest request;
+        request.hash = fixture.testHash1_;
+        auto result = fixture.documentService_->retrieve(request);
+        REQUIRE_FALSE(result);
+        CHECK(result.error().code == metadataResult.error().code);
+        CHECK(result.error().message == metadataResult.error().message);
+        CHECK(result.error().code != ErrorCode::NotFound);
+    }
+
     SECTION("Retrieve document by hash") {
         REQUIRE_FALSE(fixture.testHash1_.empty());
 

--- a/tests/unit/cli/content_roundtrip_catch2_test.cpp
+++ b/tests/unit/cli/content_roundtrip_catch2_test.cpp
@@ -1,0 +1,179 @@
+#include <nlohmann/json.hpp>
+#include "../../../tools/yams-cli/logging.h"
+#include "../../common/test_helpers_catch2.h"
+#include <catch2/catch_test_macros.hpp>
+#include <yams/cli/command.h>
+#include <yams/cli/yams_cli.h>
+#include <yams/crypto/hasher.h>
+
+#include <filesystem>
+#include <iostream>
+#include <optional>
+#include <span>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace yams::cli {
+std::unique_ptr<ICommand> createCatCommand();
+}
+
+TEST_CASE("CLI cat accepts exactly one content selector", "[cli][cat][parser]") {
+    CLI::App app{"yams"};
+    auto command = yams::cli::createCatCommand();
+    command->registerCommand(app, nullptr);
+    app.get_subcommand("cat")->callback([] {});
+    const std::string hash(64, 'a');
+    SECTION("Explicit hash hydration") {
+        REQUIRE_NOTHROW(app.parse("cat --hash " + hash + " --raw"));
+    }
+    SECTION("Positional hash remains supported") {
+        REQUIRE_NOTHROW(app.parse("cat " + hash));
+    }
+    SECTION("Positional path remains supported") {
+        REQUIRE_NOTHROW(app.parse("cat evidence.txt"));
+    }
+    SECTION("Explicit hash prefix remains supported") {
+        REQUIRE_NOTHROW(app.parse("cat --hash abcdef"));
+    }
+    SECTION("Explicit hash must be hexadecimal") {
+        REQUIRE_THROWS_AS(app.parse("cat --hash " + std::string(64, 'z')), CLI::ParseError);
+    }
+    SECTION("Explicit hash must not be empty") {
+        REQUIRE_THROWS_AS(app.parse("cat --hash"), CLI::ParseError);
+    }
+    SECTION("A selector is required") {
+        REQUIRE_THROWS_AS(app.parse("cat --raw"), CLI::ParseError);
+    }
+    SECTION("Conflicting selectors are rejected") {
+        REQUIRE_THROWS_AS(app.parse("cat evidence.txt --hash " + hash), CLI::ParseError);
+    }
+}
+
+namespace {
+struct StreamCapture {
+    std::ostringstream output;
+    std::istringstream input;
+    std::streambuf* oldOutput;
+    std::streambuf* oldInput;
+    explicit StreamCapture(const std::string& payload)
+        : input(payload), oldOutput(std::cout.rdbuf(output.rdbuf())),
+          oldInput(std::cin.rdbuf(input.rdbuf())) {}
+    ~StreamCapture() {
+        std::cout.rdbuf(oldOutput);
+        std::cin.rdbuf(oldInput);
+        std::cin.clear();
+    }
+};
+
+std::pair<int, std::string> runCli(std::vector<std::string> args, const std::string& payload = {}) {
+    yams::cli::YamsCLI cli;
+    std::vector<char*> argv;
+    for (auto& arg : args)
+        argv.push_back(arg.data());
+    StreamCapture capture(payload);
+    const auto code = cli.run(static_cast<int>(argv.size()), argv.data());
+    return {code, capture.output.str()};
+}
+} // namespace
+
+TEST_CASE("CLI startup diagnostics do not contaminate content output", "[cli][logging]") {
+    const auto previousLogger = spdlog::default_logger();
+    std::ostringstream diagnostics;
+    struct RestoreLogging {
+        std::shared_ptr<spdlog::logger> previous;
+        ~RestoreLogging() { spdlog::set_default_logger(std::move(previous)); }
+    } restore{previousLogger};
+    StreamCapture content("");
+    yams::cli::initializeCliLogging(diagnostics);
+    spdlog::warn("startup-warning-probe");
+    spdlog::default_logger()->flush();
+    std::cout << "immutable content";
+    CHECK(content.output.str() == "immutable content");
+    CHECK(diagnostics.str().find("startup-warning-probe") != std::string::npos);
+}
+
+TEST_CASE("CLI acknowledged stdin content hydrates immediately by full hash", "[cli][roundtrip]") {
+    const auto root = yams::test::make_temp_dir("yams_content_roundtrip_");
+    struct Cleanup {
+        std::filesystem::path root;
+        ~Cleanup() {
+            std::error_code ec;
+            std::filesystem::remove_all(root, ec);
+        }
+    } cleanup{root};
+    yams::test::ScopedEnvVar embedded("YAMS_EMBEDDED", std::string("1"));
+    yams::test::ScopedEnvVar inDaemon("YAMS_IN_DAEMON", std::nullopt);
+    yams::test::ScopedEnvVar socket("YAMS_DAEMON_SOCKET", std::nullopt);
+    yams::test::ScopedEnvVar socketAlias("YAMS_DAEMON_SOCKET_PATH", std::nullopt);
+    yams::test::ScopedEnvVar config("YAMS_CONFIG", (root / "config.toml").string());
+    yams::test::ScopedEnvVar data("YAMS_DATA_DIR", (root / "data").string());
+    yams::test::ScopedEnvVar storage("YAMS_STORAGE", (root / "data").string());
+    yams::test::ScopedEnvVar vectors("YAMS_DISABLE_VECTORS", std::string("1"));
+    yams::test::ScopedEnvVar models("YAMS_SKIP_MODEL_LOADING", std::string("1"));
+    yams::test::ScopedEnvVar watcher("YAMS_DISABLE_SESSION_WATCHER", std::string("1"));
+    yams::test::ScopedEnvVar autostart("YAMS_CLI_DISABLE_DAEMON_AUTOSTART", std::string("1"));
+    std::string payload = "Immutable evidence\nsecond line\n\tindent\n";
+    bool checkSearch = true;
+    SECTION("Text is searchable and hydrates byte-for-byte") {}
+    SECTION("Multi-chunk binary content preserves embedded NUL bytes") {
+        payload.assign(131073, 'x');
+        payload[65535] = '\0';
+        payload[65536] = '\n';
+        payload.back() = '\0';
+        checkSearch = false;
+    }
+    const auto expectedHash =
+        yams::crypto::SHA256Hasher::hash(std::as_bytes(std::span(payload.data(), payload.size())));
+    const auto [added, output] =
+        runCli({"yams", "--data-dir", (root / "data").string(), "--json", "add", "-", "--name",
+                "evidence.txt", "--no-embeddings", "--sync"},
+               payload);
+    INFO(output);
+    REQUIRE(added == 0);
+    const auto response = nlohmann::json::parse(output);
+    REQUIRE(response.at("summary").at("failed") == 0);
+    const auto hash = response.at("results").at(0).at("hash").get<std::string>();
+    REQUIRE(hash.size() == 64);
+    CHECK(hash == expectedHash);
+    const auto [retrieved, content] =
+        runCli({"yams", "--data-dir", (root / "data").string(), "cat", hash, "--raw"});
+    INFO("Retrieved bytes: " << content.size());
+    REQUIRE(retrieved == 0);
+    CHECK(content == payload);
+
+    const auto [explicitCode, explicitContent] =
+        runCli({"yams", "--data-dir", (root / "data").string(), "cat", "--hash", hash, "--raw"});
+    REQUIRE(explicitCode == 0);
+    CHECK(explicitContent == payload);
+
+    // Explicit corpus selection must not leak content from the default corpus
+    // or reuse an embedded host belonging to another data directory.
+    const auto [wrongCorpusCode, wrongCorpusContent] =
+        runCli({"yams", "--data-dir", (root / "other-data").string(), "cat", hash, "--raw"});
+    CHECK(wrongCorpusCode != 0);
+    CHECK(wrongCorpusContent.empty());
+
+    if (!checkSearch)
+        return;
+
+    const auto [searched, searchOutput] =
+        runCli({"yams", "--data-dir", (root / "data").string(), "--json", "search", "Immutable",
+                "--type", "keyword"});
+    INFO(searchOutput);
+    REQUIRE(searched == 0);
+    const auto results = nlohmann::json::parse(searchOutput).at("results");
+    REQUIRE_FALSE(results.empty());
+    CHECK(results.at(0).at("hash") == hash);
+    CHECK(results.at(0).at("hydration").at("hash") == hash);
+
+    const auto [grepped, grepOutput] =
+        runCli({"yams", "--data-dir", (root / "data").string(), "grep", "Immutable", "--json"});
+    INFO(grepOutput);
+    REQUIRE(grepped == 0);
+    const auto matches = nlohmann::json::parse(grepOutput).at("matches");
+    REQUIRE_FALSE(matches.empty());
+    CHECK(matches.at(0).at("hash") == hash);
+    CHECK(matches.at(0).at("hydration").at("hash") == hash);
+}

--- a/tests/unit/cli/retrieval_json_catch2_test.cpp
+++ b/tests/unit/cli/retrieval_json_catch2_test.cpp
@@ -1,0 +1,63 @@
+#include "../../../src/cli/commands/file_history_json.h"
+#include <catch2/catch_test_macros.hpp>
+#include <yams/cli/result_renderer.h>
+
+namespace {
+struct CaptureOutput {
+    std::ostringstream stream;
+    std::streambuf* previous = std::cout.rdbuf(stream.rdbuf());
+    ~CaptureOutput() { std::cout.rdbuf(previous); }
+};
+} // namespace
+
+TEST_CASE("JSON results expose content identity and hydration independent of display flags",
+          "[cli][retrieval][json]") {
+    yams::metadata::DocumentInfo doc;
+    doc.id = 42;
+    doc.fileName = "evidence.txt";
+    doc.sha256Hash = std::string(64, 'a');
+    std::vector<yams::metadata::DocumentInfo> documents{doc};
+    CaptureOutput output;
+    auto renderer = yams::cli::createDocumentRenderer("", yams::cli::OutputFormat::JSON, false);
+    renderer.render("evidence", "list", documents);
+    const auto result = nlohmann::json::parse(output.stream.str()).at("results").at(0);
+    CHECK(result.at("hash") == doc.sha256Hash);
+    REQUIRE(result.contains("hydration"));
+    CHECK(result.at("hydration").at("hash") == doc.sha256Hash);
+    CHECK(result.at("hydration").at("method") == "cat");
+}
+
+TEST_CASE("JSON results explicitly report missing content identity", "[cli][retrieval][json]") {
+    yams::metadata::DocumentInfo doc;
+    doc.fileName = "unindexed.txt";
+    std::vector<yams::metadata::DocumentInfo> documents{doc};
+    CaptureOutput output;
+    yams::cli::createDocumentRenderer("", yams::cli::OutputFormat::JSON)
+        .render("unindexed", "list", documents);
+    const auto result = nlohmann::json::parse(output.stream.str()).at("results").at(0);
+    REQUIRE(result.contains("hash"));
+    CHECK(result.at("hash").is_null());
+    CHECK(result.at("hydration").is_null());
+}
+
+TEST_CASE("File history uses a document envelope for empty and populated responses",
+          "[cli][retrieval][json]") {
+    yams::daemon::FileHistoryResponse history;
+    history.filepath = "/evidence/note.txt";
+    auto empty = yams::cli::fileHistoryToJson(history);
+    CHECK(empty.at("documents").is_array());
+    CHECK(empty.at("documents").empty());
+    CHECK(empty.at("total") == 0);
+    CHECK(empty.at("found") == false);
+    history.found = true;
+    history.totalVersions = 3;
+    history.versions.push_back({"snapshot-1", std::string(64, 'b'), 123, 456});
+    const auto populated = yams::cli::fileHistoryToJson(history);
+    CHECK(populated.at("total") == 1);
+    CHECK(populated.at("total_versions") == 3);
+    const auto& doc = populated.at("documents").at(0);
+    CHECK(doc.at("hash") == std::string(64, 'b'));
+    CHECK(doc.at("hydration").at("hash") == doc.at("hash"));
+    CHECK(doc.at("snapshot_id") == "snapshot-1");
+    CHECK(doc.at("indexed") == 456);
+}

--- a/tests/unit/daemon/grep_result_window_catch2_test.cpp
+++ b/tests/unit/daemon/grep_result_window_catch2_test.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <any>
 
 #include <yams/daemon/client/global_io_context.h>
 #include <yams/daemon/components/grep_result_window.h>
@@ -11,6 +12,32 @@ GlobalIOContextInitializer::~GlobalIOContextInitializer() = default;
 } // namespace yams::daemon
 
 namespace {
+
+// Exercise the legacy field contract without depending on the protobuf codec.
+struct RecordedFields {
+    std::vector<std::any> values;
+    std::size_t offset{0};
+    template <typename T> RecordedFields& operator<<(const T& value) {
+        values.emplace_back(value);
+        return *this;
+    }
+    template <typename T> yams::Result<T> read() {
+        if (offset >= values.size())
+            return yams::ErrorCode::InvalidData;
+        const auto* value = std::any_cast<T>(&values[offset]);
+        if (!value)
+            return yams::ErrorCode::InvalidData;
+        ++offset;
+        return *value;
+    }
+    yams::Result<std::string> readString() { return read<std::string>(); }
+    yams::Result<std::vector<std::string>> readStringVector() {
+        return read<std::vector<std::string>>();
+    }
+    yams::Result<std::map<std::string, std::string>> readStringMap() {
+        return read<std::map<std::string, std::string>>();
+    }
+};
 
 yams::app::services::GrepMatch makeMatch(std::size_t lineNumber, std::string line) {
     yams::app::services::GrepMatch match;
@@ -30,6 +57,42 @@ makeFileResult(std::string file, std::vector<yams::app::services::GrepMatch> mat
 }
 
 } // namespace
+
+TEST_CASE("Legacy grep response appends identity without changing match layout",
+          "[daemon][grep][identity][serialization]") {
+    yams::daemon::GrepResponse response;
+    yams::daemon::GrepMatch match;
+    match.file = "evidence.txt";
+    match.hash = std::string(64, 'a');
+    response.matches = {match, match};
+    RecordedFields fields;
+    response.serialize(fields);
+    bool legacy = false;
+    SECTION("New response roundtrips hashes") {}
+    SECTION("Older response remains readable without hashes") {
+        fields.values.pop_back(); // Old response ends at pathsOnly.
+        legacy = true;
+    }
+    const auto result = yams::daemon::GrepResponse::deserialize(fields);
+    REQUIRE(result);
+    REQUIRE(result.value().matches.size() == 2);
+    for (const auto& decoded : result.value().matches) {
+        CHECK(decoded.file == match.file);
+        CHECK(decoded.hash == (legacy ? std::string{} : match.hash));
+    }
+}
+
+TEST_CASE("Grep result window preserves immutable revisions at the same path",
+          "[daemon][grep][result-window][identity]") {
+    auto first = makeFileResult("evidence.txt", {makeMatch(1, "same content")});
+    first.hash = std::string(64, 'a');
+    auto second = first;
+    second.hash = std::string(64, 'b');
+    const auto selected = yams::daemon::grep_result_window::select({first, second, first}, 0);
+    REQUIRE(selected.matches.size() == 2);
+    CHECK(selected.matches[0].hash == first.hash);
+    CHECK(selected.matches[1].hash == second.hash);
+}
 
 TEST_CASE("Grep result window deduplicates identities before applying its total cap",
           "[daemon][grep][result-window]") {

--- a/tests/unit/daemon/in_process_transport_catch2_test.cpp
+++ b/tests/unit/daemon/in_process_transport_catch2_test.cpp
@@ -219,6 +219,12 @@ TEST_CASE("InProcessTransport orders callbacks for unary requests",
         events.push_back(std::move(event));
     };
     yams::daemon::Request req = yams::daemon::StatusRequest{};
+    SECTION("Control response is delivered once") {}
+    SECTION("Non-control immediate error response is delivered once") {
+        yams::daemon::GetRequest get;
+        get.hash = std::string(64, 'f');
+        req = std::move(get);
+    }
 
     auto result = run_streaming(
         transport, req, [&](const yams::daemon::Response&) { recordEvent("header"); },

--- a/tests/unit/daemon/proto_serializer_catch2_test.cpp
+++ b/tests/unit/daemon/proto_serializer_catch2_test.cpp
@@ -11,6 +11,28 @@
 
 namespace yams::daemon::test {
 
+TEST_CASE("ProtoSerializer grep preserves immutable content identity",
+          "[proto][serializer][grep]") {
+    GrepResponse response;
+    GrepMatch indexed;
+    indexed.file = "evidence.txt";
+    indexed.hash = std::string(64, 'a');
+    response.matches.push_back(indexed);
+    GrepMatch legacy;
+    legacy.file = "unknown.txt";
+    response.matches.push_back(legacy);
+    Message message{};
+    message.payload = Response{response};
+    const auto encoded = ProtoSerializer::encode_payload(message);
+    REQUIRE(encoded);
+    const auto decoded = ProtoSerializer::decode_payload(std::span{encoded.value()});
+    REQUIRE(decoded);
+    const auto& result = std::get<GrepResponse>(std::get<Response>(decoded.value().payload));
+    REQUIRE(result.matches.size() == 2);
+    CHECK(result.matches[0].hash == indexed.hash);
+    CHECK(result.matches[1].hash.empty());
+}
+
 TEST_CASE("ProtoSerializer PingRequest roundtrip", "[proto][serializer][ping]") {
     PingRequest req{};
     req.timestamp = std::chrono::steady_clock::now();

--- a/tests/unit/mcp/mcp_daemon_dto_parsing_more_catch2_test.cpp
+++ b/tests/unit/mcp/mcp_daemon_dto_parsing_more_catch2_test.cpp
@@ -61,9 +61,11 @@ TEST_CASE(
         r.type = "hybrid";
         r.executionTimeMs = 7;
         r.paths = {"a.md", "b.md"};
-        MCPSearchResponse::Result ignored;
-        ignored.id = "ignored";
-        r.results.push_back(std::move(ignored));
+        MCPSearchResponse::Result reference;
+        reference.id = "reference";
+        reference.hash = std::string(64, 'a');
+        reference.snippet = "omitted in compact output";
+        r.results.push_back(std::move(reference));
 
         const auto j = r.toJson();
         CHECK(j["total"] == 3);
@@ -71,8 +73,12 @@ TEST_CASE(
         CHECK(j["execution_time_ms"] == 7);
         CHECK(j["paths"] == json::array({"a.md", "b.md"}));
 
-        // paths_only mode should return early without emitting results
-        CHECK_FALSE(j.contains("results"));
+        // Paths remain available, with compact identities but no snippet payload.
+        REQUIRE(j.at("results").size() == 1);
+        CHECK(j.at("results").at(0).at("hash") == std::string(64, 'a'));
+        CHECK(j.at("results").at(0).at("hydration").at("method") == "get");
+        CHECK_FALSE(j.at("results").at(0).contains("snippet"));
+        CHECK_FALSE(j.at("results").at(0).contains("score"));
     }
 
     {

--- a/tests/unit/mcp/mcp_tool_registry_dto_roundtrip_catch2_test.cpp
+++ b/tests/unit/mcp/mcp_tool_registry_dto_roundtrip_catch2_test.cpp
@@ -6,6 +6,27 @@
 
 using yams::mcp::json;
 
+TEST_CASE("MCP search references survive missing hashes and paths-only output",
+          "[mcp][dto][search][retrieval-reference]") {
+    yams::mcp::MCPSearchResponse response;
+    response.results.emplace_back();
+    auto missing = response.toJson();
+    REQUIRE(missing.at("results").at(0).contains("hash"));
+    CHECK(missing.at("results").at(0).at("hash").is_null());
+    CHECK(missing.at("results").at(0).at("hydration").is_null());
+    CHECK(yams::mcp::MCPSearchResponse::fromJson(missing).results.at(0).hash.empty());
+    response.results[0].hash = std::string(64, 'a');
+    response.pathsOnly = true;
+    response.paths = {"/source"};
+    auto paths = response.toJson();
+    REQUIRE(paths.at("paths") == response.paths);
+    REQUIRE(paths.contains("results"));
+    CHECK(paths.at("results").at(0).at("hash") == response.results[0].hash);
+    CHECK(paths.at("results").at(0).at("hydration").at("method") == "get");
+    CHECK(yams::mcp::MCPSearchResponse::fromJson(paths).results.at(0).hash ==
+          response.results[0].hash);
+}
+
 TEST_CASE("MCP DTO - SearchResponse includes anchors and truncation markers",
           "[mcp][dto][search][anchors][catch2]") {
     yams::mcp::MCPSearchResponse resp;
@@ -62,6 +83,7 @@ TEST_CASE("MCP DTO - GrepResponse preserves structured matches",
     m.confidence = 1.0;
     m.matchId = "src/mcp/mcp_server.cpp:4241:1";
     m.fileMatches = 16;
+    m.hash = std::string(64, 'a');
     resp.matches.push_back(m);
 
     json j = resp.toJson();
@@ -70,13 +92,28 @@ TEST_CASE("MCP DTO - GrepResponse preserves structured matches",
     REQUIRE(j["matches"].size() == 1);
     CHECK(j["output_truncated"].get<bool>());
     CHECK(j["output_max_bytes"] == 16384);
+    CHECK(j["matches"][0]["hash"] == m.hash);
+    CHECK(j["matches"][0]["hydration"]["hash"] == m.hash);
+    CHECK(j["matches"][0]["hydration"]["method"] == "get");
 
     auto back = yams::mcp::MCPGrepResponse::fromJson(j);
     REQUIRE(back.matches.size() == 1);
     CHECK(back.matches[0].file == "src/mcp/mcp_server.cpp");
     CHECK(back.matches[0].lineNumber == 4241);
     CHECK(back.matches[0].fileMatches == 16);
+    CHECK(back.matches[0].hash == m.hash);
     CHECK(back.outputTruncated);
+}
+
+TEST_CASE("MCP grep unknown identity stays explicitly unhydratable", "[mcp][dto][grep]") {
+    const auto legacy = yams::mcp::MCPGrepResponse::fromJson(
+        json{{"matches", json::array({json{{"file", "unknown.txt"}}})}});
+    const auto output = legacy.toJson();
+    CHECK(output.at("matches").at(0).at("hash").is_null());
+    CHECK(output.at("matches").at(0).at("hydration").is_null());
+    const auto roundtrip = yams::mcp::MCPGrepResponse::fromJson(output);
+    REQUIRE(roundtrip.matches.size() == 1);
+    CHECK(roundtrip.matches[0].hash.empty());
 }
 
 TEST_CASE("MCP DTO - GrepRequest preserves session and selector fields",

--- a/tools/yams-cli/logging.h
+++ b/tools/yams-cli/logging.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <spdlog/sinks/ostream_sink.h>
+#include <spdlog/spdlog.h>
+
+namespace yams::cli {
+
+// Install before constructing the CLI: command callbacks and embedded startup
+// can emit diagnostics before parsed logging flags have been applied.
+// The stream must outlive the logger; production uses the process-owned stderr.
+inline void initializeCliLogging(std::ostream& diagnostics = std::cerr) {
+    auto sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(diagnostics, true);
+    auto logger = std::make_shared<spdlog::logger>("yams-cli", std::move(sink));
+    logger->set_level(spdlog::level::warn);
+    logger->set_pattern("[%H:%M:%S] [%l] %v");
+    spdlog::set_default_logger(std::move(logger));
+}
+
+} // namespace yams::cli

--- a/tools/yams-cli/main.cpp
+++ b/tools/yams-cli/main.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include "logging.h"
 
 #include <spdlog/spdlog.h>
 #include <boost/asio/executor_work_guard.hpp>
@@ -66,8 +67,7 @@ int main(int argc, char* argv[]) {
         }
 
         // Set up logging with conservative default; YamsCLI::run() adjusts based on flags
-        spdlog::set_level(spdlog::level::warn);
-        spdlog::set_pattern("[%H:%M:%S] [%l] %v");
+        yams::cli::initializeCliLogging();
         yams::cli::cli_perf_trace("main.logging",
                                   std::chrono::duration_cast<std::chrono::microseconds>(
                                       std::chrono::steady_clock::now() - mainStart));


### PR DESCRIPTION
Stack 2/8; depends on stack/01-replica-derivation-readiness.

Summary:
- include content hashes consistently in JSON retrieval/list/history output
- expose hydration hints and preserve raw content bytes during hash round trips
- deliver immediate in-process responses exactly once
- propagate metadata lookup failures instead of misreporting missing documents

Validation:
- retrieval JSON: 17 assertions / 3 cases
- CLI content roundtrip: 28 assertions / 1 case
- document retrieval: 58 assertions / 1 case
- full search and exact rebased release build passed