### PR TITLE
fix(memory-sync): require explicit shared corpus scope

### DIFF
--- a/include/yams/daemon/daemon.h
+++ b/include/yams/daemon/daemon.h
@@ -8,6 +8,7 @@
 #include <yams/daemon/components/TuningConfig.h>
 #include <yams/daemon/resource/onnx_model_pool.h> // For DaemonConfig
 #include <yams/memory_sync/memory_sync.h>
+#include <yams/memory_sync/corpus_scope.h>
 #include <yams/storage/disk_pressure.h>
 
 #include <atomic>
@@ -127,6 +128,7 @@ struct DaemonConfig {
     /// No YAMS_* env knobs.
     struct MemorySyncPolicy {
         bool enabled{false};
+        memory_sync::CorpusScope corpusScope{memory_sync::CorpusScope::Personal};
         std::string nodeId;              // explicit stable daemon writer UUID
         std::string corpusId;            // stable replication-domain identifier
         std::uint64_t corpusEpoch{0};    // incompatible reset/migration generation

--- a/include/yams/memory_sync/corpus_scope.h
+++ b/include/yams/memory_sync/corpus_scope.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <string_view>
+
+namespace yams::memory_sync {
+
+// Scope applies to the entire local corpus, including derived vectors and graph
+// records. Document metadata is not a replication authorization mechanism.
+enum class CorpusScope { Personal, Shared, Invalid };
+
+inline CorpusScope parseCorpusScope(std::string_view value) {
+    if (value == "personal") {
+        return CorpusScope::Personal;
+    }
+    if (value == "shared") {
+        return CorpusScope::Shared;
+    }
+    return CorpusScope::Invalid;
+}
+
+} // namespace yams::memory_sync

--- a/include/yams/memory_sync/memory_sync_config.h
+++ b/include/yams/memory_sync/memory_sync_config.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include <yams/core/types.h>
+#include <yams/memory_sync/corpus_scope.h>
 #include <yams/memory_sync/memory_sync_service.h>
 #include <yams/storage/storage_backend.h>
 
@@ -56,6 +57,7 @@ inline bool isCanonicalCorpusId(std::string_view value) {
 
 struct MemorySyncDaemonConfig {
     bool enabled{false};
+    CorpusScope corpusScope{CorpusScope::Personal};
     std::string nodeId;                     /// explicit stable daemon writer UUID
     std::string corpusId;                   /// stable replication-domain identifier
     std::uint64_t corpusEpoch{0};           /// incompatible reset/migration generation
@@ -80,6 +82,9 @@ struct MemorySyncDaemonConfig {
         };
         if (const auto* v = get("enabled")) {
             cfg.enabled = parseBool(*v);
+        }
+        if (const auto* v = get("corpus_scope")) {
+            cfg.corpusScope = parseCorpusScope(*v);
         }
         if (const auto* v = get("node_id")) {
             cfg.nodeId = *v;
@@ -296,6 +301,11 @@ createMemorySyncService(const MemorySyncDaemonConfig& config,
                         WriterTrustFileReader trustFileReader = {}) {
     if (!config.enabled) {
         return Error{ErrorCode::InvalidState, "memory_sync is disabled"};
+    }
+    if (config.corpusScope != CorpusScope::Shared) {
+        return Error{ErrorCode::InvalidArgument,
+                     "replication requires memory_sync.corpus_scope=shared; keep personal "
+                     "memory in a separate data directory"};
     }
 
     if (!isCanonicalWriterUuid(config.nodeId)) {

--- a/src/daemon/components/ConfigResolver.cpp
+++ b/src/daemon/components/ConfigResolver.cpp
@@ -1659,6 +1659,14 @@ bool ConfigResolver::applyMemorySync(const ConfigSections& sections, DaemonConfi
     }
 
     auto policy = config.memorySync;
+    if (const auto it = section->second.find("corpus_scope"); it != section->second.end()) {
+        policy.corpusScope = yams::memory_sync::parseCorpusScope(it->second);
+        if (policy.corpusScope == yams::memory_sync::CorpusScope::Invalid) {
+            spdlog::warn("Config: memory_sync.corpus_scope must be personal or shared");
+            config.memorySync.enabled = false;
+            return false;
+        }
+    }
     const bool transportSpecified = section->second.contains("transport");
     if (const auto it = section->second.find("enabled"); it != section->second.end()) {
         const auto enabled = parseBoolValue(it->second);
@@ -1813,6 +1821,13 @@ bool ConfigResolver::applyMemorySync(const ConfigSections& sections, DaemonConfi
     if (!policy.enabled) {
         config.memorySync = std::move(policy);
         return true;
+    }
+    if (policy.corpusScope != yams::memory_sync::CorpusScope::Shared) {
+        spdlog::warn("Config: replication requires memory_sync.corpus_scope=shared; keep "
+                     "personal memory in a separate data directory");
+        policy.enabled = false;
+        config.memorySync = std::move(policy);
+        return false;
     }
     if (policy.transport != "direct" && policy.transport != "shared-store") {
         spdlog::warn("Config: disabling invalid memory_sync.transport '{}'", policy.transport);

--- a/src/daemon/components/service_manager/memory_sync.cpp
+++ b/src/daemon/components/service_manager/memory_sync.cpp
@@ -976,6 +976,11 @@ Result<void> ServiceManager::initializeMemorySync(const std::filesystem::path& d
     if (!policy.enabled) {
         return Result<void>();
     }
+    if (policy.corpusScope != memory_sync::CorpusScope::Shared) {
+        return Error{ErrorCode::InvalidArgument,
+                     "replication requires memory_sync.corpus_scope=shared; keep personal "
+                     "memory in a separate data directory"};
+    }
     if (policy.transport == "direct" &&
         (!policy.writerAuthRequired || policy.writerAuthManifestPath.empty())) {
         return Error{ErrorCode::InvalidArgument,
@@ -986,6 +991,7 @@ Result<void> ServiceManager::initializeMemorySync(const std::filesystem::path& d
     try {
         yams::memory_sync::MemorySyncDaemonConfig cfg;
         cfg.enabled = true;
+        cfg.corpusScope = policy.corpusScope;
         cfg.nodeId = policy.nodeId;
         cfg.corpusId = policy.corpusId;
         cfg.corpusEpoch = policy.corpusEpoch;

--- a/tests/integration/daemon/memory_sync_service_integration_test.cpp
+++ b/tests/integration/daemon/memory_sync_service_integration_test.cpp
@@ -163,6 +163,7 @@ yams::test::DaemonHarness::Options makeMemorySyncHarnessOptions(std::string node
     options.isolateState = true;
     options.configureDaemon = [nodeId, corpusId](yams::daemon::DaemonConfig& config) {
         config.memorySync.enabled = true;
+        config.memorySync.corpusScope = yams::memory_sync::CorpusScope::Shared;
         config.memorySync.nodeId = nodeId;
         config.memorySync.corpusId = corpusId;
         config.memorySync.corpusEpoch = 1;
@@ -177,6 +178,7 @@ yams::test::DaemonHarness::Options makeMemorySyncHarnessOptions(std::string node
          << "auto_repair = false\n\n"
          << "[memory_sync]\n"
          << "enabled = true\n"
+         << "corpus_scope = \"shared\"\n"
          << "node_id = \"" << nodeId << "\"\n"
          << "corpus_id = \"" << corpusId << "\"\n"
          << "corpus_epoch = 1\n"
@@ -206,6 +208,7 @@ TEST_CASE("Daemon refuses enabled memory sync when writer authentication cannot 
                                                 "startup-failure-corpus");
     options.configureDaemon = [](yams::daemon::DaemonConfig& config) {
         config.memorySync.enabled = true;
+        config.memorySync.corpusScope = yams::memory_sync::CorpusScope::Shared;
         config.memorySync.nodeId = "123e4567-e89b-42d3-a456-426614174099";
         config.memorySync.corpusId = "startup-failure-corpus";
         config.memorySync.corpusEpoch = 1;
@@ -232,6 +235,7 @@ TEST_CASE("Daemon memory sync periodically converges and stops cleanly",
     options.isolateState = true;
     options.configureDaemon = [](yams::daemon::DaemonConfig& config) {
         config.memorySync.enabled = true;
+        config.memorySync.corpusScope = yams::memory_sync::CorpusScope::Shared;
         config.memorySync.nodeId = "123e4567-e89b-42d3-a456-426614174000";
         config.memorySync.corpusId = "integration-corpus";
         config.memorySync.corpusEpoch = 1;
@@ -247,6 +251,7 @@ auto_repair = false
 
 [memory_sync]
 enabled = true
+corpus_scope = "shared"
 node_id = "123e4567-e89b-42d3-a456-426614174000"
 corpus_id = "integration-corpus"
 corpus_epoch = 1
@@ -1302,6 +1307,7 @@ TEST_CASE("Daemon temporary memory sync converges inside one session and cleans 
     options.isolateState = true;
     options.configureDaemon = [](yams::daemon::DaemonConfig& config) {
         config.memorySync.enabled = true;
+        config.memorySync.corpusScope = yams::memory_sync::CorpusScope::Shared;
         config.memorySync.nodeId = "123e4567-e89b-42d3-a456-426614174001";
         config.memorySync.corpusId = "temporary-integration-corpus";
         config.memorySync.corpusEpoch = 1;

--- a/tests/unit/daemon/components/config_resolver_test.cpp
+++ b/tests/unit/daemon/components/config_resolver_test.cpp
@@ -1580,6 +1580,7 @@ TEST_CASE("ConfigResolver applies typed memory-sync policy", "[daemon][config][m
          {{"enabled", "true"},
           {"node_id", "123e4567-e89b-42d3-a456-426614174000"},
           {"corpus_id", "corpus-a"},
+          {"corpus_scope", "shared"},
           {"corpus_epoch", "9"},
           {"backend", "filesystem"},
           {"path", "shared-memory"},
@@ -1618,6 +1619,28 @@ TEST_CASE("ConfigResolver applies typed memory-sync policy", "[daemon][config][m
     CHECK(config.memorySync.writerAuthManifestPath == "/secure/writers.json");
 }
 
+TEST_CASE("ConfigResolver requires explicit shared corpus scope for replication",
+          "[daemon][config][memory-sync][sharing]") {
+    ConfigResolver::ConfigSections sections = {
+        {"memory_sync",
+         {{"enabled", "true"},
+          {"transport", "shared-store"},
+          {"node_id", "123e4567-e89b-42d3-a456-426614174000"},
+          {"corpus_id", "corpus-a"},
+          {"corpus_epoch", "1"},
+          {"path", "shared-memory"}}},
+    };
+    DaemonConfig config;
+    CHECK_FALSE(ConfigResolver::applyMemorySync(sections, config));
+    CHECK_FALSE(config.memorySync.enabled);
+    sections["memory_sync"]["corpus_scope"] = "shared";
+    CHECK(ConfigResolver::applyMemorySync(sections, config));
+    CHECK(config.memorySync.enabled);
+    sections["memory_sync"]["corpus_scope"] = "personal";
+    CHECK_FALSE(ConfigResolver::applyMemorySync(sections, config));
+    CHECK_FALSE(config.memorySync.enabled);
+}
+
 TEST_CASE("Direct P2P defaults to operator-approved first contact",
           "[daemon][config][memory-sync][p2p][security]") {
     DaemonConfig config;
@@ -1631,6 +1654,7 @@ TEST_CASE("ConfigResolver rejects direct P2P without usable writer authenticatio
          {{"enabled", "true"},
           {"node_id", "123e4567-e89b-42d3-a456-426614174000"},
           {"corpus_id", "corpus-a"},
+          {"corpus_scope", "shared"},
           {"corpus_epoch", "9"},
           {"transport", "direct"},
           {"listen", "0.0.0.0:9721"},
@@ -1651,6 +1675,7 @@ TEST_CASE("ConfigResolver accepts authenticated direct P2P without a shared path
          {{"enabled", "true"},
           {"node_id", "123e4567-e89b-42d3-a456-426614174000"},
           {"corpus_id", "corpus-a"},
+          {"corpus_scope", "shared"},
           {"corpus_epoch", "9"},
           {"transport", "direct"},
           {"listen", "0.0.0.0:9721"},
@@ -1679,6 +1704,7 @@ TEST_CASE("ConfigResolver rejects direct P2P sync_interval_ms above the reconnec
          {{"enabled", "true"},
           {"node_id", "123e4567-e89b-42d3-a456-426614174000"},
           {"corpus_id", "corpus-a"},
+          {"corpus_scope", "shared"},
           {"corpus_epoch", "9"},
           {"transport", "direct"},
           {"listen", "0.0.0.0:9721"},
@@ -1698,6 +1724,7 @@ TEST_CASE("ConfigResolver infers shared-store for legacy backend path",
          {{"enabled", "true"},
           {"node_id", "123e4567-e89b-42d3-a456-426614174000"},
           {"corpus_id", "corpus-a"},
+          {"corpus_scope", "shared"},
           {"corpus_epoch", "9"},
           {"backend", "filesystem"},
           {"path", "shared-memory"}}},
@@ -1715,6 +1742,7 @@ TEST_CASE("ConfigResolver exposes explicit legacy migration mode",
          {{"enabled", "true"},
           {"node_id", "123e4567-e89b-42d3-a456-426614174000"},
           {"corpus_id", "corpus-a"},
+          {"corpus_scope", "shared"},
           {"corpus_epoch", "9"},
           {"backend", "filesystem"},
           {"path", "shared-memory"},
@@ -1735,6 +1763,7 @@ TEST_CASE("ConfigResolver rejects legacy migration for temporary mode",
          {{"enabled", "true"},
           {"node_id", "123e4567-e89b-42d3-a456-426614174000"},
           {"corpus_id", "corpus-a"},
+          {"corpus_scope", "shared"},
           {"corpus_epoch", "9"},
           {"backend", "filesystem"},
           {"path", "shared-memory"},
@@ -1755,6 +1784,7 @@ TEST_CASE("ConfigResolver rejects writer authentication during legacy migration"
          {{"enabled", "true"},
           {"node_id", "123e4567-e89b-42d3-a456-426614174000"},
           {"corpus_id", "corpus-a"},
+          {"corpus_scope", "shared"},
           {"corpus_epoch", "9"},
           {"backend", "filesystem"},
           {"path", "shared-memory"},
@@ -1786,6 +1816,7 @@ TEST_CASE("ConfigResolver bounds temporary session expiry",
          {{"enabled", "true"},
           {"node_id", "123e4567-e89b-42d3-a456-426614174000"},
           {"corpus_id", "corpus-a"},
+          {"corpus_scope", "shared"},
           {"corpus_epoch", "9"},
           {"backend", "filesystem"},
           {"path", "shared-memory"},

--- a/tests/unit/daemon/service_manager_catch2_test.cpp
+++ b/tests/unit/daemon/service_manager_catch2_test.cpp
@@ -522,10 +522,38 @@ TEST_CASE_METHOD(ServiceManagerFixture,
     CHECK((result.error().message.find(config_.dataDir.string()) != std::string::npos));
 }
 
+TEST_CASE_METHOD(ServiceManagerFixture, "ServiceManager rejects replication of a personal corpus",
+                 "[daemon][service_manager][sharing][security][config]") {
+    config_.memorySync.enabled = true;
+    config_.memorySync.nodeId = "123e4567-e89b-42d3-a456-42661417400a";
+    config_.memorySync.corpusId = "personal-corpus";
+    config_.memorySync.corpusEpoch = 1;
+    config_.memorySync.path = (config_.dataDir / "forbidden-sync-store").string();
+    SECTION("direct") {
+        config_.memorySync.transport = "direct";
+    }
+    SECTION("shared store") {
+        config_.memorySync.transport = "shared-store";
+    }
+    ServiceManager manager(config_, state_, lifecycleFsm_);
+    REQUIRE(manager.initialize().has_value());
+    boost::asio::io_context io;
+    compat::stop_source stopSource;
+    auto future = boost::asio::co_spawn(
+        io, manager.initializeAsyncAwaitable(stopSource.get_token()), boost::asio::use_future);
+    io.run();
+    const auto initialized = future.get();
+    REQUIRE_FALSE(initialized.has_value());
+    CHECK(initialized.error().message.find("corpus_scope=shared") != std::string::npos);
+    CHECK_FALSE(fs::exists(config_.memorySync.path));
+    CHECK_FALSE(fs::exists(config_.dataDir / "p2p" / "op-store"));
+}
+
 TEST_CASE_METHOD(ServiceManagerFixture,
                  "ServiceManager rejects direct P2P without usable writer authentication",
                  "[daemon][service_manager][p2p][security][config]") {
     config_.memorySync.enabled = true;
+    config_.memorySync.corpusScope = yams::memory_sync::CorpusScope::Shared;
     config_.memorySync.transport = "direct";
     config_.memorySync.nodeId = "123e4567-e89b-42d3-a456-42661417400a";
     config_.memorySync.corpusId = "missing-writer-auth";
@@ -555,6 +583,7 @@ TEST_CASE_METHOD(ServiceManagerFixture,
     std::ofstream(legacyObject) << "unsigned-history";
 
     config_.memorySync.enabled = true;
+    config_.memorySync.corpusScope = yams::memory_sync::CorpusScope::Shared;
     config_.memorySync.transport = "direct";
     config_.memorySync.nodeId = nodeId;
     config_.memorySync.corpusId = corpusId;
@@ -619,6 +648,7 @@ TEST_CASE_METHOD(ServiceManagerFixture, "ServiceManager rejects symbolic-link P2
     fs::create_symlink(victim, identity);
 
     config_.memorySync.enabled = true;
+    config_.memorySync.corpusScope = yams::memory_sync::CorpusScope::Shared;
     config_.memorySync.transport = "direct";
     config_.memorySync.nodeId = "123e4567-e89b-42d3-a456-42661417400a";
     config_.memorySync.corpusId = "identity-security-test";
@@ -653,6 +683,7 @@ TEST_CASE_METHOD(ServiceManagerFixture,
     grantUntrustedKeyAccess(testDir_ / "writer-private.pem", false);
 
     config_.memorySync.enabled = true;
+    config_.memorySync.corpusScope = yams::memory_sync::CorpusScope::Shared;
     config_.memorySync.transport = "direct";
     config_.memorySync.nodeId = nodeId;
     config_.memorySync.corpusId = corpusId;
@@ -689,6 +720,7 @@ TEST_CASE_METHOD(ServiceManagerFixture, "ServiceManager rejects writable direct 
     }
 
     config_.memorySync.enabled = true;
+    config_.memorySync.corpusScope = yams::memory_sync::CorpusScope::Shared;
     config_.memorySync.transport = "direct";
     config_.memorySync.nodeId = nodeId;
     config_.memorySync.corpusId = corpusId;

--- a/tests/unit/memory_sync/memory_sync_config_catch2_test.cpp
+++ b/tests/unit/memory_sync/memory_sync_config_catch2_test.cpp
@@ -94,11 +94,37 @@ TEST_CASE("MemorySyncDaemonConfig defaults to disabled", "[memory-sync][config]"
     CHECK(cfg.syncIntervalMs == 5000);
 }
 
+TEST_CASE("memory sync rejects personal or unknown corpus scope before opening a backend",
+          "[memory-sync][config][sharing]") {
+    for (const std::string scope : {"", "personal", "unknown"}) {
+        const auto path =
+            std::filesystem::temp_directory_path() /
+            ("yams-personal-scope-" +
+             std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+        std::map<std::string, std::string> flat = {
+            {"memory_sync.enabled", "true"},
+            {"memory_sync.node_id", "123e4567-e89b-42d3-a456-426614174000"},
+            {"memory_sync.corpus_id", "personal-corpus"},
+            {"memory_sync.corpus_epoch", "1"},
+            {"memory_sync.path", path.string()},
+        };
+        if (!scope.empty()) {
+            flat["memory_sync.corpus_scope"] = scope;
+        }
+        auto service = createMemorySyncService(MemorySyncDaemonConfig::fromToml(flat));
+        CHECK_FALSE(service.has_value());
+        CHECK_FALSE(std::filesystem::exists(path));
+        service = yams::Error{yams::ErrorCode::InvalidState, "test cleanup"};
+        std::filesystem::remove_all(path);
+    }
+}
+
 TEST_CASE("createMemorySyncService rejects omitted or placeholder writer identity",
           "[memory-sync][config][identity]") {
     for (const std::string nodeId : {"", "default"}) {
         MemorySyncDaemonConfig cfg;
         cfg.enabled = true;
+        cfg.corpusScope = CorpusScope::Shared;
         cfg.nodeId = nodeId;
         cfg.corpusId = "corpus-a";
         cfg.corpusEpoch = 1;
@@ -115,6 +141,7 @@ TEST_CASE("createMemorySyncService requires UUID writer and corpus identity",
           "[memory-sync][config][identity]") {
     MemorySyncDaemonConfig cfg;
     cfg.enabled = true;
+    cfg.corpusScope = CorpusScope::Shared;
     cfg.nodeId = "node-a";
     cfg.backend = "filesystem";
     cfg.path = std::filesystem::temp_directory_path().string();
@@ -161,6 +188,7 @@ TEST_CASE("authenticated writer manifest produces schema-v4 envelopes",
 
     MemorySyncDaemonConfig cfg;
     cfg.enabled = true;
+    cfg.corpusScope = CorpusScope::Shared;
     cfg.nodeId = std::string(writerId);
     cfg.corpusId = "corpus-a";
     cfg.corpusEpoch = 7;
@@ -220,6 +248,7 @@ TEST_CASE("authenticated writer recovery reports legacy unsigned history",
 
     MemorySyncDaemonConfig unsignedConfig;
     unsignedConfig.enabled = true;
+    unsignedConfig.corpusScope = CorpusScope::Shared;
     unsignedConfig.nodeId = std::string(writerId);
     unsignedConfig.corpusId = "corpus-a";
     unsignedConfig.corpusEpoch = 7;
@@ -286,6 +315,7 @@ TEST_CASE("authenticated writer mode rejects legacy migration and manifest misma
           "[memory-sync][config][auth][migration]") {
     MemorySyncDaemonConfig cfg;
     cfg.enabled = true;
+    cfg.corpusScope = CorpusScope::Shared;
     cfg.nodeId = "123e4567-e89b-42d3-a456-426614174000";
     cfg.corpusId = "corpus-a";
     cfg.corpusEpoch = 1;
@@ -308,6 +338,7 @@ TEST_CASE("createMemorySyncService rejects disabled config", "[memory-sync][conf
 TEST_CASE("createMemorySyncService rejects unknown backend", "[memory-sync][config]") {
     MemorySyncDaemonConfig cfg;
     cfg.enabled = true;
+    cfg.corpusScope = CorpusScope::Shared;
     cfg.backend = "ftp";
     cfg.path = "ftp://example.com";
     const auto svc = createMemorySyncService(cfg);
@@ -336,6 +367,7 @@ TEST_CASE("memory sync S3 target overrides primary bucket while retaining creden
 TEST_CASE("createMemorySyncService rejects s3 with a non-s3 URL", "[memory-sync][config]") {
     MemorySyncDaemonConfig cfg;
     cfg.enabled = true;
+    cfg.corpusScope = CorpusScope::Shared;
     cfg.backend = "s3";
     cfg.path = "/not/an/s3/url";
     const auto svc = createMemorySyncService(cfg);
@@ -351,6 +383,7 @@ TEST_CASE("temporary memory sync owns and cleans only its session namespace",
 
     MemorySyncDaemonConfig persistent;
     persistent.enabled = true;
+    persistent.corpusScope = CorpusScope::Shared;
     persistent.nodeId = "123e4567-e89b-42d3-a456-426614174000";
     persistent.corpusId = "corpus-a";
     persistent.corpusEpoch = 1;
@@ -404,6 +437,7 @@ TEST_CASE("temporary memory sync collects bounded stale session leases",
 
     MemorySyncDaemonConfig temporary;
     temporary.enabled = true;
+    temporary.corpusScope = CorpusScope::Shared;
     temporary.nodeId = "123e4567-e89b-42d3-a456-426614174001";
     temporary.corpusId = "corpus-a";
     temporary.corpusEpoch = 1;
@@ -438,6 +472,7 @@ TEST_CASE("createMemorySyncService builds a working filesystem service", "[memor
 
     MemorySyncDaemonConfig cfg;
     cfg.enabled = true;
+    cfg.corpusScope = CorpusScope::Shared;
     cfg.nodeId = "123e4567-e89b-42d3-a456-426614174000";
     cfg.corpusId = "corpus-a";
     cfg.corpusEpoch = 1;


### PR DESCRIPTION
Stack 3/8; depends on stack/02-retrieval-output-contracts.

Summary:
- separate personal and shared corpus configuration
- reject replication unless corpus_scope is explicitly shared
- keep private/local stores from becoming sync sources through visibility metadata alone

Boundary:
- this is a corpus/data-directory sync boundary, not a per-document ACL system

Validation:
- ConfigResolver, memory-sync, and ServiceManager coverage included
- full daemon-component and ServiceManager suites passed