### PR TITLE
feat(memory-sync): validate traceable task revision records

### DIFF
--- a/include/yams/memory_sync/task_record.h
+++ b/include/yams/memory_sync/task_record.h
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+
+#include <nlohmann/json.hpp>
+#include <yams/core/types.h>
+#include <yams/memory_sync/version_vector.h>
+
+namespace yams::memory_sync {
+
+inline constexpr std::string_view kTaskRecordPrefix = "task-record/";
+inline constexpr std::size_t kMaxTaskRecordBytes = 1024 * 1024;
+
+// A task identity survives source revisions. The publication key's final segment
+// is SHA-256 of the exact JSON bytes, not a mutable task-head alias. Supersession
+// references are revision hashes within the same task; they need not be locally
+// hydrated yet. They do not imply that either record is trusted or executable.
+inline Result<void> validateTaskRecordPublication(std::string_view key, std::string_view value,
+                                                  std::string_view contentHash) {
+    const auto invalid = [](std::string message) -> Result<void> {
+        return Error{ErrorCode::InvalidArgument, std::move(message)};
+    };
+    if (value.size() > kMaxTaskRecordBytes) {
+        return invalid("task record exceeds 1 MiB");
+    }
+    std::unordered_set<std::string> fieldNames;
+    bool duplicateField = false;
+    const auto record = nlohmann::json::parse(
+        value,
+        [&](int, nlohmann::json::parse_event_t event, nlohmann::json& parsed) {
+            if (event == nlohmann::json::parse_event_t::key) {
+                duplicateField |= !fieldNames.insert(parsed.get<std::string>()).second;
+            }
+            return true;
+        },
+        false);
+    if (!record.is_object() || duplicateField) {
+        return invalid("task record must be a JSON object without duplicate fields");
+    }
+    static constexpr std::array<std::string_view, 11> fields = {"schema",
+                                                                "task_id",
+                                                                "kind",
+                                                                "owner",
+                                                                "source_uri",
+                                                                "source_revision",
+                                                                "recorded_at_ms",
+                                                                "source_timestamp_ms",
+                                                                "supersedes",
+                                                                "ownership_semantics",
+                                                                "body"};
+    if (record.size() != fields.size() ||
+        !std::all_of(fields.begin(), fields.end(),
+                     [&](auto field) { return record.contains(field); })) {
+        return invalid("task record fields do not match yams.task-record/v1");
+    }
+    const auto text = [&](std::string_view field, std::size_t limit) {
+        const auto& item = record.at(field);
+        if (!item.is_string()) {
+            return false;
+        }
+        const auto& str = item.get_ref<const std::string&>();
+        return !str.empty() && str.size() <= limit &&
+               std::none_of(str.begin(), str.end(),
+                            [](unsigned char c) { return c < 32 || c == 127; });
+    };
+    if (record.at("schema") != "yams.task-record/v1" ||
+        record.at("ownership_semantics") != "record_only") {
+        return invalid(
+            "task claims are descriptive records, not acquired leases or fencing tokens");
+    }
+    if (!text("task_id", 36) || !text("owner", 128) || !text("source_uri", 4096) ||
+        !text("source_revision", 256) || !record.at("body").is_string()) {
+        return invalid(
+            "task record requires task identity, owner, source provenance and text body");
+    }
+    const auto& taskId = record.at("task_id").get_ref<const std::string&>();
+    if (taskId.size() != 36) {
+        return invalid("task_id must be a canonical lowercase UUID");
+    }
+    for (std::size_t i = 0; i < taskId.size(); ++i) {
+        const char c = taskId[i];
+        const bool separator = i == 8 || i == 13 || i == 18 || i == 23;
+        if (separator ? c != '-' : !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) {
+            return invalid("task_id must be a canonical lowercase UUID");
+        }
+    }
+    const auto& kind = record.at("kind");
+    if (kind != "claim" && kind != "note" && kind != "decision" && kind != "checkpoint" &&
+        kind != "completion") {
+        return invalid("unsupported task record kind");
+    }
+    for (const auto field : {"recorded_at_ms", "source_timestamp_ms"}) {
+        const auto& stamp = record.at(field);
+        const bool valid =
+            stamp.is_number_unsigned()
+                ? stamp.get<std::uint64_t>() > 0 &&
+                      stamp.get<std::uint64_t>() <= std::numeric_limits<std::int64_t>::max()
+                : stamp.is_number_integer() && stamp.get<std::int64_t>() > 0;
+        if (!valid) {
+            return invalid("task timestamps must be positive signed-64-bit Unix milliseconds");
+        }
+    }
+    const auto canonicalHash = [](std::string_view hash) {
+        return hash.size() == 64 && std::all_of(hash.begin(), hash.end(), [](char c) {
+                   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+               });
+    };
+    if (!canonicalHash(contentHash) ||
+        key != std::string(kTaskRecordPrefix) + taskId + "/" + std::string(contentHash)) {
+        return invalid("task record key must bind task_id and SHA-256 of the exact JSON bytes");
+    }
+    const auto& links = record.at("supersedes");
+    if (!links.is_array() || links.size() > 64) {
+        return invalid("supersedes must contain at most 64 revision hashes");
+    }
+    std::unordered_set<std::string> seen;
+    for (const auto& link : links) {
+        if (!link.is_string()) {
+            return invalid("supersession reference must be a SHA-256 hash");
+        }
+        const auto& hash = link.get_ref<const std::string&>();
+        if (!canonicalHash(hash) || hash == contentHash || !seen.insert(hash).second) {
+            return invalid(
+                "supersession references must be distinct non-self lowercase SHA-256 hashes");
+        }
+    }
+    return {};
+}
+
+} // namespace yams::memory_sync

--- a/src/daemon/components/service_manager/memory_sync.cpp
+++ b/src/daemon/components/service_manager/memory_sync.cpp
@@ -37,6 +37,8 @@
 #include <yams/memory_sync/memory_sync_config.h>
 #include <yams/memory_sync/memory_sync_service.h>
 #include <yams/memory_sync/records.h>
+#include <yams/memory_sync/task_record.h>
+#include <yams/crypto/hasher.h>
 #include <yams/metadata/metadata_sync_adapter.h>
 #include <yams/metadata/topology_sync_adapter.h>
 #include <yams/storage/storage_runtime_resolver.h>
@@ -181,6 +183,12 @@ Result<void> ServiceManager::publishMemorySync(const std::string& key, const std
     if (!namespacedKey) {
         return namespacedKey.error();
     }
+    if (key.starts_with(memory_sync::kTaskRecordPrefix)) {
+        const auto hash = crypto::SHA256Hasher::hash(std::as_bytes(std::span(value)));
+        if (auto valid = memory_sync::validateTaskRecordPublication(key, value, hash); !valid) {
+            return valid.error();
+        }
+    }
     std::vector<std::byte> bytes;
     bytes.reserve(value.size());
     for (const unsigned char byte : value) {
@@ -213,7 +221,14 @@ Result<std::string> ServiceManager::readMemorySyncCached(const std::string& key)
         return value.error();
     }
     const auto& bytes = value.value();
-    return std::string(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+    std::string text(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+    if (key.starts_with(memory_sync::kTaskRecordPrefix)) {
+        const auto hash = crypto::SHA256Hasher::hash(std::span<const std::byte>(bytes));
+        if (auto valid = memory_sync::validateTaskRecordPublication(key, text, hash); !valid) {
+            return Error{ErrorCode::InvalidData, valid.error().message};
+        }
+    }
+    return text;
 }
 
 Result<ServiceManager::MemorySyncStatus> ServiceManager::getMemorySyncStatus() const {

--- a/tests/unit/daemon/service_manager_catch2_test.cpp
+++ b/tests/unit/daemon/service_manager_catch2_test.cpp
@@ -40,6 +40,8 @@
 #include <yams/daemon/components/TuneAdvisor.h>
 #include <yams/daemon/daemon.h>
 #include <yams/memory_sync/writer_auth.h>
+#include <yams/memory_sync/memory_sync_service.h>
+#include <yams/crypto/hasher.h>
 #include <yams/metadata/database.h>
 
 namespace fs = std::filesystem;
@@ -520,6 +522,56 @@ TEST_CASE_METHOD(ServiceManagerFixture,
     CHECK((result.error().code == ErrorCode::IOError));
     CHECK((result.error().message.find("Failed to create data directory") != std::string::npos));
     CHECK((result.error().message.find(config_.dataDir.string()) != std::string::npos));
+}
+
+TEST_CASE_METHOD(ServiceManagerFixture,
+                 "Task record publication and reads validate immutable revision identity",
+                 "[daemon][service_manager][task-record]") {
+    storage::BackendConfig backendConfig;
+    backendConfig.localPath = config_.dataDir / "task-record-store";
+    auto backend = std::make_unique<storage::FilesystemBackend>();
+    REQUIRE(backend->initialize(backendConfig).has_value());
+    ServiceManager manager(config_, state_, lifecycleFsm_);
+    manager.testingSetMemorySyncService(std::make_unique<memory_sync::MemorySyncService>(
+        std::move(backend), memory_sync::MemorySyncConfig{"A", 50}));
+    auto* sync = manager.testingMemorySyncService();
+    const std::string taskId = "123e4567-e89b-42d3-a456-426614174000";
+    nlohmann::json record = {
+        {"schema", "yams.task-record/v1"},
+        {"task_id", taskId},
+        {"kind", "claim"},
+        {"owner", "agent-a"},
+        {"source_uri", "repo:src/search"},
+        {"source_revision", "git:9883a438"},
+        {"recorded_at_ms", 2000},
+        {"source_timestamp_ms", 1000},
+        {"supersedes", nlohmann::json::array()},
+        {"ownership_semantics", "record_only"},
+        {"body", "Investigating retrieval"},
+    };
+    const auto value = record.dump();
+    const auto hash = crypto::SHA256Hasher::hash(std::as_bytes(std::span(value)));
+    const auto key = "task-record/" + taskId + "/" + hash;
+    REQUIRE(manager.publishMemorySync(key, value).has_value());
+    REQUIRE(sync->syncOnce().has_value());
+    const auto hydrated = manager.readMemorySyncCached(key);
+    REQUIRE(hydrated.has_value());
+    CHECK(hydrated.value() == value);
+
+    record["body"] = "changed revision";
+    CHECK_FALSE(manager.publishMemorySync(key, record.dump()).has_value());
+    record["ownership_semantics"] = "acquired";
+    const auto acquired = record.dump();
+    const auto acquiredHash = crypto::SHA256Hasher::hash(std::as_bytes(std::span(acquired)));
+    CHECK_FALSE(manager.publishMemorySync("task-record/" + taskId + "/" + acquiredHash, acquired)
+                    .has_value());
+
+    // A remote/lower-level writer cannot bypass the typed read contract.
+    const auto namespaced = memory_sync::userLogicalKey(key);
+    REQUIRE(namespaced.has_value());
+    REQUIRE(sync->publish(namespaced.value(), std::as_bytes(std::span(acquired))).has_value());
+    REQUIRE(sync->syncOnce().has_value());
+    CHECK_FALSE(manager.readMemorySyncCached(key).has_value());
 }
 
 TEST_CASE_METHOD(ServiceManagerFixture, "ServiceManager rejects replication of a personal corpus",

--- a/tests/unit/memory_sync/records_catch2_test.cpp
+++ b/tests/unit/memory_sync/records_catch2_test.cpp
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 
 #include <yams/memory_sync/records.h>
+#include <yams/memory_sync/task_record.h>
 
 using namespace yams::memory_sync;
 
@@ -108,4 +109,69 @@ TEST_CASE("memory-sync record keys reject malformed envelope hashes", "[memory-s
     const auto key = recordIndexKey(MemoryStore::ContentBlob, "blob", envelope);
     REQUIRE_FALSE(key.has_value());
     CHECK(key.error().code == yams::ErrorCode::InvalidArgument);
+}
+
+TEST_CASE("task records bind traceability and descriptive ownership to a revision key",
+          "[memory-sync][records][task-record]") {
+    const std::string taskId = "123e4567-e89b-42d3-a456-426614174000";
+    const std::string key = "task-record/" + taskId + "/" + std::string(kHashA);
+    nlohmann::json record = {
+        {"schema", "yams.task-record/v1"},
+        {"task_id", taskId},
+        {"kind", "claim"},
+        {"owner", "agent-a"},
+        {"source_uri", "repo:src/search"},
+        {"source_revision", "git:9883a438"},
+        {"recorded_at_ms", 2000},
+        {"source_timestamp_ms", 1000},
+        {"supersedes", nlohmann::json::array({kHashB})},
+        {"ownership_semantics", "record_only"},
+        {"body", "Investigating retrieval"},
+    };
+    SECTION("valid revision") {
+        CHECK(validateTaskRecordPublication(key, record.dump(), kHashA).has_value());
+    }
+    SECTION("key cannot alias another task or revision") {
+        CHECK_FALSE(validateTaskRecordPublication(key, record.dump(), kHashB).has_value());
+        record["task_id"] = "223e4567-e89b-42d3-a456-426614174000";
+        CHECK_FALSE(validateTaskRecordPublication(key, record.dump(), kHashA).has_value());
+    }
+    SECTION("claims cannot advertise acquisition") {
+        record["ownership_semantics"] = "acquired";
+        CHECK_FALSE(validateTaskRecordPublication(key, record.dump(), kHashA).has_value());
+        record["ownership_semantics"] = "record_only";
+        record["fencing_token"] = 1;
+        CHECK_FALSE(validateTaskRecordPublication(key, record.dump(), kHashA).has_value());
+    }
+    SECTION("required provenance cannot be omitted") {
+        record.erase("source_revision");
+        CHECK_FALSE(validateTaskRecordPublication(key, record.dump(), kHashA).has_value());
+    }
+    SECTION("timestamps are positive integer milliseconds") {
+        for (const auto& value :
+             {nlohmann::json(0), nlohmann::json(-1), nlohmann::json(1.5), nlohmann::json("2000")}) {
+            record["recorded_at_ms"] = value;
+            CHECK_FALSE(validateTaskRecordPublication(key, record.dump(), kHashA).has_value());
+        }
+    }
+    SECTION("supersession links must be distinct non-self hashes") {
+        for (const auto& links :
+             {nlohmann::json::array({kHashA}), nlohmann::json::array({kHashB, kHashB}),
+              nlohmann::json::array({"unknown"})}) {
+            record["supersedes"] = links;
+            CHECK_FALSE(validateTaskRecordPublication(key, record.dump(), kHashA).has_value());
+        }
+    }
+    SECTION("supersession references use canonical lowercase hashes") {
+        record["supersedes"] = nlohmann::json::array({std::string(64, 'B')});
+        CHECK_FALSE(validateTaskRecordPublication(key, record.dump(), kHashA).has_value());
+    }
+    SECTION("invalid JSON and unknown schema are rejected") {
+        CHECK_FALSE(validateTaskRecordPublication(key, "not-json", kHashA).has_value());
+        auto duplicate = record.dump();
+        duplicate.insert(1, "\"ownership_semantics\":\"acquired\",");
+        CHECK_FALSE(validateTaskRecordPublication(key, duplicate, kHashA).has_value());
+        record["schema"] = "yams.task-record/v2";
+        CHECK_FALSE(validateTaskRecordPublication(key, record.dump(), kHashA).has_value());
+    }
 }


### PR DESCRIPTION
Stack 4/8; depends on stack/03-explicit-shared-corpus.

Summary:
- add stable task IDs, source revisions, timestamps, and supersession links
- validate revision and supersession invariants at the memory-sync boundary
- identify ownership mode explicitly as record_only

Boundary:
- these are traceable records, not leases, fencing tokens, or exclusive-execution claims

Validation:
- task-record and memory-sync tests included
- full daemon-component and ServiceManager suites passed