### PR TITLE
fix(daemon): harden async initialization and cancellation ownership

### DIFF
--- a/include/yams/daemon/components/AsyncInitOrchestrator.h
+++ b/include/yams/daemon/components/AsyncInitOrchestrator.h
@@ -114,12 +114,23 @@ public:
     /// Returns true if the coroutine finished (or was never started),
     /// false if the wait timed out.
     bool requestStopAndWait(std::chrono::milliseconds timeout) {
+        return waitForCompletionImpl(timeout, true);
+    }
+
+    /// Wait without requesting cancellation. A timeout preserves the owned future
+    /// so an embedded caller may return while initialization safely continues.
+    bool waitForCompletion(std::chrono::milliseconds timeout) {
+        return waitForCompletionImpl(timeout, false);
+    }
+
+private:
+    bool waitForCompletionImpl(std::chrono::milliseconds timeout, bool requestStop) {
         std::lock_guard waitLock(waitMutex_);
         const auto deadline = std::chrono::steady_clock::now() + timeout;
         std::future<void> future;
         {
             std::unique_lock lock(futureMutex_);
-            if (stopSource_.stop_possible()) {
+            if (requestStop && stopSource_.stop_possible()) {
                 stopSource_.request_stop();
             }
             if (!futureInstalled_.wait_until(lock, deadline,

--- a/include/yams/daemon/components/ServiceManager.h
+++ b/include/yams/daemon/components/ServiceManager.h
@@ -131,6 +131,10 @@ public:
     void startAsyncInit(std::promise<void>* barrierPromise = nullptr,
                         std::atomic<bool>* barrierSet = nullptr);
 
+    bool waitForAsyncInitCompletion(std::chrono::milliseconds timeout) {
+        return asyncInit_.waitForCompletion(timeout);
+    }
+
     void shutdown() override;
 
     void prepareForRestart() {

--- a/include/yams/daemon/components/ServiceManager.h
+++ b/include/yams/daemon/components/ServiceManager.h
@@ -497,6 +497,11 @@ public:
                                         std::uint64_t freePageCount, std::uint64_t pageSize) {
         return shouldAutoVacuum(databaseBytes, pageCount, freePageCount, pageSize);
     }
+    bool
+    testingEnsureDatabaseIntegrityOrRecover(const std::filesystem::path& path,
+                                            const std::shared_ptr<metadata::Database>& database) {
+        return ensureDatabaseIntegrityOrRecover(path, database);
+    }
 #endif
 
     // Graph Component (PBI-009)

--- a/include/yams/metadata/database.h
+++ b/include/yams/metadata/database.h
@@ -303,14 +303,19 @@ public:
 
     /**
      * @brief Run PRAGMA quick_check; fails if SQLite reports corruption.
-     * Bounded ~ 10s by setting a busy timeout. Suitable for pre-flight on
-     * daemon startup before migrations run. Transient SQLite lock/busy failures
+     * Lock waits use a 10s busy timeout; this does NOT bound scan duration.
+     * Suitable for pre-flight before migrations. Transient SQLite lock/busy failures
      * return ErrorCode::ResourceBusy and must not be treated as corruption;
      * corruption reported via quick_check rows or SQLITE_CORRUPT/NOTADB returns
      * ErrorCode::CorruptedData. On read-only connections, FTS5 inverted-index
      * validation cannot run and those rows alone are treated as success.
      */
     Result<void> checkIntegrity();
+    // Exclusive connection use required. Temporarily owns the connection's progress
+    // handler (no other progress handler may be installed by the caller); the
+    // predicate must not access this connection. Interruption is not
+    // evidence of corruption. The handler is removed before this call returns.
+    Result<void> checkIntegrity(const std::function<bool()>& shouldCancel);
 
     /**
      * @brief Begin transaction

--- a/src/daemon/components/ServiceManager.cpp
+++ b/src/daemon/components/ServiceManager.cpp
@@ -3047,7 +3047,17 @@ bool ServiceManager::openDatabaseOnce(const std::filesystem::path& dbPath,
 bool ServiceManager::ensureDatabaseIntegrityOrRecover(
     const std::filesystem::path& dbPath, const std::shared_ptr<metadata::Database>& database) {
     databaseIntegrityStampEligible_.store(false, std::memory_order_release);
-    auto integrity = database->checkIntegrity();
+    // This startup connection is owned by the blocking worker until validation
+    // finishes. Poll shutdown inside SQLite, rather than waiting until a potentially
+    // multi-minute scan completes while shutdown is joining this worker.
+    auto integrity = database->checkIntegrity(
+        [this] { return shutdownInvoked_.load(std::memory_order_acquire); });
+    if (shutdownInvoked_.load(std::memory_order_acquire) ||
+        (!integrity && integrity.error().code == ErrorCode::OperationCancelled)) {
+        spdlog::info("[ServiceManager] Metadata integrity check cancelled; preserving database");
+        database->close();
+        return false;
+    }
     if (integrity) {
         databaseIntegrityStampEligible_.store(true, std::memory_order_release);
         return true;
@@ -3085,6 +3095,12 @@ bool ServiceManager::ensureDatabaseIntegrityOrRecover(
     spdlog::error("[ServiceManager] Metadata DB integrity check failed: {}",
                   integrity.error().message);
     database->close();
+
+    // I/O errors, an unavailable connection, and other validation failures are not
+    // proof of corruption. Only confirmed structural corruption permits recovery.
+    if (integrity.error().code != ErrorCode::CorruptedData) {
+        return false;
+    }
 
     auto recovery = quarantineAndRecreate(dbPath);
     if (!recovery) {

--- a/src/daemon/embedded_service_host.cpp
+++ b/src/daemon/embedded_service_host.cpp
@@ -167,16 +167,16 @@ public:
             spdlog::warn("EmbeddedServiceHost background tasks failed to start: {}", e.what());
         }
 
-        std::promise<void> asyncInitCompletedPromise;
-        auto asyncInitCompletedFuture = asyncInitCompletedPromise.get_future();
-        serviceManager_->startAsyncInit(&asyncInitCompletedPromise, nullptr);
+        // Startup may return while initialization is still running. Wait on the
+        // ServiceManager-owned future, never lend a stack-local completion promise
+        // to a coroutine that can outlive this call.
+        serviceManager_->startAsyncInit();
 
         const auto initTimeoutSeconds = std::max(5, options_.initTimeoutSeconds);
         auto snap = serviceManager_->waitForServiceManagerTerminalState(initTimeoutSeconds);
         if (snap.state == ServiceManagerState::Ready) {
-            if (asyncInitCompletedFuture.valid() &&
-                asyncInitCompletedFuture.wait_for(std::chrono::seconds(initTimeoutSeconds)) ==
-                    std::future_status::timeout) {
+            if (!serviceManager_->waitForAsyncInitCompletion(
+                    std::chrono::seconds(initTimeoutSeconds))) {
                 lifecycleFsm_.dispatch(
                     FailureEvent{"Embedded ServiceManager async initialization timed out"});
                 return Error{ErrorCode::Timeout,

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -655,16 +655,52 @@ Result<void> Database::execute(const std::string& sql) {
 }
 
 Result<void> Database::checkIntegrity() {
+    return checkIntegrity({});
+}
+
+Result<void> Database::checkIntegrity(const std::function<bool()>& shouldCancel) {
     if (!db_) {
         return Error{ErrorCode::InvalidState, "Database not open"};
+    }
+
+    struct ProgressGuard {
+        sqlite3* db;
+        const std::function<bool()>& predicate;
+        bool installed{false};
+
+        static int poll(void* context) noexcept {
+            auto& self = *static_cast<ProgressGuard*>(context);
+            try {
+                return self.predicate() ? 1 : 0;
+            } catch (...) {
+                // Never unwind through SQLite's C callback frames.
+                return 1;
+            }
+        }
+        ~ProgressGuard() {
+            if (installed) {
+                sqlite3_progress_handler(db, 0, nullptr, nullptr);
+            }
+        }
+    } progress{db_, shouldCancel};
+    if (shouldCancel) {
+        if (ProgressGuard::poll(&progress)) {
+            return Error{ErrorCode::OperationCancelled, "integrity check cancelled before scan"};
+        }
+        sqlite3_progress_handler(db_, 1000, &ProgressGuard::poll, &progress);
+        progress.installed = true;
     }
 
     sqlite3_busy_timeout(db_, 10000);
 
     sqlite3_stmt* stmt = nullptr;
     int rc = sqlite3_prepare_v2(db_, "PRAGMA quick_check", -1, &stmt, nullptr);
+    std::unique_ptr<sqlite3_stmt, decltype(&sqlite3_finalize)> statement(stmt, sqlite3_finalize);
     if (rc != SQLITE_OK) {
         std::string err = sqlite3_errmsg(db_);
+        if ((rc & 0xff) == SQLITE_INTERRUPT) {
+            return Error{ErrorCode::OperationCancelled, "quick_check prepare interrupted: " + err};
+        }
         if (is_sqlite_busy_or_locked(rc) || is_transient_integrity_check_message(err)) {
             return Error{ErrorCode::ResourceBusy, "quick_check prepare failed: " + err};
         }
@@ -693,10 +729,13 @@ Result<void> Database::checkIntegrity() {
             break;
         }
     }
-    sqlite3_finalize(stmt);
+    statement.reset();
 
     if (rc != SQLITE_DONE && rc != SQLITE_ROW) {
         std::string err = sqlite3_errmsg(db_);
+        if ((rc & 0xff) == SQLITE_INTERRUPT) {
+            return Error{ErrorCode::OperationCancelled, "quick_check step interrupted: " + err};
+        }
         if (is_sqlite_busy_or_locked(rc) || is_transient_integrity_check_message(err)) {
             return Error{ErrorCode::ResourceBusy, "quick_check step failed: " + err};
         }

--- a/tests/unit/daemon/service_manager_catch2_test.cpp
+++ b/tests/unit/daemon/service_manager_catch2_test.cpp
@@ -454,6 +454,28 @@ TEST_CASE_METHOD(ServiceManagerFixture, "ServiceManager construction succeeds",
     REQUIRE_NOTHROW(ServiceManager(config_, state_, lifecycleFsm_));
 }
 
+TEST_CASE("Async initialization completion wait survives caller timeout",
+          "[daemon][service_manager][async-completion]") {
+    AsyncInitOrchestrator init;
+    REQUIRE(init.tryStart());
+    const auto token = init.getStopToken();
+
+    // A caller may time out before co_spawn installs its future.
+    CHECK_FALSE(init.waitForCompletion(std::chrono::milliseconds(0)));
+    CHECK_FALSE(token.stop_requested());
+
+    std::promise<void> completion;
+    init.setFuture(completion.get_future());
+    CHECK_FALSE(init.waitForCompletion(std::chrono::milliseconds(0)));
+    CHECK_FALSE(token.stop_requested());
+
+    // The future remains owned by the orchestrator, not the timed-out caller.
+    completion.set_value();
+    CHECK(init.waitForCompletion(std::chrono::milliseconds(0)));
+    CHECK_FALSE(token.stop_requested());
+    CHECK(init.requestStopAndWait(std::chrono::milliseconds(0)));
+}
+
 TEST_CASE_METHOD(ServiceManagerFixture, "ServiceManager getName returns correct component name",
                  "[daemon][service_manager]") {
     ServiceManager sm(config_, state_, lifecycleFsm_);

--- a/tests/unit/daemon/service_manager_catch2_test.cpp
+++ b/tests/unit/daemon/service_manager_catch2_test.cpp
@@ -1312,6 +1312,29 @@ TEST_CASE_METHOD(ServiceManagerFixture,
 }
 
 TEST_CASE_METHOD(ServiceManagerFixture,
+                 "ServiceManager preserves metadata when integrity validation cannot finish",
+                 "[daemon][service_manager][startup][integrity][cancellation]") {
+    const auto dbPath = metadataDbPath(config_);
+    seedMetadataDb(dbPath, "must-survive");
+    auto database = std::make_shared<metadata::Database>();
+    auto sm = std::make_shared<ServiceManager>(config_, state_, lifecycleFsm_);
+
+    SECTION("shutdown cancels validation without recovery") {
+        REQUIRE(database->open(dbPath.string(), metadata::ConnectionMode::ReadWrite));
+        sm->shutdown();
+    }
+    SECTION("an unavailable connection is not evidence of corruption") {
+        // The on-disk database is valid; the supplied connection is closed.
+    }
+
+    CHECK_FALSE(sm->testingEnsureDatabaseIntegrityOrRecover(dbPath, database));
+    database->close();
+    CHECK_FALSE(findQuarantinedFile(config_.dataDir).has_value());
+    CHECK(state_.readiness.databaseRecoveredFrom.empty());
+    CHECK(startupProbeRowCount(dbPath) == 1);
+}
+
+TEST_CASE_METHOD(ServiceManagerFixture,
                  "ServiceManager records recovery provenance for corrupt metadata DB startup",
                  "[daemon][service_manager][startup][recovery]") {
     config_.enableModelProvider = false;

--- a/tests/unit/metadata/database_corruption_catch2_test.cpp
+++ b/tests/unit/metadata/database_corruption_catch2_test.cpp
@@ -258,6 +258,46 @@ TEST_CASE("interrupted VACUUM does not emit SQL error log",
     db.close();
 }
 
+TEST_CASE("integrity checks support cancellation without poisoning the connection",
+          "[unit][metadata][integrity][cancellation]") {
+    Database db;
+    REQUIRE(db.open(":memory:", ConnectionMode::Memory));
+    REQUIRE(db.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)"));
+    REQUIRE(db.execute("WITH RECURSIVE n(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM n "
+                       "WHERE x<2000) INSERT INTO t SELECT x, 'payload' FROM n"));
+
+    SECTION("already cancelled") {
+        const auto result = db.checkIntegrity([] { return true; });
+        REQUIRE_FALSE(result);
+        CHECK(result.error().code == ErrorCode::OperationCancelled);
+    }
+    SECTION("cancel during SQLite execution") {
+        int polls = 0;
+        const auto result = db.checkIntegrity([&] { return ++polls >= 3; });
+        REQUIRE_FALSE(result);
+        CHECK(polls >= 3);
+        CHECK(result.error().code == ErrorCode::OperationCancelled);
+    }
+    SECTION("external SQLite interruption is not corruption") {
+        sqlite3_progress_handler(db.rawHandle(), 1, [](void*) { return 1; }, nullptr);
+        const auto result = db.checkIntegrity();
+        sqlite3_progress_handler(db.rawHandle(), 0, nullptr, nullptr);
+        REQUIRE_FALSE(result);
+        CHECK(result.error().code == ErrorCode::OperationCancelled);
+    }
+    SECTION("cancellation also preserves FTS validation state") {
+        REQUIRE(db.execute("CREATE VIRTUAL TABLE search_text USING fts5(payload)"));
+        REQUIRE(db.execute("INSERT INTO search_text SELECT payload FROM t"));
+        int polls = 0;
+        const auto result = db.checkIntegrity([&] { return ++polls >= 3; });
+        REQUIRE_FALSE(result);
+        CHECK(result.error().code == ErrorCode::OperationCancelled);
+    }
+    // No dangling progress callback and no persistent interrupt after return.
+    REQUIRE(db.checkIntegrity());
+    CHECK(countRows(db) == 2000);
+}
+
 TEST_CASE("transient integrity message classification", "[unit][metadata][corruption]") {
     using yams::metadata::testing_isTransientIntegrityCheckMessage;
 


### PR DESCRIPTION
Stack 5/8; depends on stack/04-traceable-task-records.

Summary:
- retain async initialization completion state until all waiters are safe
- distinguish integrity-validation cancellation from corruption
- avoid quarantining healthy databases during shutdown cancellation

Validation:
- full daemon-component suite: 1,374 assertions / 120 cases
- ServiceManager: 889 assertions; 54 passed, 1 skipped
- metadata corruption: 11,372 assertions / 23 cases