### PR TITLE
perf(search): reuse lexical scores and refill vector documents

### DIFF
--- a/include/yams/search/simeon_lexical_backend.h
+++ b/include/yams/search/simeon_lexical_backend.h
@@ -10,6 +10,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -213,6 +214,25 @@ public:
     struct TopCandidateDecision {
         const char* recipe_name = "Bm25SabSmooth";
         std::vector<TopCandidate> candidates;
+    };
+
+    /// Request-local, lazy scoring for one query and recipe. The backend must outlive
+    /// this session and must not be rebuilt while it is in use. Sessions are not shared
+    /// between threads or requests; failures are memoized as well as successful scores.
+    class QuerySession {
+    public:
+        QuerySession(const SimeonLexicalBackend& backend, std::string_view query,
+                     std::string_view arm = {})
+            : backend_(backend), query_(query), arm_(arm) {}
+        Result<RescoreDecision> score(std::span<const std::int64_t> documentIds);
+        Result<TopCandidateDecision> searchTop(std::size_t limit);
+
+    private:
+        Result<void> ensureScored();
+        const SimeonLexicalBackend& backend_;
+        std::string query_;
+        std::string arm_;
+        std::optional<Result<RescoreDecision>> scores_;
     };
 
     // Router-driven rescore: computes pre-retrieval QueryFeatures, picks a

--- a/include/yams/vector/vector_types.h
+++ b/include/yams/vector/vector_types.h
@@ -179,6 +179,9 @@ struct EntitySearchParams {
 /// Per-call backend work counters. A zero is meaningful only when its matching
 /// `*Observed` flag is true; ANN libraries do not always expose internal work.
 struct VectorSearchDiagnostics {
+    /// Number of samples merged by the search pipeline (zero for a backend sample).
+    size_t accumulatedSamples = 0;
+    size_t documentRefillAttempts = 0;
     bool usedAnn = false;
     bool usedExactScan = false;
     bool usedCandidateIndexCache = false;

--- a/src/search/search_engine.cpp
+++ b/src/search/search_engine.cpp
@@ -1587,37 +1587,6 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
                                             vector::CandidateFilterMode candidateFilterMode =
                                                 vector::CandidateFilterMode::BackendDefault)
         -> Result<std::vector<ComponentResult>> {
-        const auto mergeDiagnostics = [](vector::VectorSearchDiagnostics& total,
-                                         const vector::VectorSearchDiagnostics& sample) {
-            total.usedAnn = total.usedAnn || sample.usedAnn;
-            total.usedExactScan = total.usedExactScan || sample.usedExactScan;
-            total.usedCandidateIndexCache =
-                total.usedCandidateIndexCache || sample.usedCandidateIndexCache;
-            total.collectVisitedDocumentHashes =
-                total.collectVisitedDocumentHashes || sample.collectVisitedDocumentHashes;
-            total.visitedDocumentHashes.insert(sample.visitedDocumentHashes.begin(),
-                                               sample.visitedDocumentHashes.end());
-            total.rowsVisitedObserved = total.rowsVisitedObserved || sample.rowsVisitedObserved;
-            total.exactDistanceEvaluationsObserved =
-                total.exactDistanceEvaluationsObserved || sample.exactDistanceEvaluationsObserved;
-            total.annCandidateBudgetObserved =
-                total.annCandidateBudgetObserved || sample.annCandidateBudgetObserved;
-            total.rowsVisited += sample.rowsVisited;
-            total.exactDistanceEvaluations += sample.exactDistanceEvaluations;
-            total.annCandidateBudget += sample.annCandidateBudget;
-            total.candidateLookupCount += sample.candidateLookupCount;
-            total.candidateIndexPayloadBytes =
-                std::max(total.candidateIndexPayloadBytes, sample.candidateIndexPayloadBytes);
-            total.materializedRows += sample.materializedRows;
-            total.returnedRows += sample.returnedRows;
-            total.candidateLookupNanoseconds += sample.candidateLookupNanoseconds;
-            total.candidateProjectionNanoseconds += sample.candidateProjectionNanoseconds;
-            total.pqLutNanoseconds += sample.pqLutNanoseconds;
-            total.adcScoringNanoseconds += sample.adcScoringNanoseconds;
-            total.topKSelectionNanoseconds += sample.topKSelectionNanoseconds;
-            total.resultMaterializationNanoseconds += sample.resultMaterializationNanoseconds;
-            total.exactRerankNanoseconds += sample.exactRerankNanoseconds;
-        };
         const auto runVectorQuery = [&](const SearchEngineConfig& config) {
             vector::VectorSearchDiagnostics sample;
             sample.collectVisitedDocumentHashes =
@@ -1627,7 +1596,7 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
                                                  candidateFilterMode, &sample)
                               : queryVectorIndex(embedding, config, limit, &sample);
             if (diagnostics != nullptr) {
-                mergeDiagnostics(*diagnostics, sample);
+                detail::mergeVectorSearchDiagnostics(*diagnostics, sample);
             }
             return result;
         };
@@ -4382,6 +4351,8 @@ Result<SearchResponse> SearchEngine::Impl::searchInternal(const std::string& que
         std::to_string(graphDocExpansionFtsAddedCount);
     response.debugStats["graph_text_blocked_low_score_count"] =
         std::to_string(textExpansionStats.graphTextBlockedLowScoreCount);
+    response.debugStats["vector_document_refill_attempts"] =
+        std::to_string(vectorSearchDiagnostics.documentRefillAttempts);
     response.debugStats["simeon_direct_raw_hit_count"] =
         std::to_string(textExpansionStats.simeonDirectRawHitCount);
     response.debugStats["simeon_direct_added_count"] =

--- a/src/search/search_lexical_pipeline.cpp
+++ b/src/search/search_lexical_pipeline.cpp
@@ -76,10 +76,10 @@ void appendLexicalBatchAtRank(const std::string& query, QueryIntent queryIntent,
 }
 
 std::optional<yams::metadata::SearchResults>
-makeSimeonLexicalResults(const std::string& query, SimeonLexicalBackend* backend,
+makeSimeonLexicalResults(SimeonLexicalBackend::QuerySession* session,
                          const yams::metadata::SearchResults& searchResults,
-                         std::string* lastSimeonRouteRecipe, const SearchEngineConfig& config) {
-    if (!backend || !backend->ready() || searchResults.results.empty()) {
+                         std::string* lastSimeonRouteRecipe) {
+    if (!session || searchResults.results.empty()) {
         return std::nullopt;
     }
 
@@ -89,15 +89,7 @@ makeSimeonLexicalResults(const std::string& query, SimeonLexicalBackend* backend
         ids.push_back(r.document.id);
     }
 
-    auto decision = [&]() -> Result<SimeonLexicalBackend::RescoreDecision> {
-        if (!config.simeonBanditArm.empty()) {
-            return backend->scoreBanditRouted(query, config.simeonBanditArm, ids);
-        }
-        if (backend->hasStrategyRouter()) {
-            return backend->scoreStrategyRouted(query, ids);
-        }
-        return backend->scoreRouted(query, ids);
-    }();
+    auto decision = session->score(ids);
     if (!decision) {
         spdlog::debug("[simeon-lexical] score failed, keeping FTS5 scores: {}",
                       decision.error().message);
@@ -124,15 +116,14 @@ makeSimeonLexicalResults(const std::string& query, SimeonLexicalBackend* backend
     return rescored;
 }
 
-void appendSimeonLexicalBatch(const std::string& query, SimeonLexicalBackend* backend,
+void appendSimeonLexicalBatch(const std::string& query, SimeonLexicalBackend::QuerySession* session,
                               std::string* lastSimeonRouteRecipe, QueryIntent queryIntent,
                               const SearchEngineConfig& config,
                               const yams::metadata::SearchResults& searchResults,
                               float scorePenalty, std::unordered_set<std::string>& simeonSeenHashes,
                               std::vector<ComponentResult>& results,
                               QueryExpansionStats* expansionStats) {
-    auto simeonResults =
-        makeSimeonLexicalResults(query, backend, searchResults, lastSimeonRouteRecipe, config);
+    auto simeonResults = makeSimeonLexicalResults(session, searchResults, lastSimeonRouteRecipe);
     if (!simeonResults) {
         return;
     }
@@ -144,13 +135,13 @@ void appendSimeonLexicalBatch(const std::string& query, SimeonLexicalBackend* ba
 
 std::optional<yams::metadata::SearchResults> makeDirectSimeonLexicalResults(
     const std::shared_ptr<yams::metadata::MetadataRepository>& metadataRepo,
-    const std::string& query, SimeonLexicalBackend* backend, std::string* lastSimeonRouteRecipe,
-    const SearchEngineConfig& config, size_t limit, QueryExpansionStats* expansionStats) {
-    if (!metadataRepo || !backend || !backend->ready() || limit == 0) {
+    const std::string& query, SimeonLexicalBackend::QuerySession* session,
+    std::string* lastSimeonRouteRecipe, size_t limit, QueryExpansionStats* expansionStats) {
+    if (!metadataRepo || !session || limit == 0) {
         return std::nullopt;
     }
 
-    auto decision = backend->searchTop(query, limit, config.simeonBanditArm);
+    auto decision = session->searchTop(limit);
     if (!decision) {
         spdlog::debug("[simeon-lexical] direct candidate search failed: {}",
                       decision.error().message);
@@ -195,12 +186,12 @@ std::optional<yams::metadata::SearchResults> makeDirectSimeonLexicalResults(
 
 void appendDirectSimeonLexicalBatch(
     const std::shared_ptr<yams::metadata::MetadataRepository>& metadataRepo,
-    const std::string& query, SimeonLexicalBackend* backend, std::string* lastSimeonRouteRecipe,
-    QueryIntent queryIntent, const SearchEngineConfig& config, size_t limit,
-    std::unordered_set<std::string>& seenHashes, std::vector<ComponentResult>& results,
-    QueryExpansionStats* expansionStats) {
+    const std::string& query, SimeonLexicalBackend::QuerySession* session,
+    std::string* lastSimeonRouteRecipe, QueryIntent queryIntent, const SearchEngineConfig& config,
+    size_t limit, std::unordered_set<std::string>& seenHashes,
+    std::vector<ComponentResult>& results, QueryExpansionStats* expansionStats) {
     auto directResults = makeDirectSimeonLexicalResults(
-        metadataRepo, query, backend, lastSimeonRouteRecipe, config, limit, expansionStats);
+        metadataRepo, query, session, lastSimeonRouteRecipe, limit, expansionStats);
     if (!directResults || directResults->results.empty()) {
         return;
     }
@@ -217,9 +208,9 @@ void appendDirectSimeonLexicalBatch(
 
 Fts5CandidatePoolStats fetchFts5CandidatePool(
     const std::shared_ptr<yams::metadata::MetadataRepository>& metadataRepo,
-    SimeonLexicalBackend* backend, std::string* lastSimeonRouteRecipe, const std::string& query,
-    QueryIntent queryIntent, const SearchEngineConfig& config, size_t limit,
-    QueryExpansionStats* expansionStats, std::vector<ComponentResult>& results,
+    SimeonLexicalBackend::QuerySession* session, std::string* lastSimeonRouteRecipe,
+    const std::string& query, QueryIntent queryIntent, const SearchEngineConfig& config,
+    size_t limit, QueryExpansionStats* expansionStats, std::vector<ComponentResult>& results,
     std::unordered_set<std::string>& seenHashes,
     const std::function<std::vector<std::string>(const std::string&, size_t)>& subPhraseGenerator) {
     Fts5CandidatePoolStats stats;
@@ -237,7 +228,7 @@ Fts5CandidatePoolStats fetchFts5CandidatePool(
         stats.baseFtsHitCount = fts5Results.value().results.size();
         appendLexicalBatch(query, queryIntent, config, fts5Results.value(), 1.0f, true, &seenHashes,
                            ComponentResult::Source::Text, results, expansionStats);
-        appendSimeonLexicalBatch(query, backend, lastSimeonRouteRecipe, queryIntent, config,
+        appendSimeonLexicalBatch(query, session, lastSimeonRouteRecipe, queryIntent, config,
                                  fts5Results.value(), 1.0f, simeonSeenHashes, results,
                                  expansionStats);
     }
@@ -277,7 +268,7 @@ Fts5CandidatePoolStats fetchFts5CandidatePool(
                 appendLexicalBatch(query, queryIntent, config, expandedResults.value(), penalty,
                                    true, &seenHashes, ComponentResult::Source::Text, results,
                                    expansionStats);
-                appendSimeonLexicalBatch(query, backend, lastSimeonRouteRecipe, queryIntent, config,
+                appendSimeonLexicalBatch(query, session, lastSimeonRouteRecipe, queryIntent, config,
                                          expandedResults.value(), penalty, simeonSeenHashes,
                                          results, expansionStats);
                 spdlog::debug("queryFullText lexical expansion: base_hits={} expanded_hits={} "
@@ -343,7 +334,7 @@ Fts5CandidatePoolStats fetchFts5CandidatePool(
                 appendLexicalBatch(query, queryIntent, config, expandedResults.value(), penalty,
                                    true, &seenHashes, ComponentResult::Source::Text, results,
                                    expansionStats);
-                appendSimeonLexicalBatch(query, backend, lastSimeonRouteRecipe, queryIntent, config,
+                appendSimeonLexicalBatch(query, session, lastSimeonRouteRecipe, queryIntent, config,
                                          expandedResults.value(), penalty, simeonSeenHashes,
                                          results, expansionStats);
                 if (expansionStats != nullptr) {
@@ -566,7 +557,12 @@ std::vector<ComponentResult> queryFullTextPipeline(
     std::unordered_set<std::string> seenHashes;
     seenHashes.reserve(limit * 2);
 
-    const auto poolStats = fetchFts5CandidatePool(metadataRepo, backend, lastSimeonRouteRecipe,
+    std::optional<SimeonLexicalBackend::QuerySession> queryScores;
+    if (backend && backend->ready()) {
+        queryScores.emplace(*backend, query, config.simeonBanditArm);
+    }
+    auto* session = queryScores ? &*queryScores : nullptr;
+    const auto poolStats = fetchFts5CandidatePool(metadataRepo, session, lastSimeonRouteRecipe,
                                                   query, queryIntent, config, limit, expansionStats,
                                                   results, seenHashes, subPhraseGenerator);
     const size_t baseFtsHitCount = poolStats.baseFtsHitCount;
@@ -575,7 +571,7 @@ std::vector<ComponentResult> queryFullTextPipeline(
     const bool weakLexicalPool = baseFtsHitCount < config.weakQueryMinTextHits ||
                                  results.size() < config.weakQueryMinTextHits;
     if (weakLexicalPool) {
-        appendDirectSimeonLexicalBatch(metadataRepo, query, backend, lastSimeonRouteRecipe,
+        appendDirectSimeonLexicalBatch(metadataRepo, query, session, lastSimeonRouteRecipe,
                                        queryIntent, config, limit, seenHashes, results,
                                        expansionStats);
     }

--- a/src/search/search_vector_pipeline.cpp
+++ b/src/search/search_vector_pipeline.cpp
@@ -8,9 +8,48 @@
 #include <algorithm>
 #include <functional>
 #include <limits>
+#include <type_traits>
 #include <unordered_map>
 
 namespace yams::search::detail {
+
+void mergeVectorSearchDiagnostics(vector::VectorSearchDiagnostics& total,
+                                  const vector::VectorSearchDiagnostics& sample) {
+    const bool first = total.accumulatedSamples == 0;
+    const auto add = [](auto& target, auto value) {
+        const auto maximum = std::numeric_limits<std::remove_reference_t<decltype(target)>>::max();
+        target = value > maximum - target ? maximum : target + value;
+    };
+    add(total.accumulatedSamples, std::max<size_t>(1, sample.accumulatedSamples));
+    add(total.documentRefillAttempts, sample.documentRefillAttempts);
+    total.usedAnn |= sample.usedAnn;
+    total.usedExactScan |= sample.usedExactScan;
+    total.usedCandidateIndexCache |= sample.usedCandidateIndexCache;
+    total.collectVisitedDocumentHashes |= sample.collectVisitedDocumentHashes;
+    total.visitedDocumentHashes.insert(sample.visitedDocumentHashes.begin(),
+                                       sample.visitedDocumentHashes.end());
+    total.rowsVisitedObserved = sample.rowsVisitedObserved && (first || total.rowsVisitedObserved);
+    total.exactDistanceEvaluationsObserved = sample.exactDistanceEvaluationsObserved &&
+                                             (first || total.exactDistanceEvaluationsObserved);
+    total.annCandidateBudgetObserved =
+        sample.annCandidateBudgetObserved && (first || total.annCandidateBudgetObserved);
+    add(total.rowsVisited, sample.rowsVisited);
+    add(total.exactDistanceEvaluations, sample.exactDistanceEvaluations);
+    add(total.annCandidateBudget, sample.annCandidateBudget);
+    add(total.candidateLookupCount, sample.candidateLookupCount);
+    total.candidateIndexPayloadBytes =
+        std::max(total.candidateIndexPayloadBytes, sample.candidateIndexPayloadBytes);
+    add(total.materializedRows, sample.materializedRows);
+    add(total.returnedRows, sample.returnedRows);
+    add(total.candidateLookupNanoseconds, sample.candidateLookupNanoseconds);
+    add(total.candidateProjectionNanoseconds, sample.candidateProjectionNanoseconds);
+    add(total.pqLutNanoseconds, sample.pqLutNanoseconds);
+    add(total.adcScoringNanoseconds, sample.adcScoringNanoseconds);
+    add(total.topKSelectionNanoseconds, sample.topKSelectionNanoseconds);
+    add(total.resultMaterializationNanoseconds, sample.resultMaterializationNanoseconds);
+    add(total.exactRerankNanoseconds, sample.exactRerankNanoseconds);
+}
+
 namespace {
 
 std::string truncateSearchSnippet(const std::string& content, size_t maxLen) {
@@ -201,7 +240,7 @@ queryVectorIndexImpl(const std::shared_ptr<yams::metadata::MetadataRepository>& 
     std::vector<ComponentResult> results;
     results.reserve(limit);
 
-    if (!vectorDb) {
+    if (!vectorDb || limit == 0) {
         return results;
     }
 
@@ -212,15 +251,55 @@ queryVectorIndexImpl(const std::shared_ptr<yams::metadata::MetadataRepository>& 
             candidateFilterMode == vector::CandidateFilterMode::ExactDocumentComplete
                 ? -1.0F
                 : config.similarityThreshold;
-        params.diagnostics = diagnostics;
         if (candidates != nullptr) {
             params.candidate_hashes = *candidates;
             params.candidate_filter_mode = candidateFilterMode;
+            // DocumentTopK's backend selection is MAX. Averaging needs all matching
+            // chunk scores before document truncation; the PQ path already exact-scores
+            // every allowed row in this mode, so bypass its redundant ADC selection.
+            if (candidateFilterMode == vector::CandidateFilterMode::DocumentTopK &&
+                config.chunkAggregation != SearchEngineConfig::ChunkAggregation::MAX) {
+                params.candidate_filter_mode = vector::CandidateFilterMode::ExactDocumentComplete;
+                params.similarity_threshold = -1.0F;
+            }
         }
 
-        auto vectorRecords = vectorDb->search(embedding, params);
+        const auto search = [&]() {
+            vector::VectorSearchDiagnostics sample;
+            sample.collectVisitedDocumentHashes =
+                diagnostics && diagnostics->collectVisitedDocumentHashes;
+            params.diagnostics = diagnostics ? &sample : nullptr;
+            auto records = vectorDb->search(embedding, params);
+            if (diagnostics) {
+                mergeVectorSearchDiagnostics(*diagnostics, sample);
+            }
+            return records;
+        };
+        auto vectorRecords = search();
+        const auto rawCount = vectorRecords.size();
         if (!vectorRecords.empty()) {
             vectorRecords = aggregateChunkVectorScores(vectorRecords, config, limit);
+        }
+        // One bounded refill, only when chunk crowding filled the raw request. Keep
+        // exact controls and explicit document-complete modes unchanged. This improves
+        // document fill; it does not claim exhaustive document ranking.
+        if (candidateFilterMode == vector::CandidateFilterMode::BackendDefault &&
+            rawCount == params.k && vectorRecords.size() < limit &&
+            rawCount > vectorRecords.size()) {
+            const size_t available = vectorDb->getVectorCount();
+            const size_t larger = params.k > std::numeric_limits<size_t>::max() / 2
+                                      ? std::numeric_limits<size_t>::max()
+                                      : params.k * 2;
+            if (const auto next = std::min(available, larger); next > params.k) {
+                params.k = next;
+                auto expanded = aggregateChunkVectorScores(search(), config, limit);
+                if (expanded.size() >= vectorRecords.size()) {
+                    vectorRecords = std::move(expanded);
+                }
+                if (diagnostics) {
+                    ++diagnostics->documentRefillAttempts;
+                }
+            }
         }
         if (vectorRecords.empty()) {
             return results;

--- a/src/search/search_vector_pipeline_internal.h
+++ b/src/search/search_vector_pipeline_internal.h
@@ -24,6 +24,9 @@ class VectorDatabase;
 
 namespace yams::search::detail {
 
+void mergeVectorSearchDiagnostics(vector::VectorSearchDiagnostics& total,
+                                  const vector::VectorSearchDiagnostics& sample);
+
 Result<std::vector<ComponentResult>>
 queryVectorIndexPipeline(const std::shared_ptr<yams::metadata::MetadataRepository>& metadataRepo,
                          const std::shared_ptr<vector::VectorDatabase>& vectorDb,

--- a/src/search/simeon_lexical_backend.cpp
+++ b/src/search/simeon_lexical_backend.cpp
@@ -916,6 +916,18 @@ SimeonLexicalBackend::scoreRouted(std::string_view query,
 
     RescoreDecision decision;
     decision.recipe_name = recipe_label;
+    // QuerySession requests the backend's own dense ID order. Retain that score
+    // buffer directly instead of hashing every corpus ID to rebuild the same array.
+    if (candidate_doc_ids.data() == index_to_doc_id_.data() &&
+        candidate_doc_ids.size() == index_to_doc_id_.size()) {
+        for (size_t di = 0; di < full.size(); ++di) {
+            if (!std::isfinite(full[di])) {
+                full[di] = di < lexical.size() && std::isfinite(lexical[di]) ? lexical[di] : 0.0f;
+            }
+        }
+        decision.scores = std::move(full);
+        return decision;
+    }
     decision.scores.reserve(candidate_doc_ids.size());
     for (auto id : candidate_doc_ids) {
         auto it = doc_id_to_index_.find(id);
@@ -1055,6 +1067,16 @@ SimeonLexicalBackend::scoreStrategyRouted(std::string_view query,
 
     RescoreDecision decision;
     decision.recipe_name = recipe_label;
+    if (candidate_doc_ids.data() == index_to_doc_id_.data() &&
+        candidate_doc_ids.size() == index_to_doc_id_.size()) {
+        for (auto& score : full) {
+            if (!std::isfinite(score)) {
+                score = 0.0f;
+            }
+        }
+        decision.scores = std::move(full);
+        return decision;
+    }
     decision.scores.reserve(candidate_doc_ids.size());
     for (auto id : candidate_doc_ids) {
         auto it = doc_id_to_index_.find(id);
@@ -1130,6 +1152,17 @@ SimeonLexicalBackend::scoreBanditRouted(std::string_view query, std::string_view
 
     RescoreDecision decision;
     decision.recipe_name = recipe_label;
+    if (candidate_doc_ids.data() == index_to_doc_id_.data() &&
+        candidate_doc_ids.size() == index_to_doc_id_.size()) {
+        // The bandit scratch is thread-local and reused: the session must own a copy.
+        decision.scores = full;
+        for (auto& score : decision.scores) {
+            if (!std::isfinite(score)) {
+                score = 0.0f;
+            }
+        }
+        return decision;
+    }
     decision.scores.reserve(candidate_doc_ids.size());
     for (auto id : candidate_doc_ids) {
         auto it = doc_id_to_index_.find(id);
@@ -1147,31 +1180,69 @@ SimeonLexicalBackend::scoreBanditRouted(std::string_view query, std::string_view
 Result<SimeonLexicalBackend::TopCandidateDecision>
 SimeonLexicalBackend::searchTop(std::string_view query, std::size_t limit,
                                 std::string_view arm_name) const {
-    if (!ready_.load(std::memory_order_acquire) || !index_) {
+    ScoreTimingScope scoreTiming(*this);
+    QuerySession session(*this, query, arm_name);
+    return session.searchTop(limit);
+}
+
+Result<void> SimeonLexicalBackend::QuerySession::ensureScored() {
+    if (!scores_) {
+        if (!backend_.ready()) {
+            return Error{ErrorCode::NotInitialized, "SimeonLexicalBackend: not ready"};
+        }
+        scores_.emplace([&]() -> Result<RescoreDecision> {
+            if (!arm_.empty()) {
+                return backend_.scoreBanditRouted(query_, arm_, backend_.index_to_doc_id_);
+            }
+            if (backend_.hasStrategyRouter()) {
+                return backend_.scoreStrategyRouted(query_, backend_.index_to_doc_id_);
+            }
+            return backend_.scoreRouted(query_, backend_.index_to_doc_id_);
+        }());
+    }
+    if (!scores_->has_value()) {
+        return scores_->error();
+    }
+    return {};
+}
+
+Result<SimeonLexicalBackend::RescoreDecision>
+SimeonLexicalBackend::QuerySession::score(std::span<const std::int64_t> documentIds) {
+    auto scored = ensureScored();
+    if (!scored) {
+        return scored.error();
+    }
+    RescoreDecision result;
+    result.recipe_name = scores_->value().recipe_name;
+    result.scores.reserve(documentIds.size());
+    for (const auto id : documentIds) {
+        const auto found = backend_.doc_id_to_index_.find(id);
+        result.scores.push_back(found == backend_.doc_id_to_index_.end()
+                                    ? 0.0F
+                                    : scores_->value().scores[found->second]);
+    }
+    return result;
+}
+
+Result<SimeonLexicalBackend::TopCandidateDecision>
+SimeonLexicalBackend::QuerySession::searchTop(std::size_t limit) {
+    if (!backend_.ready()) {
         return Error{ErrorCode::NotInitialized, "SimeonLexicalBackend: not ready"};
     }
-    ScoreTimingScope scoreTiming(*this);
 
     TopCandidateDecision out;
+    const auto& index_to_doc_id_ = backend_.index_to_doc_id_;
     if (limit == 0 || index_to_doc_id_.empty()) {
         return out;
     }
 
-    auto decision = [&]() -> Result<RescoreDecision> {
-        if (!arm_name.empty()) {
-            return scoreBanditRouted(query, arm_name, index_to_doc_id_);
-        }
-        if (hasStrategyRouter()) {
-            return scoreStrategyRouted(query, index_to_doc_id_);
-        }
-        return scoreRouted(query, index_to_doc_id_);
-    }();
-    if (!decision) {
-        return Error{decision.error().code, decision.error().message};
+    auto scored = ensureScored();
+    if (!scored) {
+        return scored.error();
     }
 
-    out.recipe_name = decision.value().recipe_name;
-    const auto& scores = decision.value().scores;
+    out.recipe_name = scores_->value().recipe_name;
+    const auto& scores = scores_->value().scores;
     if (scores.size() != index_to_doc_id_.size()) {
         return Error{ErrorCode::InternalError, "SimeonLexicalBackend: direct score size mismatch"};
     }

--- a/tests/benchmarks/simeon_lexical_score_bench.cpp
+++ b/tests/benchmarks/simeon_lexical_score_bench.cpp
@@ -142,6 +142,43 @@ struct BucketLatency {
     double maxUs = 0.0;
 };
 
+BucketLatency measureRequestBatches(const SimeonLexicalBackend& backend,
+                                    const std::vector<std::string>& terms,
+                                    const std::vector<std::int64_t>& ids, int repeats,
+                                    bool reuseScores, size_t batches = 2,
+                                    bool includeDirect = true) {
+    std::vector<double> samples;
+    for (const auto& term : terms) {
+        for (int repeat = 0; repeat < repeats; ++repeat) {
+            const auto start = std::chrono::steady_clock::now();
+            if (reuseScores) {
+                SimeonLexicalBackend::QuerySession session(backend, term);
+                for (size_t batch = 0; batch < batches; ++batch) {
+                    REQUIRE(session.score(ids).has_value());
+                }
+                if (includeDirect) {
+                    REQUIRE(session.searchTop(32).has_value());
+                }
+            } else {
+                for (size_t batch = 0; batch < batches; ++batch) {
+                    REQUIRE(backend.scoreRouted(term, ids).has_value());
+                }
+                if (includeDirect) {
+                    REQUIRE(backend.searchTop(term, 32).has_value());
+                }
+            }
+            samples.push_back(
+                std::chrono::duration<double, std::micro>(std::chrono::steady_clock::now() - start)
+                    .count());
+        }
+    }
+    std::sort(samples.begin(), samples.end());
+    if (samples.empty()) {
+        return {};
+    }
+    return {samples[samples.size() / 2], samples[(samples.size() - 1) * 95 / 100], samples.back()};
+}
+
 BucketLatency measureBucket(const SimeonLexicalBackend& backend,
                             const std::vector<std::string>& terms,
                             const std::vector<std::int64_t>& docIds, int callsPerTerm) {
@@ -151,9 +188,9 @@ BucketLatency measureBucket(const SimeonLexicalBackend& backend,
         for (int c = 0; c < callsPerTerm; ++c) {
             const auto start = std::chrono::steady_clock::now();
             auto result = backend.score(term, docIds);
-            const auto us = std::chrono::duration<double, std::micro>(
-                                std::chrono::steady_clock::now() - start)
-                                .count();
+            const auto us =
+                std::chrono::duration<double, std::micro>(std::chrono::steady_clock::now() - start)
+                    .count();
             REQUIRE(result.has_value());
             samples.push_back(us);
         }
@@ -207,6 +244,22 @@ TEST_CASE("Simeon lexical score latency by IDF bucket", "[bench][simeon][score-i
 
     const auto common = measureBucket(backend, commonTerms, corpus->docIds, callsPerTerm);
     const auto rare = measureBucket(backend, rareTerms, corpus->docIds, callsPerTerm);
+    const auto callsBefore = backend.scoreCalls();
+    const auto separateRequests =
+        measureRequestBatches(backend, commonTerms, corpus->docIds, callsPerTerm, false);
+    const auto separateCalls = backend.scoreCalls() - callsBefore;
+    const auto sharedCallsBefore = backend.scoreCalls();
+    const auto sharedRequests =
+        measureRequestBatches(backend, commonTerms, corpus->docIds, callsPerTerm, true);
+    const auto sharedCalls = backend.scoreCalls() - sharedCallsBefore;
+    REQUIRE(separateCalls == sharedCalls * 3);
+    const std::vector<std::int64_t> smallBatch(corpus->docIds.begin(),
+                                               corpus->docIds.begin() +
+                                                   std::min<size_t>(32, corpus->docIds.size()));
+    const auto separateSingle =
+        measureRequestBatches(backend, commonTerms, smallBatch, callsPerTerm, false, 1, false);
+    const auto sharedSingle =
+        measureRequestBatches(backend, commonTerms, smallBatch, callsPerTerm, true, 1, false);
 
     SimeonLexicalBackend::Config cachedCfg;
     cachedCfg.score_cache_entries = 256;
@@ -227,6 +280,16 @@ TEST_CASE("Simeon lexical score latency by IDF bucket", "[bench][simeon][score-i
                 {"common_df_min", byFrequency[99].second},
                 {"rare_df_max", byFrequency[byFrequency.size() - 100].second},
                 {"common_p50_us", common.p50Us},
+                {"routed_separate_batches_p50_us", separateRequests.p50Us},
+                {"routed_shared_batches_p50_us", sharedRequests.p50Us},
+                {"routed_separate_batches_p95_us", separateRequests.p95Us},
+                {"routed_shared_batches_p95_us", sharedRequests.p95Us},
+                {"routed_separate_score_calls", separateCalls},
+                {"routed_shared_score_calls", sharedCalls},
+                {"routed_separate_single_batch_p50_us", separateSingle.p50Us},
+                {"routed_shared_single_batch_p50_us", sharedSingle.p50Us},
+                {"routed_separate_single_batch_p95_us", separateSingle.p95Us},
+                {"routed_shared_single_batch_p95_us", sharedSingle.p95Us},
                 {"common_p95_us", common.p95Us},
                 {"common_max_us", common.maxUs},
                 {"rare_p50_us", rare.p50Us},

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -166,7 +166,7 @@ src/plugins/plugin_repo_client.cpp:62:portability/env-read # reviewed raw enviro
 src/search/search_engine.cpp:378:portability/env-read # reviewed raw environment read
 src/search/search_engine.cpp:391:portability/env-read # reviewed raw environment read
 src/search/search_engine.cpp:3165:portability/env-read # reviewed raw environment read
-src/search/search_lexical_pipeline.cpp:605:portability/env-read # reviewed raw environment read
+src/search/search_lexical_pipeline.cpp:601:portability/env-read # reviewed raw environment read
 src/storage/compressed_storage_engine.cpp:632:portability/env-read # reviewed raw environment read
 src/storage/object_storage_plugin_loader.cpp:126:portability/env-read # reviewed raw environment read
 src/storage/object_storage_plugin_loader.cpp:130:portability/env-read # reviewed raw environment read
@@ -389,7 +389,7 @@ tests/benchmarks/search/retrieval_quality_bench.cpp:9167:portability/env-read # 
 tests/benchmarks/search/retrieval_quality_bench.cpp:9289:portability/env-read # reviewed raw environment read
 tests/benchmarks/search/simeon_arm_quality_bench.cpp:67:portability/env-read # reviewed raw environment read
 tests/benchmarks/search/simeon_arm_quality_bench.cpp:236:portability/env-read # reviewed raw environment read
-tests/benchmarks/simeon_lexical_score_bench.cpp:179:portability/env-read # reviewed raw environment read
+tests/benchmarks/simeon_lexical_score_bench.cpp:216:portability/env-read # reviewed raw environment read
 tests/benchmarks/single_client_pipeline_bench.cpp:65:portability/env-read # reviewed raw environment read
 tests/benchmarks/single_client_pipeline_bench.cpp:205:portability/env-read # reviewed raw environment read
 tests/benchmarks/single_client_pipeline_bench.cpp:272:portability/env-read # reviewed raw environment read
@@ -504,7 +504,7 @@ tests/unit/search/kg_scorer_simple_catch2_test.cpp:32:portability/env-read # rev
 tests/unit/search/search_engine_simeon_lexical_catch2_test.cpp:25:portability/env-read # reviewed raw environment read
 tests/unit/search/search_engine_topology_catch2_test.cpp:43:portability/env-read # reviewed raw environment read
 tests/unit/search/simeon_bandit_backend_catch2_test.cpp:30:portability/env-read # reviewed raw environment read
-tests/unit/search/simeon_lexical_backend_catch2_test.cpp:26:portability/env-read # reviewed raw environment read
+tests/unit/search/simeon_lexical_backend_catch2_test.cpp:27:portability/env-read # reviewed raw environment read
 tests/unit/topology/topology_baseline_catch2_test.cpp:64:portability/env-read # reviewed raw environment read
 tests/unit/vector/sqlite_vec_backend_comprehensive_catch2_test.cpp:42:portability/env-read # reviewed raw environment read
 tests/unit/vector/sqlite_vec_backend_comprehensive_catch2_test.cpp:48:portability/env-read # reviewed raw environment read

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -165,7 +165,7 @@ src/metadata/versioning_util.cpp:101:portability/env-read # reviewed raw environ
 src/plugins/plugin_repo_client.cpp:62:portability/env-read # reviewed raw environment read
 src/search/search_engine.cpp:378:portability/env-read # reviewed raw environment read
 src/search/search_engine.cpp:391:portability/env-read # reviewed raw environment read
-src/search/search_engine.cpp:3165:portability/env-read # reviewed raw environment read
+src/search/search_engine.cpp:3134:portability/env-read # reviewed raw environment read
 src/search/search_lexical_pipeline.cpp:601:portability/env-read # reviewed raw environment read
 src/storage/compressed_storage_engine.cpp:632:portability/env-read # reviewed raw environment read
 src/storage/object_storage_plugin_loader.cpp:126:portability/env-read # reviewed raw environment read

--- a/tests/unit/search/search_engine_simeon_lexical_catch2_test.cpp
+++ b/tests/unit/search/search_engine_simeon_lexical_catch2_test.cpp
@@ -210,6 +210,27 @@ TEST_CASE("Simeon backend can generate direct top candidates",
     CHECK(top.value().candidates.front().score > 0.0F);
 }
 
+TEST_CASE("Simeon scores an expanded lexical request only once",
+          "[search][simeon][request-scores][catch2]") {
+    auto corpus = makeCorpus(kCorpus);
+    auto config = makeLexicalOnlyConfig();
+    config.enableLexicalExpansion = true;
+    config.lexicalExpansionMinHits = 100;
+    config.weakQueryMinTextHits = 100;
+    auto engine = makeEngine(corpus, config);
+    auto backend = std::make_unique<SimeonLexicalBackend>(SimeonLexicalBackend::Config{});
+    auto* scorer = backend.get();
+    engine->setSimeonLexicalBackend(std::move(backend));
+    REQUIRE(waitReady(*scorer, std::chrono::seconds(5)));
+    const auto before = scorer->scoreCalls();
+    SearchParams params;
+    params.limit = 10;
+    const auto result = engine->search("alpha beta", params);
+    REQUIRE(result.has_value());
+    REQUIRE_FALSE(result.value().empty());
+    CHECK(scorer->scoreCalls() - before == 1U);
+}
+
 TEST_CASE("SearchEngine uses direct Simeon candidates for weak FTS queries",
           "[search][simeon][integration][catch2]") {
     auto corpus = makeCorpus(kCorpus);

--- a/tests/unit/search/search_vector_pipeline_catch2_test.cpp
+++ b/tests/unit/search/search_vector_pipeline_catch2_test.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
@@ -109,6 +110,47 @@ TEST_CASE("Vector pipeline scores every admitted document before exact-control t
     CHECK(diagnostics.rowsVisited == 3U);
     CHECK(diagnostics.exactDistanceEvaluations == 3U);
     CHECK(diagnostics.returnedRows == 3U);
+
+    cfg.similarityThreshold = -1.0F;
+    yams::vector::VectorSearchDiagnostics refillWork;
+    const auto global = yams::search::detail::queryVectorIndexPipeline(
+        nullptr, vectorDb, {1.0F, 0.0F}, cfg, 2, &refillWork);
+    REQUIRE(global.has_value());
+    REQUIRE(global.value().size() == 2U);
+    CHECK(global.value()[1].documentHash == "rescued");
+    CHECK(refillWork.documentRefillAttempts == 1U);
+    CHECK(refillWork.accumulatedSamples == 2U);
+
+    cfg.chunkAggregation = SearchEngineConfig::ChunkAggregation::TOP_K_AVG;
+    cfg.chunkAggregationTopK = 2;
+    // Switching to document-complete scoring must also disable the per-chunk cutoff.
+    // Otherwise the lower chunk disappears before averaging and inflates the document score.
+    cfg.similarityThreshold = 0.999F;
+    const auto averaged = yams::search::detail::queryVectorIndexPipeline(
+        nullptr, vectorDb, {1.0F, 0.0F}, cfg, 2, routed,
+        yams::vector::CandidateFilterMode::DocumentTopK);
+    REQUIRE(averaged.has_value());
+    REQUIRE(averaged.value().size() == 2U);
+    const float secondChunk = 0.9F / std::sqrt(0.82F);
+    CHECK(averaged.value()[0].score == Catch::Approx((1.0F + secondChunk) / 2.0F));
+}
+
+TEST_CASE("Vector work remains unavailable when any merged sample is unobserved",
+          "[search][vector][topology][work][catch2]") {
+    using yams::search::detail::mergeVectorSearchDiagnostics;
+    yams::vector::VectorSearchDiagnostics known;
+    known.rowsVisitedObserved = known.exactDistanceEvaluationsObserved =
+        known.annCandidateBudgetObserved = true;
+    known.rowsVisited = 10;
+    yams::vector::VectorSearchDiagnostics total;
+    mergeVectorSearchDiagnostics(total, known);
+    CHECK(total.rowsVisitedObserved);
+    mergeVectorSearchDiagnostics(total, {});
+    CHECK_FALSE(total.rowsVisitedObserved);
+    mergeVectorSearchDiagnostics(total, known);
+    CHECK_FALSE(total.rowsVisitedObserved);
+    CHECK(total.rowsVisited == 20U);
+    CHECK(total.accumulatedSamples == 3U);
 }
 
 TEST_CASE("Vector pipeline filters global hits by routed membership with zero-overlap fallback",

--- a/tests/unit/search/simeon_lexical_backend_catch2_test.cpp
+++ b/tests/unit/search/simeon_lexical_backend_catch2_test.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include <chrono>
 #include <cmath>
@@ -117,6 +118,51 @@ TEST_CASE("SimeonLexicalBackend default config uses SabSmooth", "[search][simeon
     CHECK(cfg.fragment_geometry_pmi_sample_docs == 8192u);
     CHECK(cfg.fragment_geometry_pmi_sample_bytes == 32ULL * 1024ULL * 1024ULL);
     CHECK(cfg.concept_weight == 0.5f);
+}
+
+TEST_CASE("Simeon query sessions preserve scores and isolate queries and recipes",
+          "[search][simeon][request-scores][catch2]") {
+    auto corpus =
+        makeCorpus({{"a", "alpha alpha beta"}, {"b", "beta gamma"}, {"c", "gamma delta"}});
+    SimeonLexicalBackend::Config config;
+    config.strategy_router_enabled = GENERATE(false, true);
+    config.router_enabled = !config.strategy_router_enabled;
+    SimeonLexicalBackend backend(config);
+    REQUIRE(backend.buildAsync(corpus.repo).has_value());
+    REQUIRE(waitReady(backend, std::chrono::seconds(5)));
+    for (const auto& query : {"alpha", "gamma"}) {
+        for (const auto& arm : {"", "sab_smooth", "atire"}) {
+            const auto baseline = std::string_view(arm).empty()
+                                      ? (backend.hasStrategyRouter()
+                                             ? backend.scoreStrategyRouted(query, corpus.docIds)
+                                             : backend.scoreRouted(query, corpus.docIds))
+                                      : backend.scoreBanditRouted(query, arm, corpus.docIds);
+            REQUIRE(baseline.has_value());
+            const auto calls = backend.scoreCalls();
+            SimeonLexicalBackend::QuerySession session(backend, query, arm);
+            CHECK(backend.scoreCalls() == calls); // lazy, no work for unused sessions
+            const auto first = session.score(corpus.docIds);
+            REQUIRE(first.has_value());
+            CHECK(first.value().scores == baseline.value().scores);
+            CHECK(first.value().recipe_name == baseline.value().recipe_name);
+            const std::vector<std::int64_t> subset{corpus.docIds.back(), -1, corpus.docIds.front()};
+            const auto second = session.score(subset);
+            REQUIRE(second.has_value());
+            CHECK(second.value().scores == std::vector<float>{baseline.value().scores.back(), 0.0F,
+                                                              baseline.value().scores.front()});
+            REQUIRE(session.searchTop(2).has_value());
+            CHECK(backend.scoreCalls() == calls + 1);
+            // A second request reuses the thread-local bandit scratch. It must
+            // not alter scores retained by the first request.
+            SimeonLexicalBackend::QuerySession other(
+                backend, std::string_view(query) == "alpha" ? "gamma" : "alpha", arm);
+            REQUIRE(other.score(corpus.docIds).has_value());
+            const auto retained = session.score(corpus.docIds);
+            REQUIRE(retained.has_value());
+            CHECK(retained.value().scores == baseline.value().scores);
+            CHECK(backend.scoreCalls() == calls + 2);
+        }
+    }
 }
 
 TEST_CASE("SimeonLexicalBackend buildAsync flips ready on small corpus",


### PR DESCRIPTION
Stack 7/8; depends on stack/06-ingestion-freshness.

Summary:
- compute Simeon corpus scores once per search request and project them across routed batches/direct candidates
- refill one bounded vector batch when chunk crowding underfills document results
- score complete allowed documents for non-MAX chunk aggregation
- merge vector work diagnostics conservatively with saturating counters

Validation:
- full search suite: 3,016 assertions / 230 cases
- Simeon focused suite and vector focused suite passed
- score benchmark: multi-stage p50 10.5 us to 7.33 us; p95 15.21 us to 9.33 us; scorer calls 900 to 300
- single-batch p50 regressed slightly from 1.13 us to 1.42 us, documenting the reuse-specific tradeoff