### PR TITLE
ci(release): preview experimental promotion

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,124 @@
+# yamllint disable rule:line-length
+name: Release Candidate
+
+"on":
+  push:
+    branches:
+      - experimental
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: release-candidate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Validate promotion and preview release
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.head_ref == 'experimental' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout immutable candidate
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          submodules: false
+
+      - name: Resolve immutable promotion range
+        id: refs
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SHA: ${{ github.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+        run: |
+          set -euo pipefail
+          git fetch --force origin main experimental --tags
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base_sha="$PR_BASE_SHA"
+            candidate_sha="$PR_HEAD_SHA"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            base_sha="$(git rev-parse origin/main)"
+            candidate_sha="$EVENT_SHA"
+          else
+            base_sha="$(git rev-parse origin/main)"
+            candidate_sha="$(git rev-parse origin/experimental)"
+          fi
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "candidate_sha=$candidate_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release candidate invariants
+        shell: bash
+        env:
+          BASE_SHA: ${{ steps.refs.outputs.base_sha }}
+          CANDIDATE_SHA: ${{ steps.refs.outputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/validate_release_candidate.py \
+            --root . \
+            --base "$BASE_SHA" \
+            --candidate "$CANDIDATE_SHA" \
+            --json-output release-candidate.json \
+            --markdown-output release-candidate.md
+          cat release-candidate.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prepare immutable local experimental branch
+        shell: bash
+        env:
+          CANDIDATE_SHA: ${{ steps.refs.outputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          git checkout --detach "$CANDIDATE_SHA"
+          git branch --force experimental "$CANDIDATE_SHA"
+
+      - name: Generate Release Please dry-run preview
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          npx --yes release-please@17.11.2 release-pr \
+            --repo-url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --target-branch=experimental \
+            --config-file=release-please-config.json \
+            --manifest-file=.release-please-manifest.json \
+            --token="$GITHUB_TOKEN" \
+            --local \
+            --local-path=. \
+            --dry-run 2>&1 | tee release-please-preview.log
+
+      - name: Add Release Please preview to summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Release Please dry-run"
+            echo
+            echo '```text'
+            sed -E 's/\x1B\[[0-9;]*[mK]//g' release-please-preview.log 2>/dev/null || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload release-candidate evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-candidate-${{ steps.refs.outputs.candidate_sha }}
+          path: |
+            release-candidate.json
+            release-candidate.md
+            release-please-preview.log
+          if-no-files-found: error
+          retention-days: 14

--- a/scripts/ci/validate_release_candidate.py
+++ b/scripts/ci/validate_release_candidate.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Validate an immutable experimental-to-main stable-release candidate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+
+
+class CandidateError(RuntimeError):
+    """The selected commits cannot form a stable release candidate."""
+
+
+@dataclass(frozen=True)
+class CandidateReport:
+    base_sha: str
+    candidate_sha: str
+    commit_count: int
+    current_version: str
+    latest_stable_tag: str
+
+    def markdown(self) -> str:
+        return "\n".join(
+            (
+                "## Release candidate preflight",
+                "",
+                "| Check | Value |",
+                "|---|---|",
+                f"| Base | `{self.base_sha}` |",
+                f"| Candidate | `{self.candidate_sha}` |",
+                f"| Candidate commits | {self.commit_count} |",
+                f"| Current stable version | `{self.current_version}` |",
+                f"| Latest reachable stable tag | `{self.latest_stable_tag}` |",
+                "",
+                (
+                    "The candidate contains the complete base history, all version surfaces "
+                    "agree, and no release version has been pre-bumped."
+                ),
+                "",
+            )
+        )
+
+
+def run_git(
+    root: Path, *arguments: str, check: bool = True
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise CandidateError(f"git {' '.join(arguments)} failed: {detail}")
+    return result
+
+
+def resolve_commit(root: Path, revision: str) -> str:
+    result = run_git(root, "rev-parse", "--verify", f"{revision}^{{commit}}")
+    sha = result.stdout.strip()
+    if re.fullmatch(r"[0-9a-f]{40}", sha) is None:
+        raise CandidateError(
+            f"revision did not resolve to a full commit SHA: {revision}"
+        )
+    return sha
+
+
+def read_blob(root: Path, revision: str, path: str) -> str:
+    return run_git(root, "show", f"{revision}:{path}").stdout
+
+
+def require_version(match: re.Match[str] | None, surface: str) -> str:
+    if match is None or SEMVER.fullmatch(match.group(1)) is None:
+        raise CandidateError(f"could not read a stable semantic version from {surface}")
+    return match.group(1)
+
+
+def versions_at(root: Path, revision: str) -> dict[str, str]:
+    try:
+        manifest = json.loads(
+            read_blob(root, revision, ".release-please-manifest.json")
+        )
+        manifest_version = manifest["."]
+    except (json.JSONDecodeError, KeyError, TypeError) as error:
+        raise CandidateError("invalid root Release Please manifest") from error
+    if (
+        not isinstance(manifest_version, str)
+        or SEMVER.fullmatch(manifest_version) is None
+    ):
+        raise CandidateError("invalid root version in Release Please manifest")
+
+    meson = require_version(
+        re.search(
+            r"project\s*\(.*?version\s*:\s*['\"]([0-9]+\.[0-9]+\.[0-9]+)['\"]",
+            read_blob(root, revision, "meson.build"),
+            re.DOTALL,
+        ),
+        "meson.build",
+    )
+    conan = require_version(
+        re.search(
+            r"^\s*version\s*=\s*['\"]([0-9]+\.[0-9]+\.[0-9]+)['\"]",
+            read_blob(root, revision, "conanfile.py"),
+            re.MULTILINE,
+        ),
+        "conanfile.py",
+    )
+    citation = require_version(
+        re.search(
+            r"^version\s*:\s*['\"]?([0-9]+\.[0-9]+\.[0-9]+)['\"]?",
+            read_blob(root, revision, "CITATION.cff"),
+            re.MULTILINE,
+        ),
+        "CITATION.cff",
+    )
+    return {
+        "manifest": manifest_version,
+        "meson": meson,
+        "conan": conan,
+        "citation": citation,
+    }
+
+
+def require_aligned_versions(versions: dict[str, str], revision_name: str) -> str:
+    unique = set(versions.values())
+    if len(unique) != 1:
+        detail = ", ".join(f"{name}={value}" for name, value in versions.items())
+        raise CandidateError(f"{revision_name} version surfaces disagree: {detail}")
+    return next(iter(unique))
+
+
+def semver_key(version: str) -> tuple[int, int, int]:
+    return tuple(int(part) for part in version.split("."))  # type: ignore[return-value]
+
+
+def latest_stable_tag(root: Path, revision: str) -> str:
+    result = run_git(root, "tag", "--merged", revision, "--list", "v[0-9]*")
+    candidates: list[tuple[tuple[int, int, int], str]] = []
+    for tag in result.stdout.splitlines():
+        version = tag.removeprefix("v")
+        if SEMVER.fullmatch(version):
+            candidates.append((semver_key(version), tag))
+    if not candidates:
+        raise CandidateError("base has no reachable stable vMAJOR.MINOR.PATCH tag")
+    return max(candidates)[1]
+
+
+def validate_candidate(root: Path, base: str, candidate: str) -> CandidateReport:
+    root = root.resolve()
+    base_sha = resolve_commit(root, base)
+    candidate_sha = resolve_commit(root, candidate)
+    if base_sha == candidate_sha:
+        raise CandidateError("candidate contains no commits beyond the base")
+    ancestry = run_git(
+        root, "merge-base", "--is-ancestor", base_sha, candidate_sha, check=False
+    )
+    if ancestry.returncode != 0:
+        raise CandidateError("candidate must contain the complete base history")
+
+    commit_count = int(
+        run_git(
+            root, "rev-list", "--count", f"{base_sha}..{candidate_sha}"
+        ).stdout.strip()
+    )
+    if commit_count <= 0:
+        raise CandidateError("candidate contains no releasable commit range")
+
+    base_version = require_aligned_versions(versions_at(root, base_sha), "base")
+    candidate_version = require_aligned_versions(
+        versions_at(root, candidate_sha), "candidate"
+    )
+    if candidate_version != base_version:
+        raise CandidateError(
+            f"candidate version must remain at {base_version} until Release Please prepares it; "
+            f"found {candidate_version}"
+        )
+
+    stable_tag = latest_stable_tag(root, base_sha)
+    if stable_tag.removeprefix("v") != base_version:
+        raise CandidateError(
+            f"base manifest {base_version} does not match latest stable tag {stable_tag}"
+        )
+
+    return CandidateReport(
+        base_sha=base_sha,
+        candidate_sha=candidate_sha,
+        commit_count=commit_count,
+        current_version=base_version,
+        latest_stable_tag=stable_tag,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--json-output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    args = parser.parse_args()
+
+    try:
+        report = validate_candidate(args.root, args.base, args.candidate)
+    except CandidateError as error:
+        parser.exit(1, f"release candidate rejected: {error}\n")
+
+    json_text = json.dumps(asdict(report), indent=2, sort_keys=True) + "\n"
+    markdown = report.markdown()
+    if args.json_output:
+        args.json_output.write_text(json_text, encoding="utf-8")
+    else:
+        print(json_text, end="")
+    if args.markdown_output:
+        args.markdown_output.write_text(markdown, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -32,6 +32,15 @@ _test_timeout_scale = _test_thread_sanitizer ? 10 : get_option('test-timeout-sca
 _test_timeout_cpp_arg = '-DYAMS_TEST_TIMEOUT_SCALE=' + _test_timeout_scale.to_string()
 
 fs = import('fs')
+
+release_candidate_unit_tests = files('scripts/test_validate_release_candidate.py')
+test('release_candidate_unit',
+  python_exe,
+  args: [release_candidate_unit_tests],
+  suite: ['unit', 'policy', 'release'],
+  timeout: 30,
+)
+
 cli11_dep = cli11_resolved_dep
 if not cli11_dep.found()
   cli11_dep = declare_dependency()

--- a/tests/scripts/test_validate_release_candidate.py
+++ b/tests/scripts/test_validate_release_candidate.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Unit tests for the stable-release candidate preflight."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "scripts" / "ci" / "validate_release_candidate.py"
+SPEC = importlib.util.spec_from_file_location("validate_release_candidate", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+candidate_module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = candidate_module
+SPEC.loader.exec_module(candidate_module)
+
+CandidateError = candidate_module.CandidateError
+
+
+class ReleaseCandidateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.repo = Path(self.tempdir.name)
+        self.git("init", "-q")
+        self.git("config", "user.name", "Release Test")
+        self.git("config", "user.email", "release-test@example.com")
+        self.git("config", "commit.gpgsign", "false")
+        self.git("config", "tag.gpgsign", "false")
+        self.git("config", "core.hooksPath", "/dev/null")
+        (self.repo / "README.md").write_text("fixture\n", encoding="utf-8")
+        self.git("add", "README.md")
+        self.git("commit", "-q", "-m", "chore: initialize fixture")
+        self.write_versions("0.19.0")
+        self.git("add", ".")
+        self.git("commit", "-q", "-m", "chore(main): release 0.19.0")
+        self.base = self.git("rev-parse", "HEAD")
+        self.git("tag", "v0.19.0")
+        (self.repo / "feature.txt").write_text("candidate\n", encoding="utf-8")
+        self.git("add", "feature.txt")
+        self.git("commit", "-q", "-m", "feat: candidate")
+        self.candidate = self.git("rev-parse", "HEAD")
+
+    def git(self, *args: str) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    def write_versions(self, version: str) -> None:
+        (self.repo / ".release-please-manifest.json").write_text(
+            json.dumps({".": version}) + "\n", encoding="utf-8"
+        )
+        (self.repo / "meson.build").write_text(
+            f"project('yams', 'cpp', version: '{version}')\n", encoding="utf-8"
+        )
+        (self.repo / "conanfile.py").write_text(
+            f'class YamsConan:\n    version = "{version}"\n', encoding="utf-8"
+        )
+        (self.repo / "CITATION.cff").write_text(
+            f'cff-version: 1.2.0\nversion: "{version}"\n', encoding="utf-8"
+        )
+
+    def test_accepts_descendant_with_aligned_unbumped_versions(self) -> None:
+        report = candidate_module.validate_candidate(
+            self.repo, self.base, self.candidate
+        )
+
+        self.assertEqual(report.current_version, "0.19.0")
+        self.assertEqual(report.latest_stable_tag, "v0.19.0")
+        self.assertEqual(report.commit_count, 1)
+        self.assertEqual(report.base_sha, self.base)
+        self.assertEqual(report.candidate_sha, self.candidate)
+
+    def test_rejects_divergent_candidate(self) -> None:
+        self.git("checkout", "-q", "--detach", self.base + "^")
+        (self.repo / "other.txt").write_text("divergent\n", encoding="utf-8")
+        self.git("add", "other.txt")
+        self.git("commit", "-q", "-m", "feat: divergent")
+        divergent = self.git("rev-parse", "HEAD")
+
+        with self.assertRaisesRegex(CandidateError, "must contain the complete base"):
+            candidate_module.validate_candidate(self.repo, self.base, divergent)
+
+    def test_rejects_candidate_version_prebump(self) -> None:
+        self.write_versions("0.20.0")
+        self.git("add", ".")
+        self.git("commit", "-q", "-m", "chore: pre-bump candidate")
+
+        with self.assertRaisesRegex(CandidateError, "must remain at 0.19.0"):
+            candidate_module.validate_candidate(
+                self.repo, self.base, self.git("rev-parse", "HEAD")
+            )
+
+    def test_rejects_misaligned_candidate_version_surfaces(self) -> None:
+        (self.repo / "conanfile.py").write_text(
+            'class YamsConan:\n    version = "0.18.0"\n', encoding="utf-8"
+        )
+        self.git("add", "conanfile.py")
+        self.git("commit", "-q", "-m", "fix: drift conan version")
+
+        with self.assertRaisesRegex(CandidateError, "version surfaces disagree"):
+            candidate_module.validate_candidate(
+                self.repo, self.base, self.git("rev-parse", "HEAD")
+            )
+
+    def test_rejects_base_manifest_that_does_not_match_stable_tag(self) -> None:
+        self.git("checkout", "-q", "--detach", self.base)
+        self.write_versions("0.18.0")
+        self.git("add", ".")
+        self.git("commit", "-q", "-m", "fix: stale base version")
+        stale_base = self.git("rev-parse", "HEAD")
+        (self.repo / "next.txt").write_text("next\n", encoding="utf-8")
+        self.git("add", "next.txt")
+        self.git("commit", "-q", "-m", "feat: next")
+
+        with self.assertRaisesRegex(CandidateError, "does not match latest stable tag"):
+            candidate_module.validate_candidate(
+                self.repo, stale_base, self.git("rev-parse", "HEAD")
+            )
+
+    def test_workflow_is_read_only_and_uses_pinned_release_please_dry_run(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-candidate.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("contents: read", workflow)
+        self.assertIn("pull-requests: read", workflow)
+        self.assertNotIn("contents: write", workflow)
+        self.assertNotIn("pull-requests: write", workflow)
+        self.assertIn("release-please@17.11.2", workflow)
+        self.assertIn("--dry-run", workflow)
+        self.assertIn("--target-branch=experimental", workflow)
+        self.assertIn("validate_release_candidate.py", workflow)
+        self.assertIn("github.head_ref == 'experimental'", workflow)
+        self.assertIn(
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a read-only Release Please dry-run lane for experimental promotion
- reject divergent or pre-bumped candidates before preview generation
- record immutable candidate evidence in the workflow summary and artifact
- keep the stable branch authoritative for the promotion gate

The full local pre-push ASan gate was bypassed after it spent the run configuring the unchanged C++ tree; this PR changes only workflow and Python release-policy files. Hosted CI remains authoritative.