### PR TITLE
ci(release): reconcile draft promotion safely

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,6 +3,14 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
+# Git exports repository-local overrides to hooks. Do not let test fixtures in
+# temporary directories inherit this worktree's refs, index or shared config.
+git_local_env="$(git rev-parse --local-env-vars)"
+while IFS= read -r git_env_name; do
+  unset "$git_env_name"
+done <<< "$git_local_env"
+unset git_local_env git_env_name
+
 if [ "${YAMS_SKIP_PREPUSH_CI_GATE:-0}" != "1" ]; then
   gate_args=()
   if [ "${YAMS_PREPUSH_GATE_SELF_TEST:-0}" = "1" ]; then

--- a/.github/workflows/draft-promotion.yml
+++ b/.github/workflows/draft-promotion.yml
@@ -1,0 +1,54 @@
+# Draft visibility is deliberately separate from candidate validation and release authority.
+name: Draft Promotion
+
+"on":
+  workflow_run:
+    workflows: [Tests]
+    types: [requested]
+    branches: [experimental]
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: draft-promotion-experimental-main
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    if: >-
+      github.repository == 'trvon/yams' && github.ref == 'refs/heads/main' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'experimental' &&
+        github.event.workflow_run.head_repository.full_name == github.repository))
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout immutable main-owned tooling only
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: false
+
+      - name: Reconcile draft visibility (never promotion)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/ci/reconcile_promotion_pr.py --apply
+
+      - name: Explain delivery boundaries
+        if: always()
+        run: |
+          {
+            echo '## Draft visibility only'
+            echo 'Existing PR text and state are never updated; the initial snapshot may age.'
+            echo 'No ready-for-review, merge, version change, tag, release, or publication is authorized.'
+            echo 'GITHUB_TOKEN PR creation does not trigger normal PR-opened checks.'
+            echo 'A maintainer must verify current-head checks and close/reopen the PR with their own account if needed.'
+            echo 'If PR creation is denied, a maintainer must approve repository Actions PR-creation settings; this job never changes them.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -41,19 +41,16 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_SHA: ${{ github.sha }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
         run: |
           set -euo pipefail
           git fetch --force origin main experimental --tags
+          base_sha="$(git rev-parse origin/main)"
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            base_sha="$PR_BASE_SHA"
             candidate_sha="$PR_HEAD_SHA"
           elif [ "$EVENT_NAME" = "push" ]; then
-            base_sha="$(git rev-parse origin/main)"
             candidate_sha="$EVENT_SHA"
           else
-            base_sha="$(git rev-parse origin/main)"
             candidate_sha="$(git rev-parse origin/experimental)"
           fi
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
@@ -120,5 +117,5 @@ jobs:
             release-candidate.json
             release-candidate.md
             release-please-preview.log
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 14

--- a/scripts/ci/reconcile_promotion_pr.py
+++ b/scripts/ci/reconcile_promotion_pr.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Main-owned draft visibility only. Default to a read-only plan; never promote."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+REPOSITORY = "trvon/yams"
+START = "<!-- yams:draft-promotion:start -->"
+END = "<!-- yams:draft-promotion:end -->"
+MAX_PAGES = 5
+
+
+class PolicyError(RuntimeError):
+    """Refuse ambiguous or untrusted reconciliation without mutating a PR."""
+
+
+class APIError(RuntimeError):
+    def __init__(self, status):
+        self.status = status
+        super().__init__(
+            f"GitHub API returned HTTP {status}; no permissions/settings were changed"
+        )
+
+
+def object_value(value):
+    if not isinstance(value, dict):
+        raise PolicyError("Expected a JSON object")
+    return value
+
+
+def sha(value):
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{40}", value):
+        raise PolicyError("Expected an immutable commit SHA")
+    return value
+
+
+def trusted_context(env, event):
+    expected = REPOSITORY + "/.github/workflows/draft-promotion.yml@refs/heads/main"
+    if (
+        env.get("GITHUB_REPOSITORY") != REPOSITORY
+        or env.get("GITHUB_REF") != "refs/heads/main"
+        or env.get("GITHUB_WORKFLOW_REF") != expected
+    ):
+        raise PolicyError(
+            "Reconciliation must run from the canonical main-owned workflow"
+        )
+    sha(env.get("GITHUB_WORKFLOW_SHA"))
+    repo = object_value(object_value(event).get("repository"))
+    if repo.get("full_name") != REPOSITORY or repo.get("default_branch") != "main":
+        raise PolicyError("Unexpected repository/default branch")
+    name = env.get("GITHUB_EVENT_NAME")
+    if name == "workflow_dispatch":
+        return True
+    if name != "workflow_run" or event.get("action") != "requested":
+        raise PolicyError("Expected a requested Tests run or main-only manual recovery")
+    run = object_value(event.get("workflow_run"))
+    if (
+        run.get("name") != "Tests"
+        or run.get("path") != ".github/workflows/tests.yml"
+        or run.get("event") != "push"
+        or run.get("head_branch") != "experimental"
+        or object_value(run.get("head_repository")).get("full_name") != REPOSITORY
+    ):
+        raise PolicyError(
+            "Expected a canonical experimental push to the Tests workflow"
+        )
+    sha(run.get("head_sha"))
+    # Success, mergeability and ancestry are intentionally NOT creation conditions.
+    return False
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise APIError(code)  # Never forward the authorization header elsewhere.
+
+
+class GitHubAPI:
+    def __init__(self, token):
+        if not token:
+            raise PolicyError("GITHUB_TOKEN is required")
+        self.token = token
+        self.opener = urllib.request.build_opener(NoRedirect())
+
+    def call(self, method, path, data=None):
+        request = urllib.request.Request(
+            f"https://api.github.com/repos/{REPOSITORY}/{path}",
+            method=method,
+            data=None if data is None else json.dumps(data).encode(),
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "yams-draft-promotion",
+            },
+        )
+        try:
+            with self.opener.open(request, timeout=20) as response:
+                body = response.read(4 * 1024 * 1024 + 1)
+                if len(body) > 4 * 1024 * 1024:
+                    raise PolicyError(
+                        "GitHub response exceeded the bounded response budget"
+                    )
+                return json.loads(body)
+        except urllib.error.HTTPError as error:
+            # Do not log request headers, response bodies, credentials or human PR text.
+            raise APIError(error.code) from None
+
+
+def exact_pull(pr, state):
+    pr = object_value(pr)
+    head, base = object_value(pr.get("head")), object_value(pr.get("base"))
+    if (
+        pr.get("state") != state
+        or head.get("ref") != "experimental"
+        or base.get("ref") != "main"
+        or object_value(head.get("repo")).get("full_name") != REPOSITORY
+        or object_value(base.get("repo")).get("full_name") != REPOSITORY
+        or type(pr.get("number")) is not int
+        or pr["number"] <= 0
+    ):
+        raise PolicyError(
+            "PR response does not identify the exact canonical branch pair"
+        )
+    return pr
+
+
+def list_pulls(api, state):
+    matches = []
+    for page in range(1, MAX_PAGES + 1):
+        query = urllib.parse.urlencode(
+            {
+                "state": state,
+                "base": "main",
+                "head": "trvon:experimental",
+                "per_page": 100,
+                "page": page,
+            }
+        )
+        rows = api.call("GET", "pulls?" + query)
+        if not isinstance(rows, list):
+            raise PolicyError("Expected a PR list")
+        matches.extend(exact_pull(pr, state) for pr in rows)
+        if len(rows) < 100:
+            return matches
+    raise PolicyError(
+        "PR pagination budget exhausted; reconcile manually instead of guessing"
+    )
+
+
+def owned_section(base, head, ahead, behind):
+    return f"""{START}
+## Automated promotion visibility (not approval)
+
+Observed `main`: `{base}`; `experimental`: `{head}`.
+Experimental is {ahead} commits ahead and {behind} behind this observed main.
+This snapshot is informational, not a validation of the current PR head.
+
+Promotion, merge, version selection and publication remain maintainer decisions.
+Release Please owns version changes; this automation never marks a PR ready or merges it.
+
+**Check-trigger warning:** PRs created with `GITHUB_TOKEN` do not trigger the normal
+PR-opened workflows. A maintainer must verify all required checks for the current head;
+if absent, manually **close and reopen** this PR using their own authenticated account.
+Do not treat this draft or the upstream Tests event as release approval.
+
+This is an initial snapshot. Future runs leave existing PR text and state untouched.
+{END}"""
+
+
+def reconcile(api, env, event, *, apply=False):
+    manual = trusted_context(env, event)  # Before even read-only API requests.
+    base = sha(object_value(api.call("GET", "git/ref/heads/main"))["object"]["sha"])
+    head = sha(
+        object_value(api.call("GET", "git/ref/heads/experimental"))["object"]["sha"]
+    )
+    # GitHub serves changed-file patches only on page 1. Page 2 retains summary counts,
+    # even with zero/one commits, without downloading arbitrary candidate file patches.
+    comparison = object_value(
+        api.call("GET", f"compare/{base}...{head}?per_page=1&page=2")
+    )
+    ahead, behind = comparison.get("ahead_by"), comparison.get("behind_by")
+    if any(type(n) is not int or n < 0 for n in (ahead, behind)):
+        raise PolicyError("Invalid comparison counts")
+    summary = {"base": base, "head": head, "ahead": ahead, "behind": behind}
+    if ahead == 0:
+        return {**summary, "action": "no-changes"}
+    section = owned_section(base, head, ahead, behind)
+
+    def existing_summary(pulls):
+        if len(pulls) != 1:
+            raise PolicyError("Ambiguous open promotion PRs")
+        # GitHub already updates the PR's branch diff on push. Do not PATCH metadata:
+        # full-body writes can overwrite concurrent human edits, even within a
+        # workflow concurrency group. No undocumented conditional-write assumption.
+        return {**summary, "action": "unchanged", "number": pulls[0]["number"]}
+
+    opened = list_pulls(api, "open")
+    if opened:
+        return existing_summary(opened)
+    if not manual:
+        closed = list_pulls(api, "closed")
+        if any(sha(pr["head"].get("sha")) == head for pr in closed):
+            return {**summary, "action": "closed-current-head"}
+    if not apply:
+        return {**summary, "action": "would-create"}
+    try:
+        created = api.call(
+            "POST",
+            "pulls",
+            {
+                "title": "chore: promote experimental to main",
+                "head": "experimental",
+                "base": "main",
+                "draft": True,
+                "body": section,
+            },
+        )
+        pr = exact_pull(created, "open")
+        if pr.get("draft") is not True:
+            raise PolicyError(
+                "Creation response did not confirm a draft; inspect the PR manually"
+            )
+        return {**summary, "action": "created", "number": pr["number"]}
+    except APIError as error:
+        if error.status != 422:
+            raise
+        # A maintainer/another run may have created the PR after our initial read.
+        opened = list_pulls(api, "open")
+        if not opened:
+            raise
+        return existing_summary(opened)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Create a missing draft visibility PR; never update an existing PR",
+    )
+    args = parser.parse_args()
+    try:
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+        trusted_context(os.environ, event)
+        result = reconcile(
+            GitHubAPI(os.environ.get("GITHUB_TOKEN")),
+            os.environ,
+            event,
+            apply=args.apply,
+        )
+    except (
+        PolicyError,
+        APIError,
+        urllib.error.URLError,
+        ValueError,
+        KeyError,
+        TypeError,
+        OSError,
+    ) as error:
+        parser.exit(1, f"Draft reconciliation failed: {error}\n")
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/validate_release_candidate.py
+++ b/scripts/ci/validate_release_candidate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 from dataclasses import asdict, dataclass
@@ -53,6 +54,8 @@ def run_git(
     result = subprocess.run(
         ["git", *arguments],
         cwd=root,
+        # The explicit root owns this read, not a caller's Git-hook environment.
+        env={key: value for key, value in os.environ.items() if not key.startswith("GIT_")},
         capture_output=True,
         text=True,
         check=False,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -41,6 +41,14 @@ test('release_candidate_unit',
   timeout: 30,
 )
 
+git_environment_isolation_tests = files('scripts/test_git_environment_isolation.py')
+test('git_environment_isolation_unit',
+  python_exe,
+  args: [git_environment_isolation_tests],
+  suite: ['unit', 'policy', 'release'],
+  timeout: 60,
+)
+
 promotion_reconciliation_tests = files('scripts/test_reconcile_promotion_pr.py')
 test('promotion_reconciliation',
   python_exe,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -41,6 +41,14 @@ test('release_candidate_unit',
   timeout: 30,
 )
 
+promotion_reconciliation_tests = files('scripts/test_reconcile_promotion_pr.py')
+test('promotion_reconciliation',
+  python_exe,
+  args: [promotion_reconciliation_tests],
+  suite: ['unit', 'policy', 'release'],
+  timeout: 30,
+)
+
 cli11_dep = cli11_resolved_dep
 if not cli11_dep.found()
   cli11_dep = declare_dependency()

--- a/tests/scripts/test_git_environment_isolation.py
+++ b/tests/scripts/test_git_environment_isolation.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Exercise hostile hook environments using disposable repositories only."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class GitEnvironmentIsolationTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        # Bootstrap must not depend on the implementation under test: even a red
+        # regression can only damage the disposable victim, never the calling repo.
+        self.clean = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+        self.clean.update(GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_NOSYSTEM="1")
+        for key in list(self.clean):
+            if key.startswith(("YAMS_PREPUSH_", "YAMS_SKIP_PREPUSH_")):
+                self.clean.pop(key)
+        self.victim = self.root / "victim"
+        self.target = self.root / "target"
+        for repo in (self.victim, self.target):
+            repo.mkdir()
+            self.git(repo, "init", "-q")
+            self.git(repo, "config", "user.name", "Disposable owner")
+            self.git(repo, "config", "user.email", "fixture@example.invalid")
+            self.git(repo, "config", "commit.gpgsign", "false")
+            self.git(repo, "config", "tag.gpgsign", "false")
+            self.git(repo, "config", "core.hooksPath", os.devnull)
+            (repo / "README.md").write_text(repo.name + "\n")
+            self.git(repo, "add", "README.md")
+            self.git(repo, "commit", "-q", "-m", "fix: protect " + repo.name)
+        self.git(self.victim, "tag", "v0.19.0")
+        self.linked = self.root / "linked"
+        self.git(self.victim, "worktree", "add", "-q", "-b", "linked", str(self.linked))
+        self.gitdir = Path(self.git(self.linked, "rev-parse", "--absolute-git-dir"))
+        self.hook_env = dict(self.clean, GIT_DIR=str(self.gitdir), GIT_PREFIX="")
+        self.before = self.snapshot()
+
+    def git(self, repo, *args):
+        return subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            env=self.clean,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def snapshot(self):
+        return {
+            "config": (self.victim / ".git/config").read_bytes(),
+            "head": self.git(self.victim, "rev-parse", "HEAD"),
+            "linked_head": self.git(self.linked, "rev-parse", "HEAD"),
+            "index": (self.gitdir / "index").read_bytes(),
+            "readme": (self.linked / "README.md").read_bytes(),
+        }
+
+    def test_candidate_fixture_cannot_mutate_hook_repository(self):
+        child = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "tests/scripts/test_validate_release_candidate.py"),
+                "ReleaseCandidateTests.test_accepts_descendant_with_aligned_unbumped_versions",
+            ],
+            cwd=self.linked,
+            env=self.hook_env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        after = self.snapshot()
+        # Avoid dumping whole config/index bytes on failure.
+        self.assertEqual([k for k in self.before if self.before[k] != after[k]], [])
+        self.assertEqual(child.returncode, 0, child.stderr)
+
+    def test_validator_respects_explicit_root_despite_git_overrides(self):
+        for extra in (
+            {},
+            {
+                "GIT_WORK_TREE": str(self.linked),
+                "GIT_COMMON_DIR": str(self.victim / ".git"),
+                "GIT_INDEX_FILE": str(self.gitdir / "index"),
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "user.name",
+                "GIT_CONFIG_VALUE_0": "Injected identity",
+            },
+        ):
+            with self.subTest(override_keys=list(extra)):
+                child = subprocess.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        (
+                            "import runpy,sys; from pathlib import Path; "
+                            "ns=runpy.run_path(sys.argv[1]); "
+                            "print(ns['resolve_commit'](Path(sys.argv[2]), 'HEAD'))"
+                        ),
+                        str(ROOT / "scripts/ci/validate_release_candidate.py"),
+                        str(self.target),
+                    ],
+                    cwd=self.linked,
+                    env={**self.hook_env, **extra},
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    check=False,
+                )
+                self.assertEqual(child.returncode, 0, child.stderr)
+                self.assertEqual(
+                    child.stdout.strip(), self.git(self.target, "rev-parse", "HEAD")
+                )
+                self.assertEqual(self.snapshot(), self.before)
+
+    def test_pre_push_removes_repository_overrides_before_running_gate(self):
+        gate = self.linked / "scripts/local-ci/pre-push-ci-gate.sh"
+        gate.parent.mkdir(parents=True)
+        # A hook dispatch unit test, NOT a substitute for the actual sanitizer gate.
+        gate.write_text("""#!/usr/bin/env bash
+set -euo pipefail
+python3 - <<'PY'
+import os
+from pathlib import Path
+for key in ('GIT_DIR', 'GIT_WORK_TREE', 'GIT_COMMON_DIR', 'GIT_INDEX_FILE', 'GIT_PREFIX',
+            'GIT_CONFIG_PARAMETERS', 'GIT_CONFIG_COUNT'):
+    assert key not in os.environ, 'Leaked hook variable: ' + key
+Path('gate.ran').write_text('yes')
+PY
+""")
+        gate.chmod(0o755)
+        hook = self.linked / ".githooks/pre-push"
+        hook.parent.mkdir()
+        shutil.copyfile(ROOT / ".githooks/pre-push", hook)
+        child = subprocess.run(
+            ["bash", str(hook)],
+            cwd=self.linked,
+            env=self.hook_env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        self.assertEqual(child.returncode, 0, child.stderr)
+        self.assertTrue((self.linked / "gate.ran").is_file())
+        self.assertEqual(self.snapshot(), self.before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_reconcile_promotion_pr.py
+++ b/tests/scripts/test_reconcile_promotion_pr.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Offline contract tests: no GitHub credentials or network are used."""
+
+import copy
+import importlib.util
+import unittest
+import urllib.error
+from email.message import Message
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "promotion", ROOT / "scripts/ci/reconcile_promotion_pr.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+promotion = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(promotion)
+REPO = "trvon/yams"
+MAIN = "a" * 40
+HEAD = "b" * 40
+
+
+def context():
+    return {
+        "GITHUB_REPOSITORY": REPO,
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_WORKFLOW_REF": REPO
+        + "/.github/workflows/draft-promotion.yml@refs/heads/main",
+        "GITHUB_WORKFLOW_SHA": MAIN,
+        "GITHUB_EVENT_NAME": "workflow_run",
+    }
+
+
+def event():
+    return {
+        "action": "requested",
+        "repository": {"full_name": REPO, "default_branch": "main"},
+        "workflow_run": {
+            "name": "Tests",
+            "path": ".github/workflows/tests.yml",
+            "event": "push",
+            "head_branch": "experimental",
+            "head_sha": HEAD,
+            "head_repository": {"full_name": REPO},
+            "conclusion": "failure",
+        },
+    }
+
+
+def pull(body="Maintainer notes", draft=False):
+    return {
+        "number": 123,
+        "state": "open",
+        "body": body,
+        "title": "Human title",
+        "draft": draft,
+        "head": {"ref": "experimental", "sha": HEAD, "repo": {"full_name": REPO}},
+        "base": {"ref": "main", "repo": {"full_name": REPO}},
+    }
+
+
+class FakeAPI:
+    def __init__(self):
+        self.calls = []
+        self.open = []
+        self.closed = []
+        self.ahead = 161
+        self.race = False
+
+    def call(self, method, path, data=None):
+        self.calls.append((method, path, copy.deepcopy(data)))
+        if path == "git/ref/heads/main":
+            return {"object": {"sha": MAIN}}
+        if path == "git/ref/heads/experimental":
+            return {"object": {"sha": HEAD}}
+        if path.startswith("compare/"):
+            self.assert_compare = path
+            return {"ahead_by": self.ahead, "behind_by": 2, "status": "diverged"}
+        if path.startswith("pulls?"):
+            return copy.deepcopy(self.closed if "state=closed" in path else self.open)
+        if method == "POST" and path == "pulls":
+            assert data is not None
+            if self.race:
+                self.race = False
+                self.open = [pull()]
+                raise promotion.APIError(422)
+            self.open = [pull(data["body"], draft=data["draft"])]
+            return copy.deepcopy(self.open[0])
+        if method == "PATCH" and path == "pulls/123":
+            assert data is not None
+            self.open[0]["body"] = data["body"]
+            return copy.deepcopy(self.open[0])
+        raise AssertionError((method, path, data))
+
+    def writes(self):
+        return [c for c in self.calls if c[0] != "GET"]
+
+
+class PromotionTests(unittest.TestCase):
+    def run_reconcile(self, api, **kwargs):
+        return promotion.reconcile(api, context(), event(), **kwargs)
+
+    def test_default_is_read_only_plan(self):
+        api = FakeAPI()
+        result = self.run_reconcile(api)
+        self.assertEqual(result["action"], "would-create")
+        self.assertFalse(api.writes())
+
+    def test_divergent_failed_tests_create_only_draft(self):
+        api = FakeAPI()
+        self.assertEqual(self.run_reconcile(api, apply=True)["action"], "created")
+        self.assertEqual(len(api.writes()), 1)
+        _, path, payload = api.writes()[0]
+        self.assertEqual(path, "pulls")
+        self.assertEqual(set(payload), {"title", "body", "head", "base", "draft"})
+        self.assertTrue(payload["draft"])
+        self.assertEqual((payload["head"], payload["base"]), ("experimental", "main"))
+        self.assertIn("GITHUB_TOKEN", payload["body"])
+        self.assertIn("close and reopen", payload["body"])
+        self.assertIn(MAIN + "..." + HEAD, api.assert_compare)
+        self.assertIn("page=2", api.assert_compare)
+
+    def test_second_run_is_noop_and_preserves_ready_human_pr(self):
+        api = FakeAPI()
+        api.open = [pull()]
+        original = copy.deepcopy(api.open)
+        self.assertEqual(self.run_reconcile(api, apply=True)["action"], "unchanged")
+        self.assertEqual(self.run_reconcile(api, apply=True)["action"], "unchanged")
+        self.assertEqual(api.open, original)
+        self.assertFalse(api.writes())
+
+    def test_no_ahead_commits_does_not_create_or_close(self):
+        api = FakeAPI()
+        api.ahead = 0
+        api.open = [pull()]
+        self.assertEqual(self.run_reconcile(api, apply=True)["action"], "no-changes")
+        self.assertFalse(api.writes())
+
+    def test_closed_same_head_is_respected_unless_manually_requested(self):
+        api = FakeAPI()
+        closed = pull()
+        closed["state"] = "closed"
+        api.closed = [closed]
+        self.assertEqual(
+            self.run_reconcile(api, apply=True)["action"], "closed-current-head"
+        )
+        self.assertFalse(api.writes())
+        env = context()
+        env["GITHUB_EVENT_NAME"] = "workflow_dispatch"
+        result = promotion.reconcile(api, env, event(), apply=True)
+        self.assertEqual(result["action"], "created")
+
+    def test_trust_failures_do_not_even_read_api(self):
+        variants = []
+        for key, value in [
+            ("GITHUB_REF", "refs/heads/experimental"),
+            ("GITHUB_REPOSITORY", "fork/yams"),
+            ("GITHUB_WORKFLOW_REF", "fork/yams/workflow@refs/heads/main"),
+            ("GITHUB_WORKFLOW_SHA", "main"),
+            ("GITHUB_EVENT_NAME", "pull_request_target"),
+        ]:
+            env = context()
+            env[key] = value
+            variants.append((env, event()))
+        for key, value in [
+            ("event", "pull_request"),
+            ("head_branch", "main"),
+            ("head_repository", {"full_name": "fork/yams"}),
+            ("path", ".github/workflows/other.yml"),
+            ("name", "Pretend Tests"),
+            ("head_sha", "bad"),
+        ]:
+            ev = event()
+            ev["workflow_run"][key] = value
+            variants.append((context(), ev))
+        ev = event()
+        ev["action"] = "completed"
+        variants.append((context(), ev))
+        ev = event()
+        ev["repository"]["default_branch"] = "experimental"
+        variants.append((context(), ev))
+        for env, ev in variants:
+            with self.subTest(env=env, event=ev):
+                api = FakeAPI()
+                with self.assertRaises(promotion.PolicyError):
+                    promotion.reconcile(api, env, ev, apply=True)
+                self.assertFalse(api.calls)
+
+    def test_even_malformed_existing_markers_are_left_untouched(self):
+        for body in [
+            "notes " + promotion.START,
+            promotion.END + promotion.START,
+            promotion.START + promotion.START + promotion.END,
+        ]:
+            api = FakeAPI()
+            api.open = [pull(body)]
+            self.assertEqual(self.run_reconcile(api, apply=True)["action"], "unchanged")
+            self.assertEqual(api.open[0]["body"], body)
+            self.assertFalse(api.writes())
+
+    def test_fork_or_ambiguous_api_pr_response_fails_closed(self):
+        for pulls in [[pull(), pull()], [pull()]]:
+            api = FakeAPI()
+            api.open = pulls
+            if len(pulls) == 1:
+                pulls[0]["head"]["repo"]["full_name"] = "fork/yams"
+            with self.assertRaises(promotion.PolicyError):
+                self.run_reconcile(api, apply=True)
+            self.assertFalse(api.writes())
+
+    def test_creation_race_rereads_without_duplicate_creation(self):
+        api = FakeAPI()
+        api.race = True
+        self.assertEqual(self.run_reconcile(api, apply=True)["action"], "unchanged")
+        self.assertEqual(sum(c[0] == "POST" for c in api.calls), 1)
+        self.assertEqual(len(api.writes()), 1)  # No follow-up PATCH to the winning PR.
+
+    def test_concurrent_human_edit_and_closure_cannot_be_overwritten(self):
+        api = FakeAPI()
+        api.open = [pull()]
+        call = api.call
+
+        def interleaved(method, path, data=None):
+            result = call(method, path, data)
+            if path.startswith("pulls?") and "state=open" in path:
+                api.open[0].update(
+                    body="New human decision", state="closed", title="Do not promote"
+                )
+            return (
+                result  # Return the older observation, not the concurrent human edit.
+            )
+
+        api.call = interleaved
+        self.assertEqual(self.run_reconcile(api, apply=True)["action"], "unchanged")
+        self.assertFalse(api.writes())
+        self.assertEqual(api.open[0]["body"], "New human decision")
+        self.assertEqual(api.open[0]["state"], "closed")
+        self.assertEqual(api.open[0]["title"], "Do not promote")
+
+    def test_creation_response_must_confirm_draft_without_auto_remediation(self):
+        for draft in [False, None, "true", 1]:
+            with self.subTest(draft=draft):
+                api = FakeAPI()
+                call = api.call
+
+                def unconfirmed(method, path, data=None, *, call=call, draft=draft):
+                    result = call(method, path, data)
+                    if method == "POST":
+                        result["draft"] = draft
+                        if draft is None:
+                            del result["draft"]
+                    return result
+
+                api.call = unconfirmed
+                with self.assertRaisesRegex(promotion.PolicyError, "confirm a draft"):
+                    self.run_reconcile(api, apply=True)
+                self.assertEqual([c[0] for c in api.writes()], ["POST"])
+
+    def test_malformed_transport_json_is_rejected(self):
+        api = promotion.GitHubAPI("fixture-token-never-sent")
+        api.opener = MagicMock()
+        api.opener.open.return_value.__enter__.return_value.read.return_value = (
+            b"not-json"
+        )
+        with self.assertRaises(ValueError):
+            api.call("GET", "git/ref/heads/main")
+
+    def test_invalid_counts_and_pagination_exhaustion_fail_closed(self):
+        api = FakeAPI()
+        api.ahead = True  # bool is not a valid integer count.
+        with self.assertRaises(promotion.PolicyError):
+            self.run_reconcile(api, apply=True)
+        self.assertFalse(api.writes())
+        api = FakeAPI()
+        api.open = [pull() for _ in range(100)]
+        with self.assertRaisesRegex(promotion.PolicyError, "pagination budget"):
+            self.run_reconcile(api, apply=True)
+        self.assertFalse(api.writes())
+        self.assertEqual(
+            sum(p.startswith("pulls?") for _, p, _ in api.calls), promotion.MAX_PAGES
+        )
+
+    def test_permission_failure_does_not_report_creation_or_change_settings(self):
+        api = FakeAPI()
+        call = api.call
+
+        def denied(method, path, data=None):
+            if method == "POST":
+                raise promotion.APIError(403)
+            return call(method, path, data)
+
+        api.call = denied
+        with self.assertRaises(promotion.APIError) as raised:
+            self.run_reconcile(api, apply=True)
+        self.assertEqual(raised.exception.status, 403)
+        self.assertFalse(api.open)
+
+    def test_transport_budget_redirect_and_error_redaction(self):
+        api = promotion.GitHubAPI("fixture-token-never-sent")
+        api.opener = MagicMock()
+        response = api.opener.open.return_value.__enter__.return_value
+        response.read.return_value = b"x" * (4 * 1024 * 1024 + 1)
+        with self.assertRaisesRegex(promotion.PolicyError, "response budget"):
+            api.call("GET", "git/ref/heads/main")
+        response.read.assert_called_once_with(4 * 1024 * 1024 + 1)
+        self.assertEqual(api.opener.open.call_args.kwargs["timeout"], 20)
+        with self.assertRaises(promotion.APIError):
+            promotion.NoRedirect().redirect_request(
+                None, None, 302, "Found", {}, "https://example.invalid/"
+            )
+        api.opener.open.side_effect = urllib.error.HTTPError(
+            "https://api.github.com/",
+            403,
+            "secret fixture-token-never-sent",
+            Message(),
+            None,
+        )
+        with self.assertRaises(promotion.APIError) as raised:
+            api.call("GET", "git/ref/heads/main")
+        self.assertNotIn("fixture-token", str(raised.exception))
+        self.assertEqual(raised.exception.status, 403)
+
+    def test_workflow_authority_and_main_owned_checkout(self):
+        text = (ROOT / ".github/workflows/draft-promotion.yml").read_text()
+        self.assertIn("types: [requested]", text)
+        self.assertIn("ref: ${{ github.workflow_sha }}", text)
+        self.assertIn("persist-credentials: false", text)
+        self.assertIn("pull-requests: write", text)
+        self.assertIn("cancel-in-progress: false", text)
+        for forbidden in [
+            "pull_request_target:",
+            "contents: write",
+            "actions: write",
+            "head.sha",
+            "secrets.PAT",
+            "--merge",
+        ]:
+            self.assertNotIn(forbidden, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_validate_release_candidate.py
+++ b/tests/scripts/test_validate_release_candidate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -50,6 +51,8 @@ class ReleaseCandidateTests(unittest.TestCase):
         result = subprocess.run(
             ["git", *args],
             cwd=self.repo,
+            # Hooks export GIT_DIR even across cwd changes; never mutate the caller.
+            env={key: value for key, value in os.environ.items() if not key.startswith("GIT_")},
             check=True,
             capture_output=True,
             text=True,

--- a/tests/scripts/test_validate_release_candidate.py
+++ b/tests/scripts/test_validate_release_candidate.py
@@ -128,6 +128,13 @@ class ReleaseCandidateTests(unittest.TestCase):
                 self.repo, stale_base, self.git("rev-parse", "HEAD")
             )
 
+    def test_workflow_uses_current_main_and_preserves_validation_failure(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-candidate.yml").read_text()
+        self.assertNotIn("PR_BASE_SHA", workflow)
+        self.assertIn('base_sha="$(git rev-parse origin/main)"', workflow)
+        self.assertIn("if-no-files-found: warn", workflow)
+        self.assertNotIn("continue-on-error:", workflow)
+
     def test_workflow_is_read_only_and_uses_pinned_release_please_dry_run(self) -> None:
         workflow = (ROOT / ".github/workflows/release-candidate.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- Add main-owned, create-only experimental promotion draft reconciliation. Existing PRs remain entirely untouched; visibility does not authorize readiness, merge, promotion, or release.
- Validate candidates against freshly fetched current main; preserve validator failures while treating absent diagnostic artifacts as warnings.
- Isolate Git subprocesses and pre-push gate children from inherited repository overrides. Add disposable linked-worktree regressions proving caller config, refs, index, and files remain intact.

## Validation
- Signed/DCO commits: c3ab5faad6e97f07803a7d5a072404f0b3f32417 and 42e1e980b8cf4e1c859a17b2a3f15f54a1370fb6.
- 26 focused Python tests passed; Ruff, Actionlint, ShellCheck, shell syntax, and diff checks passed.
- Normal unfiltered pre-push gates passed on macOS arm64: ASan/UBSan 168/168; TSan 236/236. Direct git push exit 0; remote SHA verified exactly 42e1e980b8cf4e1c859a17b2a3f15f54a1370fb6.
- Cross-compilation remains unvalidated for this main-based branch: no cross compilers were available and its older hook lacks the newer smoke step.
- A previous full-gate TSan responsiveness assertion/teardown timeout remains unexplained. An unchanged focused reproduction and this subsequent complete gate passed; this PR does not claim a runtime fix.
