### PR TITLE
fix(topology): rebuild stale memberships

### DIFF
--- a/src/daemon/components/TopologyManager.cpp
+++ b/src/daemon/components/TopologyManager.cpp
@@ -471,11 +471,32 @@ TopologyManager::runRebuild(const std::string& reason, bool dryRun,
         latestBatch = std::move(latestResult.value());
     }
 
-    std::vector<std::string> rebuildHashes = documentHashes;
+    // Incremental engines retain untouched prior clusters. A deleted member outside the
+    // dirty region (or a deleted-only seed omitted by extraction) would otherwise survive
+    // every retry. Rebuild the complete artifact from current metadata, not a filtered batch
+    // with stale cluster representatives. This is not a substitute for store-time validation.
+    bool replacingStaleSnapshot = false;
+    if (latestBatch.has_value() && !documentHashes.empty()) {
+        std::vector<std::string> priorHashes;
+        priorHashes.reserve(latestBatch->memberships.size());
+        for (const auto& membership : latestBatch->memberships) {
+            priorHashes.push_back(membership.documentHash);
+        }
+        auto existingHashes = metadataRepo->getExistingDocumentHashes(priorHashes);
+        if (!existingHashes) {
+            return Result<RebuildStats>(existingHashes.error());
+        }
+        replacingStaleSnapshot =
+            std::any_of(priorHashes.begin(), priorHashes.end(),
+                        [&](const auto& hash) { return !existingHashes.value().contains(hash); });
+    }
+
+    std::vector<std::string> rebuildHashes =
+        replacingStaleSnapshot ? std::vector<std::string>{} : documentHashes;
     topology::TopologyDirtyRegion dirtyRegion;
     topology::TopologyExtractionStats seedExtractionStats;
     topology::TopologyUpdateStats updateStats;
-    if (!documentHashes.empty()) {
+    if (!rebuildHashes.empty()) {
         topology::TopologyExtractionConfig seedConfig;
         seedConfig.documentHashes = documentHashes;
         seedConfig.limit = static_cast<int>(documentHashes.size());
@@ -544,7 +565,7 @@ TopologyManager::runRebuild(const std::string& reason, bool dryRun,
     }
     buildConfig.embeddingSpaceIdentity = extractionStats.embeddingSpaceIdentity;
 
-    if (!documentHashes.empty() && extracted.value().empty()) {
+    if (!documentHashes.empty() && !replacingStaleSnapshot && extracted.value().empty()) {
         RebuildStats skipped;
         skipped.skipped = true;
         skipped.dryRun = dryRun;
@@ -582,7 +603,7 @@ TopologyManager::runRebuild(const std::string& reason, bool dryRun,
     RebuildStats stats;
     stats.reason = reason;
     stats.dryRun = dryRun;
-    stats.fullRebuild = documentHashes.empty();
+    stats.fullRebuild = documentHashes.empty() || replacingStaleSnapshot;
     stats.snapshotId = artifacts.snapshotId;
     stats.algorithm = artifacts.algorithm;
     stats.documentsRequested = extractionStats.documentsRequested;
@@ -598,7 +619,11 @@ TopologyManager::runRebuild(const std::string& reason, bool dryRun,
     stats.dirtyRegionDocs = updateStats.dirtyRegionDocs > 0 ? updateStats.dirtyRegionDocs
                                                             : extractionStats.regionDocuments;
     stats.coalescedDirtySets = updateStats.coalescedDirtySets;
-    stats.fallbackFullRebuilds = updateStats.fallbackFullRebuilds;
+    stats.fallbackFullRebuilds =
+        updateStats.fallbackFullRebuilds + (replacingStaleSnapshot ? 1 : 0);
+    if (replacingStaleSnapshot) {
+        stats.dirtySeedCount = documentHashes.size();
+    }
 
     if (!artifacts.clusters.empty()) {
         std::vector<std::size_t> sizes;
@@ -713,7 +738,10 @@ TopologyManager::runRebuild(const std::string& reason, bool dryRun,
 
     stats.issues.push_back(std::string{"topology_algorithm="} + std::string{algorithmKey});
 
-    if (!documentHashes.empty()) {
+    if (replacingStaleSnapshot) {
+        stats.issues.push_back("prior topology members are missing from metadata; rebuilding from "
+                               "the current corpus");
+    } else if (!documentHashes.empty()) {
         stats.issues.push_back("incremental topology rebuild expanded " +
                                std::to_string(documentHashes.size()) + " seed docs to " +
                                std::to_string(rebuildHashes.size()) + " docs");
@@ -726,7 +754,11 @@ TopologyManager::runRebuild(const std::string& reason, bool dryRun,
         }
     }
 
-    if (artifacts.memberships.empty()) {
+    // A confirmed empty corpus must retire deleted members. Zero ready inputs alone is not
+    // sufficient: live documents may still be awaiting embeddings or graph nodes.
+    const bool replacingWithEmptyCorpus =
+        replacingStaleSnapshot && extractionStats.documentsLoaded == 0;
+    if (artifacts.memberships.empty() && !replacingWithEmptyCorpus) {
         stats.skipped = true;
         stats.issues.push_back(
             "topology rebuild produced no memberships; graph nodes or embeddings may be missing");
@@ -742,7 +774,9 @@ TopologyManager::runRebuild(const std::string& reason, bool dryRun,
         publishedEpoch_.store(artifacts.topologyEpoch, std::memory_order_release);
     }
 
-    if (stats.stored && stats.fullRebuild) {
+    // An incremental request owns only its supplied seeds, even when recovery rebuilt the
+    // whole corpus. Leave other/newly queued dirty hashes for the scheduler's next drain.
+    if (stats.stored && stats.fullRebuild && documentHashes.empty()) {
         std::lock_guard<std::mutex> lock(dirtyMutex_);
         dirtyHashes_.clear();
         std::lock_guard<std::mutex> telemetryLock(telemetryMutex_);

--- a/tests/unit/daemon/topology_manager_catch2_test.cpp
+++ b/tests/unit/daemon/topology_manager_catch2_test.cpp
@@ -1,8 +1,19 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
+#include <memory>
+#include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 #include <yams/daemon/components/TopologyManager.h>
+#include <yams/metadata/connection_pool.h>
+#include <yams/metadata/knowledge_graph_store.h>
+#include <yams/metadata/metadata_repository.h>
+#include <yams/topology/topology_metadata_store.h>
+#include <yams/vector/vector_database.h>
+
+#include "tests/common/test_helpers_catch2.h"
 
 using namespace yams::daemon;
 
@@ -140,4 +151,250 @@ TEST_CASE("TopologyManager rebuildArtifacts concurrency guard",
 
     secondDone.store(true);
     t1.join();
+}
+
+namespace {
+
+struct RebuildFixture {
+    yams::test::ScopedEnvVar enableVectors{"YAMS_DISABLE_VECTORS", std::string{"0"}};
+    yams::test::ScopedEnvVar initializeVectors{"YAMS_SQLITE_VEC_SKIP_INIT", std::string{"0"}};
+    yams::test::ScopedEnvVar vectorMemoryMode{"YAMS_VDB_IN_MEMORY", std::nullopt};
+    yams::test::TempDirGuard directory{"topology_rebuild_"};
+    std::unique_ptr<yams::metadata::ConnectionPool> pool;
+    std::shared_ptr<yams::metadata::MetadataRepository> repository;
+    std::shared_ptr<yams::metadata::KnowledgeGraphStore> kg;
+    std::shared_ptr<yams::vector::VectorDatabase> vectors;
+
+    RebuildFixture() {
+        yams::metadata::ConnectionPoolConfig poolConfig;
+        poolConfig.minConnections = 1;
+        poolConfig.maxConnections = 2;
+        pool = std::make_unique<yams::metadata::ConnectionPool>(
+            (directory.path() / "metadata.db").string(), poolConfig);
+        REQUIRE(pool->initialize().has_value());
+        repository = std::make_shared<yams::metadata::MetadataRepository>(*pool);
+        auto kgResult = yams::metadata::makeSqliteKnowledgeGraphStore(
+            *pool, yams::metadata::KnowledgeGraphStoreConfig{});
+        REQUIRE(kgResult.has_value());
+        kg = std::shared_ptr<yams::metadata::KnowledgeGraphStore>(std::move(kgResult.value()));
+
+        yams::vector::VectorDatabaseConfig vectorConfig;
+        vectorConfig.database_path = ":memory:";
+        vectorConfig.embedding_dim = 4;
+        vectorConfig.create_if_missing = true;
+        vectorConfig.use_in_memory = true;
+        vectors = std::make_shared<yams::vector::VectorDatabase>(vectorConfig);
+        REQUIRE(vectors->initialize());
+    }
+
+    std::int64_t addDocument(const std::string& hash) {
+        yams::metadata::DocumentInfo document;
+        document.fileName = hash + ".md";
+        document.filePath = (directory.path() / document.fileName).string();
+        document.sha256Hash = hash;
+        document.mimeType = "text/plain";
+        document.contentExtracted = true;
+        document.extractionStatus = yams::metadata::ExtractionStatus::Success;
+        auto inserted = repository->insertDocument(document);
+        REQUIRE(inserted.has_value());
+
+        yams::metadata::KGNode node;
+        node.nodeKey = "doc:" + hash;
+        node.label = hash;
+        node.type = "document";
+        REQUIRE(kg->upsertNode(node).has_value());
+
+        yams::vector::VectorRecord vector;
+        vector.chunk_id = "doc-" + hash;
+        vector.document_hash = hash;
+        vector.embedding = {1.0F, 0.0F, 0.0F, 0.0F};
+        vector.model_id = "test-space-v1";
+        vector.level = yams::vector::EmbeddingLevel::DOCUMENT;
+        REQUIRE(vectors->insertVector(vector));
+        return inserted.value();
+    }
+
+    TopologyManager::Dependencies dependencies() {
+        return {[this] { return repository; }, [this] { return kg; }, [this] { return vectors; }};
+    }
+
+    yams::topology::TopologyArtifactBatch latest() {
+        // A fresh store must observe the persisted pointer, not an earlier local cache.
+        yams::topology::MetadataKgTopologyArtifactStore store(repository, kg);
+        auto loaded = store.loadLatest();
+        REQUIRE(loaded.has_value());
+        REQUIRE(loaded.value().has_value());
+        return std::move(*loaded.value());
+    }
+};
+
+} // namespace
+
+TEST_CASE("TopologyManager does not reuse deleted prior members", "[daemon][topology-recovery]") {
+    RebuildFixture fixture;
+    const auto removedId = fixture.addDocument("aaa");
+    fixture.addDocument("bbb");
+    fixture.addDocument("ccc");
+    // The removed document shares a cluster with a live member. Recovery must rebuild
+    // representatives and retain that live member, not merely discard the whole cluster.
+    auto aNode = fixture.kg->getNodeByKey("doc:aaa");
+    auto bNode = fixture.kg->getNodeByKey("doc:bbb");
+    REQUIRE(aNode.has_value());
+    REQUIRE(aNode.value().has_value());
+    REQUIRE(bNode.has_value());
+    REQUIRE(bNode.value().has_value());
+    yams::metadata::KGEdge forward;
+    forward.srcNodeId = aNode.value()->id;
+    forward.dstNodeId = bNode.value()->id;
+    forward.relation = "semantic_neighbor";
+    auto reverse = forward;
+    std::swap(reverse.srcNodeId, reverse.dstNodeId);
+    REQUIRE(fixture.kg->addEdgesUnique(std::vector{forward, reverse}).has_value());
+    TopologyManager manager(fixture.dependencies());
+    auto initial = manager.rebuildArtifacts("initial", false, {}, "connected");
+    REQUIRE(initial.has_value());
+    REQUIRE(initial.value().stored);
+    const auto previous = fixture.latest();
+    REQUIRE(previous.memberships.size() == 3);
+    REQUIRE(previous.clusters.size() == 2);
+
+    bool deleted = true;
+    bool dryRun = false;
+    std::vector<std::string> seeds{"ccc"};
+    SECTION("healthy incremental rebuild retains untouched live members") {
+        deleted = false;
+    }
+    SECTION("deleted member is outside the requested dirty region") {}
+    SECTION("the only dirty seed was deleted") {
+        seeds = {"aaa"};
+    }
+    SECTION("dry run detects stale reuse without publishing") {
+        dryRun = true;
+    }
+
+    if (deleted) {
+        REQUIRE(fixture.repository->deleteDocument(removedId).has_value());
+        // Stale vector/KG state must not resurrect a document absent from metadata.
+        REQUIRE_FALSE(fixture.vectors->getVectorsByDocument("aaa").empty());
+    }
+    // Work not included in this request must survive even if recovery needs a full rebuild.
+    manager.markDirty("new-pending");
+    auto result = manager.rebuildArtifacts("post_ingest_drain", dryRun, seeds, "connected");
+    INFO((result ? "rebuild succeeded" : result.error().message));
+    REQUIRE(result.has_value());
+    CHECK_FALSE(result.value().skipped);
+    CHECK(result.value().stored == !dryRun);
+    CHECK(result.value().fullRebuild == deleted);
+    CHECK(result.value().fallbackFullRebuilds == (deleted ? 1 : 0));
+    CHECK(result.value().membershipsBuilt == (deleted ? 2 : 3));
+    CHECK(manager.getOverlayHashes() == std::vector<std::string>{"new-pending"});
+
+    const auto current = fixture.latest();
+    CHECK(current.topologyEpoch == previous.topologyEpoch + (dryRun ? 0 : 1));
+    CHECK(manager.publishedEpoch() == current.topologyEpoch);
+    if (dryRun) {
+        CHECK(current.snapshotId == previous.snapshotId);
+        CHECK(current.memberships.size() == previous.memberships.size());
+    } else {
+        const std::unordered_set<std::string> expected =
+            deleted ? std::unordered_set<std::string>{"bbb", "ccc"}
+                    : std::unordered_set<std::string>{"aaa", "bbb", "ccc"};
+        std::unordered_set<std::string> members;
+        for (const auto& membership : current.memberships) {
+            members.insert(membership.documentHash);
+        }
+        CHECK(members == expected);
+        CHECK(current.clusters.size() == 2);
+        for (const auto& cluster : current.clusters) {
+            REQUIRE(cluster.medoid.has_value());
+            CHECK(expected.contains(cluster.medoid->documentHash));
+            for (const auto& representative : cluster.routingRepresentatives) {
+                CHECK(expected.contains(representative.documentHash));
+            }
+            CHECK(cluster.memberCount == cluster.memberDocumentHashes.size());
+            for (const auto& hash : cluster.memberDocumentHashes) {
+                CHECK(expected.contains(hash));
+            }
+        }
+    }
+}
+
+TEST_CASE("TopologyManager distinguishes an empty corpus from unready documents",
+          "[daemon][topology-recovery]") {
+    RebuildFixture fixture;
+    const auto removedId = fixture.addDocument("aaa");
+    const auto otherId = fixture.addDocument("bbb");
+    TopologyManager manager(fixture.dependencies());
+    auto initial = manager.rebuildArtifacts("initial", false, {}, "connected");
+    REQUIRE(initial.has_value());
+    REQUIRE(initial.value().stored);
+    const auto previous = fixture.latest();
+    REQUIRE(fixture.repository->deleteDocument(removedId).has_value());
+
+    bool emptyCorpus = false;
+    SECTION("all documents were deleted") {
+        REQUIRE(fixture.repository->deleteDocument(otherId).has_value());
+        emptyCorpus = true;
+    }
+    SECTION("a remaining document is temporarily missing embeddings") {
+        REQUIRE(fixture.vectors->deleteVectorsByDocument("bbb"));
+    }
+
+    manager.markDirty("new-pending");
+    auto result = manager.rebuildArtifacts("post_ingest_drain", false, {"aaa"}, "connected");
+    INFO((result ? "rebuild succeeded" : result.error().message));
+    REQUIRE(result.has_value());
+    CHECK(result.value().skipped == !emptyCorpus);
+    CHECK(result.value().stored == emptyCorpus);
+    CHECK(result.value().fullRebuild);
+    CHECK(result.value().fallbackFullRebuilds == 1);
+    CHECK(manager.getOverlayHashes() == std::vector<std::string>{"new-pending"});
+    const auto current = fixture.latest();
+    CHECK(manager.publishedEpoch() == current.topologyEpoch);
+    if (emptyCorpus) {
+        CHECK(current.topologyEpoch == previous.topologyEpoch + 1);
+        CHECK(current.memberships.empty());
+        CHECK(current.clusters.empty());
+    } else {
+        CHECK(result.value().documentsMissingEmbeddings == 1);
+        CHECK(current.snapshotId == previous.snapshotId);
+        CHECK(current.topologyEpoch == previous.topologyEpoch);
+        CHECK(current.memberships.size() == previous.memberships.size());
+    }
+}
+
+TEST_CASE("Topology publication rejects deletion after a successful membership check",
+          "[daemon][topology-recovery]") {
+    RebuildFixture fixture;
+    const auto liveId = fixture.addDocument("aaa");
+    const auto removedId = fixture.addDocument("bbb");
+    TopologyManager manager(fixture.dependencies());
+    auto initial = manager.rebuildArtifacts("initial", false, {}, "connected");
+    REQUIRE(initial.has_value());
+    REQUIRE(initial.value().stored);
+    const auto previous = fixture.latest();
+
+    auto existing = fixture.repository->getExistingDocumentHashes({"aaa", "bbb"});
+    REQUIRE(existing.has_value());
+    REQUIRE(existing.value().size() == 2);
+    REQUIRE(fixture.repository->deleteDocument(removedId).has_value());
+
+    auto candidate = previous;
+    candidate.snapshotId = "candidate-after-deletion";
+    ++candidate.topologyEpoch;
+    std::sort(
+        candidate.memberships.begin(), candidate.memberships.end(),
+        [](const auto& left, const auto& right) { return left.documentHash < right.documentHash; });
+    yams::topology::MetadataKgTopologyArtifactStore store(fixture.repository, fixture.kg);
+    const auto result = store.storeBatch(candidate);
+    REQUIRE_FALSE(result.has_value());
+    CHECK(result.error().code == yams::ErrorCode::NotFound);
+    const auto current = fixture.latest();
+    CHECK(current.snapshotId == previous.snapshotId);
+    CHECK(current.topologyEpoch == previous.topologyEpoch);
+    CHECK(current.memberships.size() == previous.memberships.size());
+    const auto liveSnapshot = fixture.repository->getMetadata(liveId, "topology.snapshot_id");
+    REQUIRE(liveSnapshot.has_value());
+    REQUIRE(liveSnapshot.value().has_value());
+    CHECK(liveSnapshot.value()->asString() == previous.snapshotId);
 }

--- a/tests/unit/daemon/topology_manager_catch2_test.cpp
+++ b/tests/unit/daemon/topology_manager_catch2_test.cpp
@@ -1,7 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <unordered_set>


### PR DESCRIPTION
## Summary
Incremental topology updates can retain deleted documents in untouched prior clusters, causing repeated `topology membership document not found` failures. A deleted-only dirty seed can also disappear during extraction and leave the stale snapshot indefinitely skipped.

- Check prior membership against current metadata before incremental reuse; propagate lookup errors rather than treating them as deletion.
- On confirmed missing members, rebuild coherent artifacts from current corpus inputs, including representatives and surviving cluster members.
- Publish an empty replacement only when metadata extraction actually loaded zero documents; retain the previous snapshot when live documents are merely unready.
- Preserve final store-time validation, monotonic epochs, dry-run behavior, and dirty work outside the supplied request.
