### PR TITLE
[01/14] Correct ingest buffer consumption and explicit WAL lifecycle

### DIFF
--- a/include/yams/daemon/components/PostIngestQueue.h
+++ b/include/yams/daemon/components/PostIngestQueue.h
@@ -426,6 +426,10 @@ public:
     }
     void testing_schedulePendingKgDrain() { schedulePendingKgDrain(); }
     void testing_enqueueKgJob(InternalEventBus::KgJob job) { enqueueKgJob(std::move(job)); }
+    void testing_processEntityExtractionBatch(
+        std::vector<InternalEventBus::EntityExtractionJob>&& jobs) {
+        processEntityExtractionBatch(std::move(jobs));
+    }
     [[nodiscard]] std::size_t testing_pendingKgJobs() const {
         std::lock_guard<std::mutex> lock(pendingKgMutex_);
         return pendingKgJobs_.size();
@@ -455,9 +459,6 @@ private:
         const std::vector<std::shared_ptr<ExternalEntityProviderAdapter>>& entityProviders);
 
     void processKnowledgeGraphBatch(std::vector<InternalEventBus::KgJob>&& jobs);
-    void processSymbolExtractionStage(const std::string& hash, int64_t docId,
-                                      const std::string& filePath, const std::string& language,
-                                      std::vector<std::byte>* contentBytes);
     void processSymbolExtractionBatch(std::vector<InternalEventBus::SymbolExtractionJob>&& jobs);
     void processEntityExtractionBatch(std::vector<InternalEventBus::EntityExtractionJob>&& jobs);
     void processTitleExtractionBatch(std::vector<InternalEventBus::TitleExtractionJob>&& jobs);
@@ -474,9 +475,11 @@ private:
     void dispatchToEntityChannel(const std::string& hash, int64_t docId,
                                  const std::string& filePath, const std::string& extension,
                                  std::shared_ptr<std::vector<std::byte>> contentBytes);
+    // contentBytes may alias a buffer shared with the KG and symbol channels; the stage
+    // reads it in place and must never move out of it.
     void processEntityExtractionStage(const std::string& hash, int64_t docId,
                                       const std::string& filePath, const std::string& extension,
-                                      std::vector<std::byte>* contentBytes);
+                                      const std::vector<std::byte>* contentBytes);
     void dispatchToTitleChannel(const std::string& hash, int64_t docId,
                                 const std::string& textSnippet, const std::string& fallbackTitle,
                                 const std::string& filePath, const std::string& language,

--- a/include/yams/wal/wal_manager.h
+++ b/include/yams/wal/wal_manager.h
@@ -33,7 +33,9 @@ class WALManager {
 public:
     // Configuration for WAL behavior
     struct Config {
-        std::filesystem::path walDirectory = "./wal";
+        // Required. Callers pass an explicit directory (the daemon uses <dataDir>/wal);
+        // initialize() rejects an empty path instead of writing into the process CWD.
+        std::filesystem::path walDirectory;
         size_t maxLogSize = 100 * 1024 * 1024;      // 100MB per log file
         size_t syncInterval = 1000;                 // Sync every N entries
         std::chrono::milliseconds syncTimeout{100}; // Max time between syncs
@@ -53,7 +55,6 @@ public:
     };
 
     // Constructor
-    WALManager();
     explicit WALManager(Config config);
     ~WALManager();
 

--- a/src/daemon/components/PostIngestQueue.cpp
+++ b/src/daemon/components/PostIngestQueue.cpp
@@ -1923,64 +1923,6 @@ void PostIngestQueue::dispatchToSymbolChannel(
     }
 }
 
-void PostIngestQueue::processSymbolExtractionStage(const std::string& hash,
-                                                   [[maybe_unused]] int64_t docId,
-                                                   const std::string& filePath,
-                                                   const std::string& language,
-                                                   std::vector<std::byte>* contentBytes) {
-    // Legacy single-item handler (kept for now); metrics are owned by the poller layer.
-    if (!graphComponent_) {
-        spdlog::warn("[PostIngestQueue] Symbol extraction skipped for {} - no graphComponent",
-                     hash);
-        return;
-    }
-
-    spdlog::info("[PostIngestQueue] Symbol extraction starting for {} ({}) lang={}", filePath,
-                 hash.substr(0, 12), language);
-
-    try {
-        auto startTime = std::chrono::steady_clock::now();
-
-        // Use GraphComponent to submit the extraction job
-        GraphComponent::EntityExtractionJob extractJob;
-        extractJob.documentHash = hash;
-        extractJob.filePath = filePath;
-        extractJob.language = language;
-
-        std::vector<std::byte> bytes;
-        if (contentBytes) {
-            bytes = std::move(*contentBytes);
-        } else if (store_) {
-            auto contentResult = store_->retrieveBytes(hash);
-            if (contentResult) {
-                bytes = std::move(contentResult.value());
-            } else {
-                spdlog::warn("[PostIngestQueue] Failed to load content for symbol extraction: {}",
-                             hash.substr(0, 12));
-                return;
-            }
-        } else {
-            spdlog::warn("[PostIngestQueue] No content store for symbol extraction");
-            return;
-        }
-        extractJob.contentUtf8 =
-            std::string(reinterpret_cast<const char*>(bytes.data()), bytes.size());
-
-        auto result = graphComponent_->submitEntityExtraction(std::move(extractJob));
-        if (!result) {
-            spdlog::warn("[PostIngestQueue] Symbol extraction failed for {}: {}", hash,
-                         result.error().message);
-        } else {
-            auto duration = std::chrono::steady_clock::now() - startTime;
-            double ms = std::chrono::duration<double, std::milli>(duration).count();
-            spdlog::debug("[PostIngestQueue] Symbol extraction submitted for {} in {:.2f}ms", hash,
-                          ms);
-        }
-    } catch (const std::exception& e) {
-        spdlog::error("[PostIngestQueue] Symbol extraction failed for {}: {}", hash, e.what());
-    }
-}
-
 void PostIngestQueue::dispatchToEntityChannel(
     const std::string& hash, int64_t docId, const std::string& filePath,
     const std::string& extension, std::shared_ptr<std::vector<std::byte>> contentBytes) {
@@ -2051,7 +1993,7 @@ void PostIngestQueue::processEntityExtractionBatch(
 void PostIngestQueue::processEntityExtractionStage(const std::string& hash, int64_t docId,
                                                    const std::string& filePath,
                                                    const std::string& extension,
-                                                   std::vector<std::byte>* contentBytes) {
+                                                   const std::vector<std::byte>* contentBytes) {
     spdlog::info("[PostIngestQueue] Entity extraction starting for {} ({}) ext={}", filePath,
                  hash.substr(0, 12), extension);
 
@@ -2079,23 +2021,25 @@ void PostIngestQueue::processEntityExtractionStage(const std::string& hash, int6
             return;
         }
 
-        // Load content from store
-        std::vector<std::byte> content;
-        if (contentBytes) {
-            content = std::move(*contentBytes);
-        } else if (store_) {
+        // Read the dispatched buffer in place: the same bytes are shared with the KG and
+        // symbol channels, so moving out of it would starve whichever consumer runs later.
+        std::vector<std::byte> ownedFallback;
+        const std::vector<std::byte>* contentPtr = contentBytes;
+        if (!contentPtr) {
+            if (!store_) {
+                spdlog::warn("[PostIngestQueue] No content store for entity extraction");
+                return;
+            }
             auto contentResult = store_->retrieveBytes(hash);
-            if (contentResult) {
-                content = std::move(contentResult.value());
-            } else {
+            if (!contentResult) {
                 spdlog::warn("[PostIngestQueue] Failed to load content for entity extraction: {}",
                              hash.substr(0, 12));
                 return;
             }
-        } else {
-            spdlog::warn("[PostIngestQueue] No content store for entity extraction");
-            return;
+            ownedFallback = std::move(contentResult.value());
+            contentPtr = &ownedFallback;
         }
+        const std::vector<std::byte>& content = *contentPtr;
 
         if (!kg_) {
             spdlog::warn("[PostIngestQueue] No KG store for entity extraction");

--- a/src/wal/wal_manager.cpp
+++ b/src/wal/wal_manager.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <atomic>
 #include <condition_variable>
+#include <cstdint>
 #include <cstring>
 #include <deque>
 #include <fstream>
@@ -32,9 +33,8 @@ bool isWalLogFile(const std::filesystem::path& path) {
     return path.extension() == ".log" || isCompressedWalLog(path);
 }
 
-// A plain segment that never received an entry is either zero bytes (clean close truncates
-// to the write position) or an mmap preallocation left behind by a killed process, which
-// starts with zeros where the first entry's magic word would be.
+// Empty segments are zero-length or entirely zero-filled mmap preallocations. A zero
+// header alone can also be damage: preserve any nonzero bytes as recovery evidence.
 bool isEmptyWalSegment(const std::filesystem::path& path) {
     if (isCompressedWalLog(path)) {
         return false;
@@ -48,11 +48,21 @@ bool isEmptyWalSegment(const std::filesystem::path& path) {
         return true;
     }
     std::ifstream in(path, std::ios::binary);
-    std::array<char, sizeof(uint32_t)> head{};
-    if (!in.read(head.data(), static_cast<std::streamsize>(head.size()))) {
-        return false;
+    std::array<char, 64 * 1024> buffer{};
+    std::uintmax_t remaining = size;
+    while (remaining > 0) {
+        const auto count =
+            static_cast<std::streamsize>(std::min<std::uintmax_t>(remaining, buffer.size()));
+        if (!in.read(buffer.data(), count)) {
+            return false;
+        }
+        if (std::any_of(buffer.begin(), buffer.begin() + count, [](char c) { return c != 0; })) {
+            return false;
+        }
+        remaining -= static_cast<std::uintmax_t>(count);
     }
-    return std::all_of(head.begin(), head.end(), [](char c) { return c == 0; });
+    // Refuse to prune if the file grew while it was inspected or EOF cannot be read.
+    return in.peek() == std::ifstream::traits_type::eof() && !in.bad();
 }
 
 std::optional<yams::compression::CompressionAlgorithm>

--- a/src/wal/wal_manager.cpp
+++ b/src/wal/wal_manager.cpp
@@ -4,6 +4,7 @@
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <condition_variable>
 #include <cstring>
@@ -29,6 +30,29 @@ bool isCompressedWalLog(const std::filesystem::path& path) {
 
 bool isWalLogFile(const std::filesystem::path& path) {
     return path.extension() == ".log" || isCompressedWalLog(path);
+}
+
+// A plain segment that never received an entry is either zero bytes (clean close truncates
+// to the write position) or an mmap preallocation left behind by a killed process, which
+// starts with zeros where the first entry's magic word would be.
+bool isEmptyWalSegment(const std::filesystem::path& path) {
+    if (isCompressedWalLog(path)) {
+        return false;
+    }
+    std::error_code ec;
+    const auto size = std::filesystem::file_size(path, ec);
+    if (ec) {
+        return false;
+    }
+    if (size == 0) {
+        return true;
+    }
+    std::ifstream in(path, std::ios::binary);
+    std::array<char, sizeof(uint32_t)> head{};
+    if (!in.read(head.data(), static_cast<std::streamsize>(head.size()))) {
+        return false;
+    }
+    return std::all_of(head.begin(), head.end(), [](char c) { return c == 0; });
 }
 
 std::optional<yams::compression::CompressionAlgorithm>
@@ -477,14 +501,16 @@ struct WALManager::Impl {
     }
 };
 
-WALManager::WALManager() : pImpl(std::make_unique<Impl>(Config{})) {}
-
 WALManager::WALManager(Config config) : pImpl(std::make_unique<Impl>(std::move(config))) {}
 
 WALManager::WALManager(WALManager&&) noexcept = default;
 WALManager& WALManager::operator=(WALManager&&) noexcept = default;
 
 Result<void> WALManager::initialize() {
+    if (pImpl->config.walDirectory.empty()) {
+        return Result<void>(Error{ErrorCode::InvalidArgument, "WAL directory is not configured"});
+    }
+
     // Create WAL directory if needed
     if (!std::filesystem::exists(pImpl->config.walDirectory)) {
         if (!yams::common::ensureDirectories(pImpl->config.walDirectory)) {
@@ -492,11 +518,16 @@ Result<void> WALManager::initialize() {
         }
     }
 
-    // Find the latest sequence number from existing logs
+    // Find the latest sequence number from existing logs. Every log that was ever opened
+    // counts, including empty ones, so the sequence stays monotonic across restarts.
     uint64_t maxSeq = 0;
+    std::vector<std::filesystem::path> emptySegments;
     for (const auto& entry : std::filesystem::directory_iterator(pImpl->config.walDirectory)) {
         if (!isWalLogFile(entry.path())) {
             continue;
+        }
+        if (isEmptyWalSegment(entry.path())) {
+            emptySegments.push_back(entry.path());
         }
 
         auto stemPath = entry.path().stem();
@@ -519,6 +550,21 @@ Result<void> WALManager::initialize() {
     }
 
     pImpl->sequenceNumber = maxSeq;
+
+    // openNewLog() creates a segment on every start; a segment that never received an
+    // entry carries nothing to recover and only slows every later directory scan.
+    for (const auto& path : emptySegments) {
+        std::error_code removeEc;
+        std::filesystem::remove(path, removeEc);
+        if (removeEc) {
+            spdlog::warn("Failed to prune empty WAL segment {}: {}", path.string(),
+                         removeEc.message());
+        }
+    }
+    if (!emptySegments.empty()) {
+        spdlog::info("Pruned {} empty WAL segment(s) from {}", emptySegments.size(),
+                     pImpl->config.walDirectory.string());
+    }
 
     // Open new log file
     auto result = pImpl->openNewLog();

--- a/tests/unit/daemon/components/post_ingest_queue_unit_catch2_test.cpp
+++ b/tests/unit/daemon/components/post_ingest_queue_unit_catch2_test.cpp
@@ -12,6 +12,7 @@
 
 #include "src/daemon/components/post_ingest_nl_graph_builder.h"
 #include <yams/daemon/components/PostIngestQueue.h>
+#include <yams/daemon/resource/external_entity_provider_adapter.h>
 #include <yams/metadata/path_utils.h>
 
 using namespace yams::daemon;
@@ -143,6 +144,38 @@ TEST_CASE("PostIngestQueue rejects and accounts KG admission after stop",
     CHECK(bus.kgQueued() == queuedBefore);
     CHECK(bus.kgDropped() == droppedBefore + 1);
     CHECK(queue.testing_pendingKgJobs() == 0);
+}
+
+TEST_CASE("PostIngestQueue entity stage leaves the shared content buffer intact",
+          "[daemon][post-ingest][entity][catch2]") {
+    // dispatchNonEmbeddingStages hands one shared_ptr<vector<byte>> to the KG, symbol,
+    // and entity channels. Any consumer that moves out of it starves the others.
+    PostIngestQueue queue{nullptr, nullptr, {}, nullptr, nullptr, nullptr, nullptr, 8};
+    queue.stop();
+    auto provider = std::make_shared<ExternalEntityProviderAdapter>(
+        nullptr, "fake-entity-plugin", "fake.getEntities", std::vector<std::string>{".bin"});
+    queue.setEntityProviders({provider});
+
+    const std::string payload = "shared content bytes";
+    auto shared = std::make_shared<std::vector<std::byte>>(payload.size());
+    std::transform(payload.begin(), payload.end(), shared->begin(),
+                   [](char c) { return static_cast<std::byte>(c); });
+    const auto expectedSize = shared->size();
+
+    InternalEventBus::EntityExtractionJob first;
+    first.hash = "shared-buffer-hash";
+    first.documentId = 1;
+    first.filePath = "a.bin";
+    first.extension = ".bin";
+    first.contentBytes = shared;
+    InternalEventBus::EntityExtractionJob second = first;
+
+    std::vector<InternalEventBus::EntityExtractionJob> jobs;
+    jobs.push_back(std::move(first));
+    jobs.push_back(std::move(second));
+    queue.testing_processEntityExtractionBatch(std::move(jobs));
+
+    CHECK(shared->size() == expectedSize);
 }
 
 TEST_CASE("PostIngestQueue stage constants", "[daemon][post-ingest][catch2]") {

--- a/tests/unit/wal/wal_manager_catch2_test.cpp
+++ b/tests/unit/wal/wal_manager_catch2_test.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include <chrono>
 #include <filesystem>
@@ -150,6 +151,40 @@ TEST_CASE("WALManager transaction lifecycle updates stats and enforces state",
 
     CHECK(manager.getStats().activeTransactions == 0);
     REQUIRE(manager.shutdown());
+}
+
+TEST_CASE("WALManager initialize preserves nonempty segments with a zero prefix",
+          "[unit][wal][manager]") {
+    TempDir temp;
+    const auto walDir = temp.path / "wal";
+    std::filesystem::create_directories(walDir);
+    const auto damagedLog = walDir / "wal_20240101_010159_150.log";
+    const auto size = GENERATE(std::size_t{3}, std::size_t{5}, std::size_t{64 * 1024},
+                               std::size_t{128 * 1024 + 1});
+    std::string original(size, '\0');
+    original.back() = 'x'; // Include short reads, buffer boundaries, and a trailing partial block.
+    {
+        std::ofstream out(damagedLog, std::ios::binary);
+        out.write(original.data(), static_cast<std::streamsize>(original.size()));
+        REQUIRE(out.good());
+    }
+
+    WALManager::Config cfg;
+    cfg.walDirectory = walDir;
+    cfg.compressOldLogs = false;
+    cfg.enableGroupCommit = false;
+    WALManager manager(cfg);
+    REQUIRE(manager.initialize());
+    CHECK(manager.getCurrentSequence() == 150);
+    REQUIRE(manager.shutdown());
+
+    REQUIRE(std::filesystem::exists(damagedLog));
+    REQUIRE(std::filesystem::file_size(damagedLog) == original.size());
+    std::ifstream in(damagedLog, std::ios::binary);
+    std::string preserved(original.size(), '\0');
+    in.read(preserved.data(), static_cast<std::streamsize>(preserved.size()));
+    REQUIRE(in.good());
+    CHECK(preserved == original);
 }
 
 TEST_CASE("WALManager initialize rejects an unconfigured directory", "[unit][wal][manager]") {

--- a/tests/unit/wal/wal_manager_catch2_test.cpp
+++ b/tests/unit/wal/wal_manager_catch2_test.cpp
@@ -151,3 +151,65 @@ TEST_CASE("WALManager transaction lifecycle updates stats and enforces state",
     CHECK(manager.getStats().activeTransactions == 0);
     REQUIRE(manager.shutdown());
 }
+
+TEST_CASE("WALManager initialize rejects an unconfigured directory", "[unit][wal][manager]") {
+    WALManager::Config cfg;
+    cfg.enableGroupCommit = false;
+    REQUIRE(cfg.walDirectory.empty());
+
+    WALManager manager(cfg);
+    auto result = manager.initialize();
+    REQUIRE_FALSE(result);
+    CHECK(result.error().code == ErrorCode::InvalidArgument);
+}
+
+TEST_CASE("WALManager initialize prunes empty log segments but keeps their sequence",
+          "[unit][wal][manager]") {
+    TempDir temp;
+    auto walDir = temp.path / "wal";
+    std::filesystem::create_directories(walDir);
+    for (int i = 0; i < 50; ++i) {
+        std::ofstream empty((walDir / ("wal_20240101_0101" + std::to_string(10 + i) + "_" +
+                                       std::to_string(100 + i) + ".log"))
+                                .string(),
+                            std::ios::binary);
+        REQUIRE(empty.good());
+    }
+    {
+        // A killed writer leaves the mmap preallocation behind: 1 MiB of zeros, no entry.
+        std::ofstream preallocated((walDir / "wal_20240101_010159_150.log").string(),
+                                   std::ios::binary);
+        std::string zeros(1024 * 1024, '\0');
+        preallocated.write(zeros.data(), static_cast<std::streamsize>(zeros.size()));
+        REQUIRE(preallocated.good());
+    }
+    {
+        std::ofstream nonEmpty((walDir / "wal_20240101_010200_7.log").string(), std::ios::binary);
+        nonEmpty << "not-a-real-entry";
+        REQUIRE(nonEmpty.good());
+    }
+
+    WALManager::Config cfg;
+    cfg.walDirectory = walDir;
+    cfg.compressOldLogs = false;
+    cfg.enableGroupCommit = false;
+    WALManager manager(cfg);
+    REQUIRE(manager.initialize());
+
+    CHECK(manager.getCurrentSequence() == 150);
+
+    std::size_t logFiles = 0;
+    bool nonEmptySurvived = false;
+    for (const auto& entry : std::filesystem::directory_iterator(walDir)) {
+        if (entry.path().extension() == ".log") {
+            ++logFiles;
+            if (entry.path().filename() == "wal_20240101_010200_7.log") {
+                nonEmptySurvived = true;
+            }
+        }
+    }
+    CHECK(nonEmptySurvived);
+    // The non-empty segment plus the freshly opened active log.
+    CHECK(logFiles == 2);
+    REQUIRE(manager.shutdown());
+}


### PR DESCRIPTION
## Purpose

Correct ingest buffer consumption and explicit WAL lifecycle

## Behavior changes

Consume shared content in place; require explicit WAL directory; prune proven-empty segments only after correction

## Compatibility impact

Callers must provide WAL directory; damaged recovery evidence must be retained

## Structural evidence

Removed unused buffer mover and copying path; source-level WAL responsibility review, not line-count claims

Pinned same-root Brick archive comparisons are available for all groups and the cumulative stack. Bounded extraction-seam review verified149 resolved includes. Final graph has1158 parser diagnostics across619 files and0.089 local dependency resolution; experimental score68.708 versus68.820 baseline. Partial heuristic coverage is not architecture quality or runtime correctness proof.

## Tests

Shared-buffer regression; explicit-directory errors; zero-length/all-zero/nonzero-tail damaged WAL fixtures; restart sequence monotonicity

Cumulative exact-final validation at `661e33c2273d7e684b41ad006e925912263dc9f5`: full canonical ASan/UBSan 204/0 and TSan 289/0; installed-only MemorySyncLoop publish/sync/read and TuneAdvisor consumer passed. These final-tip results do not certify each intermediate head independently. Policy checks found zero new portability/raw-environment/configuration violations or benchmark environment leaks.

Final-tip SciFact: 2000-document plan, 50 measured hybrid queries, k=10, three repeats per arm. Product/untraced, topology-off/untraced, and shadow/traced produced identical measured hybrid rankings (MRR 0.676667; recall@10 0.793333). Mean p50: 323.667/306.333/352 ms respectively. ASan/UBSan debug timings only; not production latency, a source-revision before/after comparison, or a performance-win claim.

## Dependencies

Group 1/14; base `experimental`, prepared head `a636204f42560304a6102b358303bab0bf16f6cf`. experimental; preserves merged topology114

All42 newly prepared commits have valid signatures and exact trvon DCO trailers. Inherited PR115 commit5393a5a8 is unsigned and lacks DCO; the user explicitly approved retaining this inherited exception to preserve fast-forward history. No exception applies to newly prepared commits.

Source replay mapping:
- `5393a5a8` → `5393a5a87802acd85126fb4ea7030099a6d2329a`
- `d6ab529c` → `9dc37e0af96b85cc49b48dc930a8d39873d40936`
