### PR TITLE
fix(wal): require an explicit WAL directory and prune empty segments

### DIFF
--- a/include/yams/wal/wal_manager.h
+++ b/include/yams/wal/wal_manager.h
@@ -33,7 +33,9 @@ class WALManager {
 public:
     // Configuration for WAL behavior
     struct Config {
-        std::filesystem::path walDirectory = "./wal";
+        // Required. Callers pass an explicit directory (the daemon uses <dataDir>/wal);
+        // initialize() rejects an empty path instead of writing into the process CWD.
+        std::filesystem::path walDirectory;
         size_t maxLogSize = 100 * 1024 * 1024;      // 100MB per log file
         size_t syncInterval = 1000;                 // Sync every N entries
         std::chrono::milliseconds syncTimeout{100}; // Max time between syncs
@@ -53,7 +55,6 @@ public:
     };
 
     // Constructor
-    WALManager();
     explicit WALManager(Config config);
     ~WALManager();
 

--- a/src/wal/wal_manager.cpp
+++ b/src/wal/wal_manager.cpp
@@ -4,6 +4,7 @@
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <condition_variable>
 #include <cstring>
@@ -29,6 +30,29 @@ bool isCompressedWalLog(const std::filesystem::path& path) {
 
 bool isWalLogFile(const std::filesystem::path& path) {
     return path.extension() == ".log" || isCompressedWalLog(path);
+}
+
+// A plain segment that never received an entry is either zero bytes (clean close truncates
+// to the write position) or an mmap preallocation left behind by a killed process, which
+// starts with zeros where the first entry's magic word would be.
+bool isEmptyWalSegment(const std::filesystem::path& path) {
+    if (isCompressedWalLog(path)) {
+        return false;
+    }
+    std::error_code ec;
+    const auto size = std::filesystem::file_size(path, ec);
+    if (ec) {
+        return false;
+    }
+    if (size == 0) {
+        return true;
+    }
+    std::ifstream in(path, std::ios::binary);
+    std::array<char, sizeof(uint32_t)> head{};
+    if (!in.read(head.data(), static_cast<std::streamsize>(head.size()))) {
+        return false;
+    }
+    return std::all_of(head.begin(), head.end(), [](char c) { return c == 0; });
 }
 
 std::optional<yams::compression::CompressionAlgorithm>
@@ -477,14 +501,16 @@ struct WALManager::Impl {
     }
 };
 
-WALManager::WALManager() : pImpl(std::make_unique<Impl>(Config{})) {}
-
 WALManager::WALManager(Config config) : pImpl(std::make_unique<Impl>(std::move(config))) {}
 
 WALManager::WALManager(WALManager&&) noexcept = default;
 WALManager& WALManager::operator=(WALManager&&) noexcept = default;
 
 Result<void> WALManager::initialize() {
+    if (pImpl->config.walDirectory.empty()) {
+        return Result<void>(Error{ErrorCode::InvalidArgument, "WAL directory is not configured"});
+    }
+
     // Create WAL directory if needed
     if (!std::filesystem::exists(pImpl->config.walDirectory)) {
         if (!yams::common::ensureDirectories(pImpl->config.walDirectory)) {
@@ -492,11 +518,16 @@ Result<void> WALManager::initialize() {
         }
     }
 
-    // Find the latest sequence number from existing logs
+    // Find the latest sequence number from existing logs. Every log that was ever opened
+    // counts, including empty ones, so the sequence stays monotonic across restarts.
     uint64_t maxSeq = 0;
+    std::vector<std::filesystem::path> emptySegments;
     for (const auto& entry : std::filesystem::directory_iterator(pImpl->config.walDirectory)) {
         if (!isWalLogFile(entry.path())) {
             continue;
+        }
+        if (isEmptyWalSegment(entry.path())) {
+            emptySegments.push_back(entry.path());
         }
 
         auto stemPath = entry.path().stem();
@@ -519,6 +550,21 @@ Result<void> WALManager::initialize() {
     }
 
     pImpl->sequenceNumber = maxSeq;
+
+    // openNewLog() creates a segment on every start; a segment that never received an
+    // entry carries nothing to recover and only slows every later directory scan.
+    for (const auto& path : emptySegments) {
+        std::error_code removeEc;
+        std::filesystem::remove(path, removeEc);
+        if (removeEc) {
+            spdlog::warn("Failed to prune empty WAL segment {}: {}", path.string(),
+                         removeEc.message());
+        }
+    }
+    if (!emptySegments.empty()) {
+        spdlog::info("Pruned {} empty WAL segment(s) from {}", emptySegments.size(),
+                     pImpl->config.walDirectory.string());
+    }
 
     // Open new log file
     auto result = pImpl->openNewLog();

--- a/tests/unit/wal/wal_manager_catch2_test.cpp
+++ b/tests/unit/wal/wal_manager_catch2_test.cpp
@@ -151,3 +151,65 @@ TEST_CASE("WALManager transaction lifecycle updates stats and enforces state",
     CHECK(manager.getStats().activeTransactions == 0);
     REQUIRE(manager.shutdown());
 }
+
+TEST_CASE("WALManager initialize rejects an unconfigured directory", "[unit][wal][manager]") {
+    WALManager::Config cfg;
+    cfg.enableGroupCommit = false;
+    REQUIRE(cfg.walDirectory.empty());
+
+    WALManager manager(cfg);
+    auto result = manager.initialize();
+    REQUIRE_FALSE(result);
+    CHECK(result.error().code == ErrorCode::InvalidArgument);
+}
+
+TEST_CASE("WALManager initialize prunes empty log segments but keeps their sequence",
+          "[unit][wal][manager]") {
+    TempDir temp;
+    auto walDir = temp.path / "wal";
+    std::filesystem::create_directories(walDir);
+    for (int i = 0; i < 50; ++i) {
+        std::ofstream empty((walDir / ("wal_20240101_0101" + std::to_string(10 + i) + "_" +
+                                       std::to_string(100 + i) + ".log"))
+                                .string(),
+                            std::ios::binary);
+        REQUIRE(empty.good());
+    }
+    {
+        // A killed writer leaves the mmap preallocation behind: 1 MiB of zeros, no entry.
+        std::ofstream preallocated((walDir / "wal_20240101_010159_150.log").string(),
+                                   std::ios::binary);
+        std::string zeros(1024 * 1024, '\0');
+        preallocated.write(zeros.data(), static_cast<std::streamsize>(zeros.size()));
+        REQUIRE(preallocated.good());
+    }
+    {
+        std::ofstream nonEmpty((walDir / "wal_20240101_010200_7.log").string(), std::ios::binary);
+        nonEmpty << "not-a-real-entry";
+        REQUIRE(nonEmpty.good());
+    }
+
+    WALManager::Config cfg;
+    cfg.walDirectory = walDir;
+    cfg.compressOldLogs = false;
+    cfg.enableGroupCommit = false;
+    WALManager manager(cfg);
+    REQUIRE(manager.initialize());
+
+    CHECK(manager.getCurrentSequence() == 150);
+
+    std::size_t logFiles = 0;
+    bool nonEmptySurvived = false;
+    for (const auto& entry : std::filesystem::directory_iterator(walDir)) {
+        if (entry.path().extension() == ".log") {
+            ++logFiles;
+            if (entry.path().filename() == "wal_20240101_010200_7.log") {
+                nonEmptySurvived = true;
+            }
+        }
+    }
+    CHECK(nonEmptySurvived);
+    // The non-empty segment plus the freshly opened active log.
+    CHECK(logFiles == 2);
+    REQUIRE(manager.shutdown());
+}


### PR DESCRIPTION
fix(wal): require an explicit WAL directory and prune empty segments

WALManager::Config defaulted walDirectory to "./wal", so any manager built
from a default config wrote segments into the process working directory.
The repo root had accumulated 43,577 such files (42,499 zero-byte, 1,078
zero-filled 1 MiB mmap preallocations from killed writers; 1.1 GB, no
entries). The daemon already passes <dataDir>/wal explicitly.

- walDirectory has no default; initialize() returns InvalidArgument when
  it is empty. The default constructor is removed (it had no callers).
- initialize() still derives the sequence from every segment name, then
  deletes plain segments that never received an entry: zero bytes, or a
  zero magic word at offset 0 (a preallocation left by an unclean exit).
  Compressed segments and anything with real bytes are untouched.

Tests: unconfigured directory is rejected; 50 empty + 1 preallocated
segments are pruned, a non-empty one survives, and the sequence still
advances past the pruned names.

---
Stack position 2 of 29; base branch `stack/09-ingest-shared-content-buffer` (merge in order).
