### PR TITLE
tools(policy): report where every configuration key is referenced

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -43,6 +43,7 @@ configuration_authority_policy_tests = files('scripts/test_check_configuration_a
 production_environment_keys = files('scripts/production_environment_keys.txt')
 configuration_reader_allowlist = files('scripts/configuration_reader_allowlist.txt')
 retrieval_contract_tests = files('benchmarks/test_retrieval_contract.py')
+config_key_usage_report_tests = files('scripts/test_report_config_key_usage.py')
 portability_policy_script = files('scripts/check_portability.py')
 portability_policy_tests = files('scripts/test_check_portability.py')
 portability_allowlist = files('scripts/portability_allowlist.txt')
@@ -123,6 +124,12 @@ test('configuration_authority_policy',
     '--environment-allowlist', production_environment_keys,
     '--reader-allowlist', configuration_reader_allowlist,
   ],
+  suite: ['unit', 'policy', 'configuration'],
+  timeout: 30,
+)
+test('config_key_usage_report_unit',
+  python_exe,
+  args: [config_key_usage_report_tests],
   suite: ['unit', 'policy', 'configuration'],
   timeout: 30,
 )

--- a/tests/scripts/check_configuration_authority.py
+++ b/tests/scripts/check_configuration_authority.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Fail on new production YAMS_* surfaces or duplicate TOML reader definitions."""
+"""Fail on new production YAMS_* surfaces or duplicate TOML reader definitions.
+
+The allowlists are a ratchet in both directions: an entry whose key or reader no
+longer exists in the source tree fails too, so the reviewed surface can only shrink.
+"""
 
 from __future__ import annotations
 
@@ -63,10 +67,24 @@ def normalized_definition(entry: str) -> str:
     return f"{path}:{name}"
 
 
+def stale_entries(
+    root: Path, environment_allowlist: Path, reader_allowlist: Path
+) -> tuple[list[str], list[str]]:
+    """Allowlist entries with no remaining occurrence in the source tree."""
+    allowed_keys = read_allowlist(environment_allowlist)
+    current_keys = production_environment_keys(root)
+    allowed_readers = read_allowlist(reader_allowlist)
+    current_readers = {
+        normalized_definition(definition) for definition in toml_reader_definitions(root)
+    }
+    return sorted(allowed_keys - current_keys), sorted(allowed_readers - current_readers)
+
+
 def run(root: Path, environment_allowlist: Path, reader_allowlist: Path) -> int:
     allowed_keys = read_allowlist(environment_allowlist)
     current_keys = production_environment_keys(root)
     unknown_keys = sorted(current_keys - allowed_keys)
+    stale_keys = sorted(allowed_keys - current_keys)
 
     allowed_readers = read_allowlist(reader_allowlist)
     definitions = sorted(toml_reader_definitions(root))
@@ -75,6 +93,8 @@ def run(root: Path, environment_allowlist: Path, reader_allowlist: Path) -> int:
         for definition in definitions
         if normalized_definition(definition) not in allowed_readers
     ]
+    current_readers = {normalized_definition(definition) for definition in definitions}
+    stale_readers = sorted(allowed_readers - current_readers)
 
     if unknown_keys:
         print(
@@ -89,13 +109,27 @@ def run(root: Path, environment_allowlist: Path, reader_allowlist: Path) -> int:
         )
         for definition in unknown_readers:
             print(f"  {definition}", file=sys.stderr)
-    if unknown_keys or unknown_readers:
+    if stale_keys:
+        print(
+            f"stale YAMS_* entries: delete these lines from {environment_allowlist.name}:",
+            file=sys.stderr,
+        )
+        for key in stale_keys:
+            print(f"  {key}", file=sys.stderr)
+    if stale_readers:
+        print(
+            f"stale TOML reader entries: delete these lines from {reader_allowlist.name}:",
+            file=sys.stderr,
+        )
+        for definition in stale_readers:
+            print(f"  {definition}", file=sys.stderr)
+    if unknown_keys or unknown_readers or stale_keys or stale_readers:
         return 1
 
     print(
         "configuration authority policy: "
         f"{len(current_keys)} reviewed YAMS_* literal(s), "
-        f"{len(definitions)} reviewed TOML reader definition(s), 0 new"
+        f"{len(definitions)} reviewed TOML reader definition(s), 0 new, 0 stale"
     )
     return 0
 

--- a/tests/scripts/production_environment_keys.txt
+++ b/tests/scripts/production_environment_keys.txt
@@ -1,5 +1,6 @@
 # Reviewed production string literals that name YAMS_* environment surfaces.
-# New entries require typed-config/provenance review; removals may remain grandfathered.
+# New entries require typed-config/provenance review. Entries whose key no longer
+# appears in src/, include/, or tools/ fail the policy and must be deleted here.
 YAMS_ADMISSION_CONTROL
 YAMS_ALLOW_MODEL_DOWNLOAD
 YAMS_AUTOLOAD_PLUGINS

--- a/tests/scripts/report_config_key_usage.py
+++ b/tests/scripts/report_config_key_usage.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Report where every reviewed configuration key is referenced.
+
+Input keys come from two places: the YAMS_* environment allowlist, and the dotted
+TOML keys literally resolved in ConfigResolver.cpp. For each key the report counts
+references per tree bucket and assigns a verdict:
+
+  KEEP        referenced by a test, bench, doc, script, or plugin
+  CANDIDATE   referenced only by product code (and the allowlists): nothing outside
+              src/ exercises or documents it, so removal needs no consumer migration
+  NOT_IN_SRC  the key is listed but no product code mentions it (stale allowlist)
+
+A verdict is evidence for review, not a decision. Key deletions must cite the
+CANDIDATE rows of this report in the change description.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+SRC_ROOTS = ("src", "include", "tools")
+BUCKET_ROOTS = {
+    "src": ("src", "include", "tools"),
+    "test": ("tests",),
+    "bench": ("tests/benchmarks", "scripts"),
+    "docs": ("docs",),
+    "plugin": ("plugins",),
+}
+SKIP_DIRS = {"build", "builddir", "third_party", "subprojects", "external", "site",
+             "public", "__pycache__", ".git", "node_modules"}
+TEXT_SUFFIXES = {".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".py", ".md", ".toml",
+                 ".txt", ".yml", ".yaml", ".json", ".sh", ".build", ".cfg", ".ini", ".lean"}
+# Allowlists list every key by construction; they are not consumers.
+SKIP_FILES = {"tests/scripts/production_environment_keys.txt",
+              "tests/scripts/raw_environment_allowlist.txt",
+              "tests/scripts/portability_allowlist.txt",
+              "tests/scripts/configuration_reader_allowlist.txt"}
+ENV_TOKEN_RE = re.compile(r"(?<![A-Z0-9_])(YAMS_[A-Z0-9_]+)(?![A-Z0-9_])")
+TOML_TOKEN_RE = re.compile(r"(?<![A-Za-z0-9_.])([a-z_]+(?:\.[a-z_]+)+)(?![A-Za-z0-9_.])")
+TOML_LITERAL_RE = re.compile(r"\"([a-z_]+(?:\.[a-z_]+)+)\"")
+
+
+def read_allowlist(path: Path) -> list[str]:
+    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")]
+
+
+def resolver_toml_keys(resolver: Path) -> list[str]:
+    return sorted(set(TOML_LITERAL_RE.findall(resolver.read_text(encoding="utf-8",
+                                                                  errors="ignore"))))
+
+
+def tracked_files(root: Path) -> set[str] | None:
+    """Paths git tracks under root, or None when root is not a git work tree.
+
+    Verdicts must be reproducible by a reviewer, so untracked local files (ignored bench
+    harnesses, scratch scripts) never count as consumers.
+    """
+    if not (root / ".git").exists():
+        # Not a repository root (a synthetic tree under a temp or build dir): scan it plainly.
+        return None
+    # Git exports GIT_DIR/GIT_WORK_TREE to hooks; inside a pre-push hook that would make git
+    # answer for the hook's repository instead of `root`. Ask about `root` alone.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    try:
+        top = subprocess.run(["git", "-C", str(root), "rev-parse", "--show-toplevel"],
+                             capture_output=True, check=True, text=True, env=env).stdout.strip()
+        if Path(top).resolve() != root.resolve():
+            return None
+        out = subprocess.run(["git", "-C", str(root), "ls-files", "-z"], capture_output=True,
+                             check=True, text=True, env=env).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return {entry for entry in out.split("\0") if entry}
+
+
+def iter_text_files(root: Path, relative_roots: tuple[str, ...], tracked: set[str] | None):
+    for relative in relative_roots:
+        base = root / relative
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*"):
+            rel = path.relative_to(root).as_posix()
+            if any(part in SKIP_DIRS for part in path.relative_to(root).parts):
+                continue
+            if not path.is_file() or path.suffix.lower() not in TEXT_SUFFIXES:
+                continue
+            if rel in SKIP_FILES:
+                continue
+            if tracked is not None and rel not in tracked:
+                continue
+            yield path
+
+
+def bucket_counts(root: Path, relative_roots: tuple[str, ...],
+                  exclude: tuple[str, ...] = (),
+                  tracked: set[str] | None = None) -> tuple[Counter, Counter]:
+    env: Counter = Counter()
+    toml: Counter = Counter()
+    for path in iter_text_files(root, relative_roots, tracked):
+        rel = path.relative_to(root).as_posix()
+        if any(rel.startswith(prefix) for prefix in exclude):
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        env.update(ENV_TOKEN_RE.findall(text))
+        toml.update(TOML_TOKEN_RE.findall(text))
+    return env, toml
+
+
+def build_report(root: Path, env_keys: list[str], toml_keys: list[str]) -> list[dict]:
+    tracked = tracked_files(root)
+    counts = {
+        "src": bucket_counts(root, BUCKET_ROOTS["src"], tracked=tracked),
+        # tests/ minus benchmarks, which are their own bucket.
+        "test": bucket_counts(root, BUCKET_ROOTS["test"], exclude=("tests/benchmarks/",),
+                              tracked=tracked),
+        "bench": bucket_counts(root, BUCKET_ROOTS["bench"], tracked=tracked),
+        "docs": bucket_counts(root, BUCKET_ROOTS["docs"], tracked=tracked),
+        "plugin": bucket_counts(root, BUCKET_ROOTS["plugin"], tracked=tracked),
+    }
+    rows = []
+    for kind, keys in (("env", env_keys), ("toml", toml_keys)):
+        idx = 0 if kind == "env" else 1
+        for key in keys:
+            row = {"kind": kind, "key": key}
+            for bucket, pair in counts.items():
+                row[bucket] = pair[idx][key]
+            if row["src"] == 0:
+                row["verdict"] = "NOT_IN_SRC"
+            elif row["test"] or row["bench"] or row["docs"] or row["plugin"]:
+                row["verdict"] = "KEEP"
+            else:
+                row["verdict"] = "CANDIDATE"
+            rows.append(row)
+    rows.sort(key=lambda r: (r["kind"], r["verdict"], r["key"]))
+    return rows
+
+
+COLUMNS = ("kind", "key", "src", "test", "bench", "docs", "plugin", "verdict")
+
+
+def write_tsv(rows: list[dict], out) -> None:
+    out.write("\t".join(COLUMNS) + "\n")
+    for row in rows:
+        out.write("\t".join(str(row[c]) for c in COLUMNS) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--environment-allowlist", type=Path,
+                        default=Path("tests/scripts/production_environment_keys.txt"))
+    parser.add_argument("--resolver", type=Path,
+                        default=Path("src/daemon/components/ConfigResolver.cpp"))
+    parser.add_argument("--prefix", default="",
+                        help="only report keys starting with this prefix")
+    parser.add_argument("--verdict", default="",
+                        help="only report rows with this verdict")
+    args = parser.parse_args()
+    root = args.root.resolve()
+    env_allowlist = args.environment_allowlist
+    if not env_allowlist.is_absolute():
+        env_allowlist = root / env_allowlist
+    resolver = args.resolver
+    if not resolver.is_absolute():
+        resolver = root / resolver
+    env_keys = read_allowlist(env_allowlist) if env_allowlist.is_file() else []
+    toml_keys = resolver_toml_keys(resolver) if resolver.is_file() else []
+    rows = build_report(root, env_keys, toml_keys)
+    if args.prefix:
+        rows = [r for r in rows if r["key"].startswith(args.prefix)]
+    if args.verdict:
+        rows = [r for r in rows if r["verdict"] == args.verdict]
+    write_tsv(rows, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_configuration_authority.py
+++ b/tests/scripts/test_check_configuration_authority.py
@@ -56,6 +56,31 @@ class ConfigurationAuthorityPolicyTest(unittest.TestCase):
             POLICY.run(self.root, self.env_allowlist, self.reader_allowlist), 1
         )
 
+    def test_stale_environment_key_fails(self) -> None:
+        # Nothing in src/ mentions YAMS_EXISTING any more: the allowlist must shrink.
+        (self.root / "src" / "config.cpp").write_text(
+            "Config parseSimpleTomlFlat(const Path&) { return {}; }\n", encoding="utf-8"
+        )
+        self.assertEqual(
+            POLICY.run(self.root, self.env_allowlist, self.reader_allowlist), 1
+        )
+
+    def test_stale_reader_entry_fails(self) -> None:
+        (self.root / "src" / "config.cpp").write_text(
+            'const char* key = "YAMS_EXISTING";\n', encoding="utf-8"
+        )
+        self.assertEqual(
+            POLICY.run(self.root, self.env_allowlist, self.reader_allowlist), 1
+        )
+
+    def test_stale_entries_are_named(self) -> None:
+        (self.root / "src" / "config.cpp").write_text("int x;\n", encoding="utf-8")
+        stale_keys, stale_readers = POLICY.stale_entries(
+            self.root, self.env_allowlist, self.reader_allowlist
+        )
+        self.assertEqual(stale_keys, ["YAMS_EXISTING"])
+        self.assertEqual(stale_readers, ["src/config.cpp:parseSimpleTomlFlat"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/scripts/test_report_config_key_usage.py
+++ b/tests/scripts/test_report_config_key_usage.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Tests for the configuration key usage report."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("report_config_key_usage.py")
+SPEC = importlib.util.spec_from_file_location("report_config_key_usage", SCRIPT)
+assert SPEC and SPEC.loader
+REPORT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(REPORT)
+
+
+class ConfigKeyUsageReportTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        for rel in ("src", "tests/scripts", "tests/benchmarks", "docs", "plugins", "build"):
+            (self.root / rel).mkdir(parents=True)
+        (self.root / "src" / "knobs.cpp").write_text(
+            'getenv("YAMS_ONLY_IN_SRC"); getenv("YAMS_BENCHED"); getenv("YAMS_DOCUMENTED");\n'
+            'resolve("search.only_in_src"); resolve("search.tested");\n',
+            encoding="utf-8",
+        )
+        (self.root / "tests" / "scripts" / "production_environment_keys.txt").write_text(
+            "# allowlist\nYAMS_ONLY_IN_SRC\nYAMS_BENCHED\nYAMS_DOCUMENTED\nYAMS_STALE\n"
+            "YAMS_BENCHED_LONGER\n",
+            encoding="utf-8",
+        )
+        (self.root / "tests" / "benchmarks" / "arms.py").write_text(
+            'ARMS = {"YAMS_BENCHED": "1", "YAMS_BENCHED_LONGER": "2"}\n', encoding="utf-8"
+        )
+        (self.root / "tests" / "unit_test.cpp").write_text(
+            'cfg = "search.tested = 3";\n', encoding="utf-8"
+        )
+        (self.root / "docs" / "config.md").write_text("Set `YAMS_DOCUMENTED`.\n",
+                                                        encoding="utf-8")
+        # Build output must never count as a consumer.
+        (self.root / "build" / "generated.cpp").write_text(
+            'getenv("YAMS_ONLY_IN_SRC"); "search.only_in_src"\n', encoding="utf-8"
+        )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def rows(self) -> dict[str, dict]:
+        env_keys = REPORT.read_allowlist(
+            self.root / "tests" / "scripts" / "production_environment_keys.txt"
+        )
+        return {r["key"]: r for r in REPORT.build_report(
+            self.root, env_keys, ["search.only_in_src", "search.tested"])}
+
+    def test_verdicts(self) -> None:
+        rows = self.rows()
+        self.assertEqual(rows["YAMS_ONLY_IN_SRC"]["verdict"], "CANDIDATE")
+        self.assertEqual(rows["YAMS_BENCHED"]["verdict"], "KEEP")
+        self.assertEqual(rows["YAMS_DOCUMENTED"]["verdict"], "KEEP")
+        self.assertEqual(rows["YAMS_STALE"]["verdict"], "NOT_IN_SRC")
+        self.assertEqual(rows["search.only_in_src"]["verdict"], "CANDIDATE")
+        self.assertEqual(rows["search.tested"]["verdict"], "KEEP")
+
+    def test_counts_are_whole_token(self) -> None:
+        rows = self.rows()
+        # YAMS_BENCHED must not absorb YAMS_BENCHED_LONGER's bench reference.
+        self.assertEqual(rows["YAMS_BENCHED"]["bench"], 1)
+        self.assertEqual(rows["YAMS_BENCHED_LONGER"]["verdict"], "NOT_IN_SRC")
+
+    def test_allowlist_and_build_output_are_not_consumers(self) -> None:
+        rows = self.rows()
+        self.assertEqual(rows["YAMS_ONLY_IN_SRC"]["test"], 0)
+        self.assertEqual(rows["YAMS_ONLY_IN_SRC"]["src"], 1)
+
+    def test_resolver_literal_extraction(self) -> None:
+        resolver = self.root / "src" / "knobs.cpp"
+        self.assertEqual(REPORT.resolver_toml_keys(resolver),
+                         ["search.only_in_src", "search.tested"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
tools(policy): report where every configuration key is referenced

Two commits, reviewed in order:

- `f637cd2b` test(policy): make the configuration-authority ratchet bidirectional
- `056d7a23` tools(policy): report where every configuration key is referenced

### test(policy): make the configuration-authority ratchet bidirectional

check_configuration_authority.py only reported keys and TOML readers
present in code but missing from the allowlists, so the reviewed
YAMS_* surface could grow but never shrink: production_environment_keys.txt
even said removals "may remain grandfathered". An allowlist that only
accretes stops describing the code.

The policy now also fails on allowlist entries with no remaining
occurrence in src/, include/, or tools/, naming the lines to delete.
Key removals in later commits therefore have to update the allowlist in
the same change, and the count in the success banner becomes a real
measure of the environment surface (432 today).

stale_entries() exposes the two stale sets for tooling; three unit
tests cover stale key, stale reader, and the returned names.

### tools(policy): report where every configuration key is referenced

Adds tests/scripts/report_config_key_usage.py: for each YAMS_* key in
production_environment_keys.txt and each dotted TOML key literally
resolved in ConfigResolver.cpp, count whole-token references per tree
bucket (src, test, bench, docs, plugin; build output and the allowlists
themselves excluded) and assign a verdict: KEEP when anything outside
product code exercises or documents the key, CANDIDATE when only
product code mentions it, NOT_IN_SRC when the allowlist is stale.

The report is evidence, not a decision. From here on a key deletion
must paste its CANDIDATE rows into the change description; the first
audit pass hand-listed keys that turned out to have bench and test
consumers, which is exactly the mistake a mechanical inventory avoids.

Today: 432 env keys (215 CANDIDATE, 217 KEEP), 117 TOML keys
(103 CANDIDATE, 14 KEEP). Registered as config_key_usage_report_unit.

The report counts only files git tracks (git ls-files) when the root is a
work tree, so an ignored local bench harness cannot turn a CANDIDATE into a
KEEP on one machine and not another; outside a work tree it falls back to
scanning the directory, which is what the synthetic-tree test exercises.

---
Stack position 6 of 29; base branch `stack/13-retrieval-contract-and-repo-cruft` (merge in order).
