### PR TITLE
fix(config): report 0 for [tuning] integer keys instead of ignoring it

### DIFF
--- a/src/daemon/components/ConfigResolver.cpp
+++ b/src/daemon/components/ConfigResolver.cpp
@@ -1357,8 +1357,20 @@ TuningConfig ConfigResolver::applyRuntimeTuning(const ConfigSections& sections,
     };
 
     const auto* tuning = findSection("tuning");
+    // Keys whose setter treats 0 as a real value (0 = auto). For every other uint32 knob 0 is
+    // the override's unset sentinel and below the minimum, so it cannot be expressed through
+    // [tuning]; storing it would silently fall back to the default.
+    static constexpr std::string_view kZeroMeansAuto[] = {"post_ingest_threads"};
     const auto applyUint32 = [&](std::string_view key, auto setter) {
         if (auto value = parseUint32(tuning, "tuning", key)) {
+            const bool zeroIsValue = std::find(std::begin(kZeroMeansAuto), std::end(kZeroMeansAuto),
+                                               key) != std::end(kZeroMeansAuto);
+            if (*value == 0 && !zeroIsValue) {
+                spdlog::warn("Config: tuning.{} = 0 cannot be expressed through [tuning] (0 is "
+                             "the unset sentinel); ignoring",
+                             key);
+                return;
+            }
             setter(*value);
             noteSource("tuning", key);
         }

--- a/tests/unit/daemon/components/config_resolver_test.cpp
+++ b/tests/unit/daemon/components/config_resolver_test.cpp
@@ -276,6 +276,35 @@ TEST_CASE("ConfigResolver applies one typed tuning snapshot for startup and relo
     TuneAdvisor::setMemoryWarningThreshold(0.0);
 }
 
+TEST_CASE("ConfigResolver rejects 0 for [tuning] integer keys instead of ignoring it",
+          "[daemon][components][config][tuning][catch2]") {
+    // For the uint32 overrides 0 is the unset sentinel and below every minimum, so "= 0"
+    // cannot mean what the operator wrote and is reported, not swallowed. The two keys where
+    // 0 is a documented value (post_ingest_threads = auto, seeded by the migrator;
+    // connection_lifetime_s = no recycling) must stay silent and keep their provenance.
+    ConfigResolver::ConfigSections sections;
+    sections["tuning"] = {{"pool_ipc_min", "0"},
+                          {"worker_poll_ms", "0"},
+                          {"pool_ipc_max", "48"},
+                          {"post_ingest_threads", "0"},
+                          {"connection_lifetime_s", "0"}};
+    TuningConfig base;
+    const auto resolved = ConfigResolver::applyRuntimeTuning(sections, base);
+    CHECK((TuneAdvisor::poolMinSizeIpc() == 1u));
+    CHECK((TuneAdvisor::workerPollMs() == 150u));
+    CHECK((TuneAdvisor::poolMaxSizeIpc() == 48u));
+    CHECK((TuneAdvisor::connectionLifetimeSeconds() == 0u));
+    CHECK((resolved.provenance.count("tuning.pool_ipc_min") == 0));
+    CHECK((resolved.provenance.count("tuning.worker_poll_ms") == 0));
+    CHECK((resolved.provenance.at("tuning.pool_ipc_max") == "config:tuning.pool_ipc_max"));
+    CHECK((resolved.provenance.at("tuning.post_ingest_threads") ==
+           "config:tuning.post_ingest_threads"));
+    CHECK((resolved.provenance.at("tuning.connection_lifetime_s") ==
+           "config:tuning.connection_lifetime_s"));
+    sections["tuning"] = {};
+    (void)ConfigResolver::applyRuntimeTuning(sections, base);
+}
+
 TEST_CASE("ConfigResolver wires [tuning] keys for every setter that was env-only",
           "[daemon][components][config][tuning][catch2]") {
     ConfigResolver::ConfigSections sections;


### PR DESCRIPTION
fix(config): report 0 for [tuning] integer keys instead of ignoring it

For the uint32 TuneAdvisor overrides 0 is the unset sentinel and below
every knob's minimum, so `pool_ipc_min = 0` used to be stored, read back
as "unset", and silently fall through to the default while the resolver
still recorded config provenance for it. applyUint32 now warns and skips
the value: nothing changes for the operator except that the mistake is
visible.

Two keys mean something by 0 and are exempt: post_ingest_threads (0 =
auto, which the config migrator seeds into every config and
`yams config` displays as "(auto)") and connection_lifetime_s (0 = no
recycling; its setter takes a signed sentinel and accepts 0, and the
environment spelling always did). Both keep their provenance and stay
silent, so a stock config produces no warning.

Test: pool_ipc_min = 0 and worker_poll_ms = 0 leave the defaults and
record no provenance, pool_ipc_max = 48 still applies, and the two
zero-valid keys apply with provenance.

---
Stack position 10 of 29; base branch `stack/17-typed-tuning-keys` (merge in order).
