### PR TITLE
feat(metadata): count uncached prepares in Database::CacheStats

### DIFF
--- a/include/yams/metadata/database.h
+++ b/include/yams/metadata/database.h
@@ -293,6 +293,9 @@ public:
         size_t misses{0};
         size_t currentSize{0};
         size_t maxSize{0};
+        // Statements compiled through prepare(), bypassing the cache. A hot path that
+        // re-prepares fixed SQL shows up here; tests pin it to zero after warm-up.
+        size_t uncachedPrepares{0};
     };
     [[nodiscard]] CacheStats getStatementCacheStats() const;
 
@@ -419,6 +422,7 @@ private:
     std::unordered_map<std::string, Statement> statementCache_;
     mutable size_t cacheHits_{0};
     mutable size_t cacheMisses_{0};
+    mutable size_t uncachedPrepares_{0};
     static constexpr size_t kMaxCacheSize = 64; // Limit cache size
 
     /**

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -429,11 +429,12 @@ Database::~Database() {
 Database::Database(Database&& other) noexcept
     : db_(other.db_), path_(std::move(other.path_)), inTransaction_(other.inTransaction_),
       statementCache_(std::move(other.statementCache_)), cacheHits_(other.cacheHits_),
-      cacheMisses_(other.cacheMisses_) {
+      cacheMisses_(other.cacheMisses_), uncachedPrepares_(other.uncachedPrepares_) {
     other.db_ = nullptr;
     other.inTransaction_ = false;
     other.cacheHits_ = 0;
     other.cacheMisses_ = 0;
+    other.uncachedPrepares_ = 0;
 }
 
 Database& Database::operator=(Database&& other) noexcept {
@@ -445,10 +446,12 @@ Database& Database::operator=(Database&& other) noexcept {
         statementCache_ = std::move(other.statementCache_);
         cacheHits_ = other.cacheHits_;
         cacheMisses_ = other.cacheMisses_;
+        uncachedPrepares_ = other.uncachedPrepares_;
         other.db_ = nullptr;
         other.inTransaction_ = false;
         other.cacheHits_ = 0;
         other.cacheMisses_ = 0;
+        other.uncachedPrepares_ = 0;
     }
     return *this;
 }
@@ -528,7 +531,12 @@ Result<Statement> Database::prepare(const std::string& sql) {
     }
 
     try {
-        return Statement(db_, sql);
+        Statement statement(db_, sql);
+        {
+            std::lock_guard<std::mutex> lock(cacheMutex_);
+            ++uncachedPrepares_;
+        }
+        return statement;
     } catch (const std::exception& e) {
         return make_sqlite_error(sqlite3_errcode(db_), e.what());
     }
@@ -631,7 +639,8 @@ void Database::clearStatementCache() {
 
 Database::CacheStats Database::getStatementCacheStats() const {
     std::lock_guard<std::mutex> lock(cacheMutex_);
-    return CacheStats{cacheHits_, cacheMisses_, statementCache_.size(), kMaxCacheSize};
+    return CacheStats{cacheHits_, cacheMisses_, statementCache_.size(), kMaxCacheSize,
+                      uncachedPrepares_};
 }
 
 Result<void> Database::execute(const std::string& sql) {

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -153,7 +153,7 @@ src/detection/file_type_detector.cpp:655:portability/env-read # reviewed raw env
 src/mcp/stdio_transport.cpp:46:portability/env-read # reviewed raw environment read
 src/metadata/connection_pool.cpp:921:portability/jthread # feature-test guarded std::jthread
 src/metadata/database.cpp:29:portability/env-read # reviewed raw environment read
-src/metadata/database.cpp:473:portability/path-cstr # std::string filename, not filesystem::path
+src/metadata/database.cpp:476:portability/path-cstr # std::string filename, not filesystem::path
 src/metadata/metadata_repository.cpp:1546:portability/env-read # reviewed raw environment read
 src/metadata/migration.cpp:1559:portability/env-read # reviewed raw environment read
 src/metadata/repository/search_ops.cpp:89:portability/env-read # reviewed raw environment read

--- a/tests/unit/metadata/database_catch2_test.cpp
+++ b/tests/unit/metadata/database_catch2_test.cpp
@@ -150,6 +150,30 @@ TEST_CASE("Database: prepared statements", "[unit][metadata][database]") {
     }
 }
 
+TEST_CASE("Database: cache stats count uncached prepares", "[unit][metadata][database]") {
+    DatabaseFixture fix;
+    Database db;
+    REQUIRE(db.open(fix.dbPath_.string(), ConnectionMode::Create).has_value());
+    REQUIRE(db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)").has_value());
+
+    const auto before = db.getStatementCacheStats();
+    REQUIRE(db.prepare("SELECT id FROM t").has_value());
+    REQUIRE(db.prepare("SELECT id FROM t").has_value());
+    {
+        auto cached = db.prepareCached("SELECT id FROM t WHERE id = ?");
+        REQUIRE(cached.has_value());
+    }
+    {
+        auto cached = db.prepareCached("SELECT id FROM t WHERE id = ?");
+        REQUIRE(cached.has_value());
+    }
+    const auto after = db.getStatementCacheStats();
+    // prepare() bypasses the cache: this is the count a hot path must drive to zero.
+    CHECK(after.uncachedPrepares - before.uncachedPrepares == 2);
+    CHECK(after.misses - before.misses == 1);
+    CHECK(after.hits - before.hits == 1);
+}
+
 TEST_CASE("Database: statement failures include sqlite error detail",
           "[unit][metadata][database]") {
     DatabaseFixture fix;


### PR DESCRIPTION
feat(metadata): count uncached prepares in Database::CacheStats

Database::prepare() compiles a statement every call; prepareCached()
reuses one. The cache stats reported hits and misses but nothing about
the bypass, so a hot path that re-prepared fixed SQL on every row was
invisible. CacheStats gains uncachedPrepares, incremented under the
existing cache mutex and carried through move construction and
assignment.

This is the measurement primitive for the following hot-path changes:
a test can warm a path, then assert that N more calls add zero uncached
prepares.

portability_allowlist.txt: one database.cpp anchor reflowed.

---
Stack position 13 of 29; base branch `stack/20-reranker-model-path-drift` (merge in order).
