### PR TITLE
perf(metadata): cache KG statements and batch the scorer's neighbor fetch

### DIFF
--- a/include/yams/metadata/database.h
+++ b/include/yams/metadata/database.h
@@ -423,7 +423,9 @@ private:
     mutable size_t cacheHits_{0};
     mutable size_t cacheMisses_{0};
     mutable size_t uncachedPrepares_{0};
-    static constexpr size_t kMaxCacheSize = 64; // Limit cache size
+    // 90 cached call sites share a connection when KG and repository work interleave; a
+    // small bound with first-found eviction would thrash them against each other.
+    static constexpr size_t kMaxCacheSize = 128;
 
     /**
      * @brief Return a statement to the cache after use

--- a/src/metadata/connection_pool.cpp
+++ b/src/metadata/connection_pool.cpp
@@ -900,12 +900,14 @@ bool ConnectionPool::isConnectionValid(const Database& db) const {
     }
 
     try {
-        auto stmtResult = const_cast<Database&>(db).prepare("SELECT 1");
+        // Runs on every acquire and release: keep the probe in the connection's statement
+        // cache instead of compiling it twice per pooled call.
+        auto stmtResult = const_cast<Database&>(db).prepareCached("SELECT 1");
         if (!stmtResult)
             return false;
 
-        Statement stmt = std::move(stmtResult).value();
-        auto result = stmt.step();
+        auto stmt = std::move(stmtResult).value();
+        auto result = stmt->step();
         if (!result.has_value())
             return false;
 

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -809,21 +809,22 @@ int Database::changes() const {
 }
 
 Result<bool> Database::tableExists(const std::string& table) {
-    auto stmtResult = prepare("SELECT COUNT(*) FROM sqlite_master "
-                              "WHERE type='table' AND name=?");
+    // Probed on hot paths (e.g. optional FTS tables per lookup); keep it cached.
+    auto stmtResult = prepareCached("SELECT COUNT(*) FROM sqlite_master "
+                                    "WHERE type='table' AND name=?");
     if (!stmtResult)
         return stmtResult.error();
 
-    Statement stmt = std::move(stmtResult).value();
-    auto bindResult = stmt.bind(1, table);
+    auto stmt = std::move(stmtResult).value();
+    auto bindResult = stmt->bind(1, table);
     if (!bindResult)
         return bindResult.error();
 
-    auto stepResult = stmt.step();
+    auto stepResult = stmt->step();
     if (!stepResult)
         return stepResult.error();
 
-    return stmt.getInt(0) > 0;
+    return stmt->getInt(0) > 0;
 }
 
 Result<bool> Database::hasFTS5() {

--- a/src/metadata/knowledge_graph_store_sqlite.cpp
+++ b/src/metadata/knowledge_graph_store_sqlite.cpp
@@ -250,23 +250,23 @@ Result<int> bindKgPathRanges(Statement& stmt, int firstIndex,
 }
 
 Result<std::int64_t> selectKgNodeIdByKey(Database& db, std::string_view nodeKey) {
-    auto stmtResult = db.prepare("SELECT id FROM kg_nodes WHERE node_key = ? LIMIT 1");
+    auto stmtResult = db.prepareCached("SELECT id FROM kg_nodes WHERE node_key = ? LIMIT 1");
     if (!stmtResult) {
         return stmtResult.error();
     }
     auto stmt = std::move(stmtResult).value();
-    auto bindResult = stmt.bind(1, nodeKey);
+    auto bindResult = stmt->bind(1, nodeKey);
     if (!bindResult) {
         return bindResult.error();
     }
-    auto stepResult = stmt.step();
+    auto stepResult = stmt->step();
     if (!stepResult) {
         return stepResult.error();
     }
     if (!stepResult.value()) {
         return Error{ErrorCode::NotFound, "node not found after upsert"};
     }
-    return stmt.getInt64(0);
+    return stmt->getInt64(0);
 }
 
 } // namespace
@@ -404,24 +404,24 @@ public:
 
     Result<std::optional<KGNode>> getNodeById(std::int64_t nodeId) override {
         return readPool()->withConnection([&](Database& db) -> Result<std::optional<KGNode>> {
-            auto stmtResult = db.prepare(std::string("SELECT ") + kKgNodeSelectProjection +
-                                         " FROM kg_nodes WHERE id = ? LIMIT 1");
+            auto stmtResult = db.prepareCached(std::string("SELECT ") + kKgNodeSelectProjection +
+                                               " FROM kg_nodes WHERE id = ? LIMIT 1");
             if (!stmtResult) {
                 return stmtResult.error();
             }
             auto stmt = std::move(stmtResult).value();
-            auto bindResult = stmt.bind(1, nodeId);
+            auto bindResult = stmt->bind(1, nodeId);
             if (!bindResult) {
                 return bindResult.error();
             }
-            auto stepResult = stmt.step();
+            auto stepResult = stmt->step();
             if (!stepResult) {
                 return stepResult.error();
             }
             if (!stepResult.value()) {
                 return std::optional<KGNode>{};
             }
-            return std::optional<KGNode>{hydrateKgNodeRow(stmt)};
+            return std::optional<KGNode>{hydrateKgNodeRow(*stmt)};
         });
     }
 
@@ -749,27 +749,28 @@ public:
                                                            std::size_t limit) override {
         return readPool()->withConnection(
             [&](Database& db) -> Result<std::vector<AliasResolution>> {
-                auto stmtR = db.prepare("SELECT node_id FROM kg_aliases WHERE alias = ? LIMIT ?");
+                auto stmtR =
+                    db.prepareCached("SELECT node_id FROM kg_aliases WHERE alias = ? LIMIT ?");
                 if (!stmtR)
                     return stmtR.error();
                 auto stmt = std::move(stmtR).value();
 
-                auto br = stmt.bind(1, alias);
+                auto br = stmt->bind(1, alias);
                 if (!br)
                     return br.error();
-                br = stmt.bind(2, static_cast<int64_t>(limit));
+                br = stmt->bind(2, static_cast<int64_t>(limit));
                 if (!br)
                     return br.error();
 
                 std::vector<AliasResolution> out;
                 while (true) {
-                    auto step = stmt.step();
+                    auto step = stmt->step();
                     if (!step)
                         return step.error();
                     if (!step.value())
                         break;
                     AliasResolution ar;
-                    ar.nodeId = stmt.getInt64(0);
+                    ar.nodeId = stmt->getInt64(0);
                     ar.score = 1.0f;
                     out.push_back(ar);
                 }
@@ -832,11 +833,11 @@ public:
                     return resolveAliasExact(aliasQuery, limit);
                 }
 
-                auto stmtR = db.prepare("SELECT a.node_id, 1.0 AS score "
-                                        "FROM kg_aliases_fts f "
-                                        "JOIN kg_aliases a ON a.id = f.rowid "
-                                        "WHERE kg_aliases_fts MATCH ? "
-                                        "LIMIT ?");
+                auto stmtR = db.prepareCached("SELECT a.node_id, 1.0 AS score "
+                                              "FROM kg_aliases_fts f "
+                                              "JOIN kg_aliases a ON a.id = f.rowid "
+                                              "WHERE kg_aliases_fts MATCH ? "
+                                              "LIMIT ?");
                 if (!stmtR)
                     return stmtR.error();
                 auto stmt = std::move(stmtR).value();
@@ -848,22 +849,22 @@ public:
                     aliasQuery.find(':') != std::string_view::npos
                         ? quoteFts5Literal(aliasQuery)
                         : sanitizeFts5UserQuery(std::string(aliasQuery));
-                auto br = stmt.bind(1, sanitizedQuery);
+                auto br = stmt->bind(1, sanitizedQuery);
                 if (!br)
                     return br.error();
-                br = stmt.bind(2, static_cast<int64_t>(limit));
+                br = stmt->bind(2, static_cast<int64_t>(limit));
                 if (!br)
                     return br.error();
 
                 std::vector<AliasResolution> out;
                 while (true) {
-                    auto step = stmt.step();
+                    auto step = stmt->step();
                     if (!step)
                         return step.error();
                     if (!step.value())
                         break;
                     AliasResolution ar;
-                    ar.nodeId = stmt.getInt64(0);
+                    ar.nodeId = stmt->getInt64(0);
                     ar.score = 1.0f;
                     out.push_back(ar);
                 }
@@ -1072,44 +1073,44 @@ public:
             }
             sql += " ORDER BY weight DESC, created_time DESC, id DESC LIMIT ? OFFSET ?";
 
-            auto stmtR = db.prepare(sql);
+            auto stmtR = db.prepareCached(sql);
             if (!stmtR)
                 return stmtR.error();
             auto stmt = std::move(stmtR).value();
 
             int idx = 1;
-            auto br = stmt.bind(idx++, srcNodeId);
+            auto br = stmt->bind(idx++, srcNodeId);
             if (!br)
                 return br.error();
             if (relation.has_value()) {
-                br = stmt.bind(idx++, relation.value());
+                br = stmt->bind(idx++, relation.value());
                 if (!br)
                     return br.error();
             }
-            br = stmt.bind(idx++, static_cast<int64_t>(limit));
+            br = stmt->bind(idx++, static_cast<int64_t>(limit));
             if (!br)
                 return br.error();
-            br = stmt.bind(idx, static_cast<int64_t>(offset));
+            br = stmt->bind(idx, static_cast<int64_t>(offset));
             if (!br)
                 return br.error();
 
             std::vector<KGEdge> out;
             while (true) {
-                auto step = stmt.step();
+                auto step = stmt->step();
                 if (!step)
                     return step.error();
                 if (!step.value())
                     break;
                 KGEdge e;
-                e.id = stmt.getInt64(0);
-                e.srcNodeId = stmt.getInt64(1);
-                e.dstNodeId = stmt.getInt64(2);
-                e.relation = stmt.getString(3);
-                e.weight = static_cast<float>(stmt.getDouble(4));
-                if (!stmt.isNull(5))
-                    e.createdTime = stmt.getInt64(5);
-                if (!stmt.isNull(6))
-                    e.properties = stmt.getString(6);
+                e.id = stmt->getInt64(0);
+                e.srcNodeId = stmt->getInt64(1);
+                e.dstNodeId = stmt->getInt64(2);
+                e.relation = stmt->getString(3);
+                e.weight = static_cast<float>(stmt->getDouble(4));
+                if (!stmt->isNull(5))
+                    e.createdTime = stmt->getInt64(5);
+                if (!stmt->isNull(6))
+                    e.properties = stmt->getString(6);
                 out.push_back(std::move(e));
             }
             return out;
@@ -1202,44 +1203,44 @@ public:
             }
             sql += " LIMIT ? OFFSET ?";
 
-            auto stmtR = db.prepare(sql);
+            auto stmtR = db.prepareCached(sql);
             if (!stmtR)
                 return stmtR.error();
             auto stmt = std::move(stmtR).value();
 
             int idx = 1;
-            auto br = stmt.bind(idx++, dstNodeId);
+            auto br = stmt->bind(idx++, dstNodeId);
             if (!br)
                 return br.error();
             if (relation.has_value()) {
-                br = stmt.bind(idx++, relation.value());
+                br = stmt->bind(idx++, relation.value());
                 if (!br)
                     return br.error();
             }
-            br = stmt.bind(idx++, static_cast<int64_t>(limit));
+            br = stmt->bind(idx++, static_cast<int64_t>(limit));
             if (!br)
                 return br.error();
-            br = stmt.bind(idx, static_cast<int64_t>(offset));
+            br = stmt->bind(idx, static_cast<int64_t>(offset));
             if (!br)
                 return br.error();
 
             std::vector<KGEdge> out;
             while (true) {
-                auto step = stmt.step();
+                auto step = stmt->step();
                 if (!step)
                     return step.error();
                 if (!step.value())
                     break;
                 KGEdge e;
-                e.id = stmt.getInt64(0);
-                e.srcNodeId = stmt.getInt64(1);
-                e.dstNodeId = stmt.getInt64(2);
-                e.relation = stmt.getString(3);
-                e.weight = static_cast<float>(stmt.getDouble(4));
-                if (!stmt.isNull(5))
-                    e.createdTime = stmt.getInt64(5);
-                if (!stmt.isNull(6))
-                    e.properties = stmt.getString(6);
+                e.id = stmt->getInt64(0);
+                e.srcNodeId = stmt->getInt64(1);
+                e.dstNodeId = stmt->getInt64(2);
+                e.relation = stmt->getString(3);
+                e.weight = static_cast<float>(stmt->getDouble(4));
+                if (!stmt->isNull(5))
+                    e.createdTime = stmt->getInt64(5);
+                if (!stmt->isNull(6))
+                    e.properties = stmt->getString(6);
                 out.push_back(std::move(e));
             }
             return out;
@@ -1443,26 +1444,26 @@ public:
                                                 std::size_t maxNeighbors) override {
         return readPool()->withConnection([&](Database& db) -> Result<std::vector<std::int64_t>> {
             auto stmtR =
-                db.prepare("SELECT dst_node_id FROM kg_edges WHERE src_node_id = ? LIMIT ?");
+                db.prepareCached("SELECT dst_node_id FROM kg_edges WHERE src_node_id = ? LIMIT ?");
             if (!stmtR)
                 return stmtR.error();
             auto stmt = std::move(stmtR).value();
 
-            auto br = stmt.bind(1, nodeId);
+            auto br = stmt->bind(1, nodeId);
             if (!br)
                 return br.error();
-            br = stmt.bind(2, static_cast<int64_t>(maxNeighbors));
+            br = stmt->bind(2, static_cast<int64_t>(maxNeighbors));
             if (!br)
                 return br.error();
 
             std::vector<std::int64_t> out;
             while (true) {
-                auto step = stmt.step();
+                auto step = stmt->step();
                 if (!step)
                     return step.error();
                 if (!step.value())
                     break;
-                out.push_back(stmt.getInt64(0));
+                out.push_back(stmt->getInt64(0));
             }
             return out;
         });
@@ -1569,37 +1570,37 @@ public:
 
     Result<std::optional<std::int64_t>> getDocumentIdByHash(std::string_view sha256) override {
         return readPool()->withConnection([&](Database& db) -> Result<std::optional<std::int64_t>> {
-            auto stmtR = db.prepare("SELECT id FROM documents WHERE sha256_hash = ? LIMIT 1");
+            auto stmtR = db.prepareCached("SELECT id FROM documents WHERE sha256_hash = ? LIMIT 1");
             if (!stmtR)
                 return stmtR.error();
             auto stmt = std::move(stmtR).value();
-            auto br = stmt.bind(1, sha256);
+            auto br = stmt->bind(1, sha256);
             if (!br)
                 return br.error();
-            auto step = stmt.step();
+            auto step = stmt->step();
             if (!step)
                 return step.error();
             if (!step.value())
                 return std::optional<std::int64_t>{};
-            return std::optional<std::int64_t>{stmt.getInt64(0)};
+            return std::optional<std::int64_t>{stmt->getInt64(0)};
         });
     }
 
     Result<std::optional<std::int64_t>> getDocumentIdByPath(std::string_view file_path) override {
         return readPool()->withConnection([&](Database& db) -> Result<std::optional<std::int64_t>> {
-            auto stmtR = db.prepare("SELECT id FROM documents WHERE file_path = ? LIMIT 1");
+            auto stmtR = db.prepareCached("SELECT id FROM documents WHERE file_path = ? LIMIT 1");
             if (!stmtR)
                 return stmtR.error();
             auto stmt = std::move(stmtR).value();
-            auto br = stmt.bind(1, file_path);
+            auto br = stmt->bind(1, file_path);
             if (!br)
                 return br.error();
-            auto step = stmt.step();
+            auto step = stmt->step();
             if (!step)
                 return step.error();
             if (!step.value())
                 return std::optional<std::int64_t>{};
-            return std::optional<std::int64_t>{stmt.getInt64(0)};
+            return std::optional<std::int64_t>{stmt->getInt64(0)};
         });
     }
 
@@ -1643,44 +1644,45 @@ public:
                                                              std::size_t limit,
                                                              std::size_t offset) override {
         return readPool()->withConnection([&](Database& db) -> Result<std::vector<DocEntity>> {
-            auto stmtR = db.prepare("SELECT id, document_id, entity_text, node_id, start_offset, "
-                                    "end_offset, confidence, extractor "
-                                    "FROM kg_doc_entities WHERE document_id = ? LIMIT ? OFFSET ?");
+            auto stmtR =
+                db.prepareCached("SELECT id, document_id, entity_text, node_id, start_offset, "
+                                 "end_offset, confidence, extractor "
+                                 "FROM kg_doc_entities WHERE document_id = ? LIMIT ? OFFSET ?");
             if (!stmtR)
                 return stmtR.error();
             auto stmt = std::move(stmtR).value();
 
-            auto br = stmt.bind(1, documentId);
+            auto br = stmt->bind(1, documentId);
             if (!br)
                 return br.error();
-            br = stmt.bind(2, static_cast<int64_t>(limit));
+            br = stmt->bind(2, static_cast<int64_t>(limit));
             if (!br)
                 return br.error();
-            br = stmt.bind(3, static_cast<int64_t>(offset));
+            br = stmt->bind(3, static_cast<int64_t>(offset));
             if (!br)
                 return br.error();
 
             std::vector<DocEntity> out;
             while (true) {
-                auto step = stmt.step();
+                auto step = stmt->step();
                 if (!step)
                     return step.error();
                 if (!step.value())
                     break;
                 DocEntity de;
-                de.id = stmt.getInt64(0);
-                de.documentId = stmt.getInt64(1);
-                de.entityText = stmt.getString(2);
-                if (!stmt.isNull(3))
-                    de.nodeId = stmt.getInt64(3);
-                if (!stmt.isNull(4))
-                    de.startOffset = stmt.getInt64(4);
-                if (!stmt.isNull(5))
-                    de.endOffset = stmt.getInt64(5);
-                if (!stmt.isNull(6))
-                    de.confidence = static_cast<float>(stmt.getDouble(6));
-                if (!stmt.isNull(7))
-                    de.extractor = stmt.getString(7);
+                de.id = stmt->getInt64(0);
+                de.documentId = stmt->getInt64(1);
+                de.entityText = stmt->getString(2);
+                if (!stmt->isNull(3))
+                    de.nodeId = stmt->getInt64(3);
+                if (!stmt->isNull(4))
+                    de.startOffset = stmt->getInt64(4);
+                if (!stmt->isNull(5))
+                    de.endOffset = stmt->getInt64(5);
+                if (!stmt->isNull(6))
+                    de.confidence = static_cast<float>(stmt->getDouble(6));
+                if (!stmt->isNull(7))
+                    de.extractor = stmt->getString(7);
                 out.push_back(std::move(de));
             }
             return out;
@@ -2232,7 +2234,7 @@ public:
             }
             sqlPattern += "%";
 
-            auto stmtR = db.prepare(R"(
+            auto stmtR = db.prepareCached(R"(
                 SELECT id, node_key, label, type, created_time, updated_time, properties
                 FROM kg_nodes
                 WHERE label LIKE ? COLLATE NOCASE
@@ -2243,32 +2245,32 @@ public:
                 return stmtR.error();
 
             auto stmt = std::move(stmtR).value();
-            auto bindRes = stmt.bindAll(sqlPattern, static_cast<std::int64_t>(limit),
-                                        static_cast<std::int64_t>(offset));
+            auto bindRes = stmt->bindAll(sqlPattern, static_cast<std::int64_t>(limit),
+                                         static_cast<std::int64_t>(offset));
             if (!bindRes)
                 return bindRes.error();
 
             std::vector<KGNode> results;
             while (true) {
-                auto step = stmt.step();
+                auto step = stmt->step();
                 if (!step)
                     return step.error();
                 if (!step.value())
                     break;
 
                 KGNode node;
-                node.id = stmt.getInt64(0);
-                node.nodeKey = stmt.getString(1);
-                if (!stmt.isNull(2))
-                    node.label = stmt.getString(2);
-                if (!stmt.isNull(3))
-                    node.type = stmt.getString(3);
-                if (!stmt.isNull(4))
-                    node.createdTime = stmt.getInt64(4);
-                if (!stmt.isNull(5))
-                    node.updatedTime = stmt.getInt64(5);
-                if (!stmt.isNull(6))
-                    node.properties = stmt.getString(6);
+                node.id = stmt->getInt64(0);
+                node.nodeKey = stmt->getString(1);
+                if (!stmt->isNull(2))
+                    node.label = stmt->getString(2);
+                if (!stmt->isNull(3))
+                    node.type = stmt->getString(3);
+                if (!stmt->isNull(4))
+                    node.createdTime = stmt->getInt64(4);
+                if (!stmt->isNull(5))
+                    node.updatedTime = stmt->getInt64(5);
+                if (!stmt->isNull(6))
+                    node.properties = stmt->getString(6);
 
                 results.push_back(std::move(node));
             }
@@ -2294,11 +2296,11 @@ public:
         return pool_->withConnection([&](Database& db) -> Result<std::int64_t> {
             // Check if blob node exists
             auto selectStmt =
-                db.prepare("SELECT id FROM kg_nodes WHERE node_key = ? AND type = 'blob'");
+                db.prepareCached("SELECT id FROM kg_nodes WHERE node_key = ? AND type = 'blob'");
             if (!selectStmt)
                 return selectStmt.error();
 
-            auto& stmt = selectStmt.value();
+            auto& stmt = *selectStmt.value();
             std::string nodeKey = std::string("blob:") + std::string(sha256);
             auto bindRes = stmt.bindAll(nodeKey);
             if (!bindRes)
@@ -2337,12 +2339,12 @@ public:
     Result<std::int64_t> ensureDocumentNode(std::string_view sha256,
                                             std::string_view label = std::string_view{}) override {
         return pool_->withConnection([&](Database& db) -> Result<std::int64_t> {
-            auto selectStmt = db.prepare(
+            auto selectStmt = db.prepareCached(
                 "SELECT id, label FROM kg_nodes WHERE node_key = ? AND type = 'document'");
             if (!selectStmt)
                 return selectStmt.error();
 
-            auto& stmt = selectStmt.value();
+            auto& stmt = *selectStmt.value();
             std::string nodeKey = std::string("doc:") + std::string(sha256);
             auto bindRes = stmt.bindAll(nodeKey);
             if (!bindRes)
@@ -2399,11 +2401,11 @@ public:
 
             // Check if path node exists
             auto selectStmt =
-                db.prepare("SELECT id FROM kg_nodes WHERE node_key = ? AND type = 'path'");
+                db.prepareCached("SELECT id FROM kg_nodes WHERE node_key = ? AND type = 'path'");
             if (!selectStmt)
                 return selectStmt.error();
 
-            auto& stmt = selectStmt.value();
+            auto& stmt = *selectStmt.value();
             auto bindRes = stmt.bindAll(nodeKey);
             if (!bindRes)
                 return bindRes.error();
@@ -2450,11 +2452,11 @@ public:
             // Logical path node to group snapshot path nodes.
             std::string logicalKey = "path:logical:" + descriptor.path;
             auto logicalSelect =
-                db.prepare("SELECT id FROM kg_nodes WHERE node_key = ? AND type = 'path'");
+                db.prepareCached("SELECT id FROM kg_nodes WHERE node_key = ? AND type = 'path'");
             if (!logicalSelect)
                 return logicalSelect.error();
 
-            auto& logicalStmt = logicalSelect.value();
+            auto& logicalStmt = *logicalSelect.value();
             auto logicalBind = logicalStmt.bindAll(logicalKey);
             if (!logicalBind)
                 return logicalBind.error();

--- a/src/search/kg_scorer_simple.cpp
+++ b/src/search/kg_scorer_simple.cpp
@@ -129,16 +129,18 @@ public:
             }
         }
 
-        // Pre-compute 1-hop neighbor set for structural scoring (budget-aware)
+        // Pre-compute the 1-hop neighbor union for structural scoring in one batched
+        // fetch instead of one statement per query node.
         std::unordered_set<std::int64_t> query_neighbor_union;
-        for (auto nid : query_nodes) {
-            if (timedOut(t0))
-                break;
-            auto nb = store_->neighbors(nid, cfg_.max_neighbors);
-            if (!nb)
-                return nb.error();
-            for (auto v : nb.value()) {
-                query_neighbor_union.insert(v);
+        if (!query_nodes.empty() && !timedOut(t0)) {
+            std::vector<std::int64_t> sources(query_nodes.begin(), query_nodes.end());
+            auto edges = store_->getEdgesFromBatch(sources, std::nullopt, cfg_.max_neighbors);
+            if (!edges)
+                return edges.error();
+            for (const auto& [src, outgoing] : edges.value()) {
+                for (const auto& e : outgoing) {
+                    query_neighbor_union.insert(e.dstNodeId);
+                }
             }
         }
 

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -151,7 +151,7 @@ src/daemon/components/dispatcher/request_dispatcher_models.cpp:38:portability/en
 src/detection/file_type_detector.cpp:612:portability/env-read # reviewed raw environment read
 src/detection/file_type_detector.cpp:655:portability/env-read # reviewed raw environment read
 src/mcp/stdio_transport.cpp:46:portability/env-read # reviewed raw environment read
-src/metadata/connection_pool.cpp:921:portability/jthread # feature-test guarded std::jthread
+src/metadata/connection_pool.cpp:923:portability/jthread # feature-test guarded std::jthread
 src/metadata/database.cpp:29:portability/env-read # reviewed raw environment read
 src/metadata/database.cpp:476:portability/path-cstr # std::string filename, not filesystem::path
 src/metadata/metadata_repository.cpp:1546:portability/env-read # reviewed raw environment read
@@ -499,7 +499,7 @@ tests/unit/repair/embedding_repair_scan_catch2_test.cpp:187:portability/env-read
 tests/unit/repair/embedding_repair_scan_catch2_test.cpp:229:portability/env-read # reviewed raw environment read
 tests/unit/search/graph_expansion_catch2_test.cpp:18:portability/env-read # reviewed raw environment read
 tests/unit/search/hybrid_search_comprehensive_test.cpp:272:portability/env-read # reviewed raw environment read
-tests/unit/search/kg_scorer_simple_catch2_test.cpp:32:portability/env-read # reviewed raw environment read
+tests/unit/search/kg_scorer_simple_catch2_test.cpp:35:portability/env-read # reviewed raw environment read
 tests/unit/search/search_engine_simeon_lexical_catch2_test.cpp:25:portability/env-read # reviewed raw environment read
 tests/unit/search/search_engine_topology_catch2_test.cpp:43:portability/env-read # reviewed raw environment read
 tests/unit/search/simeon_bandit_backend_catch2_test.cpp:30:portability/env-read # reviewed raw environment read

--- a/tests/unit/metadata/kg_store_catch2_test.cpp
+++ b/tests/unit/metadata/kg_store_catch2_test.cpp
@@ -1472,3 +1472,72 @@ TEST_CASE("KG Store: write batch cleanup helpers commit scoped deletions", "[uni
     REQUIRE((validEntities.value().size() == 1));
     CHECK((validEntities.value()[0].entityText == "BatchEntity"));
 }
+
+TEST_CASE("KG Store hot lookups reuse prepared statements after warm-up",
+          "[unit][metadata][kg][statements][catch2]") {
+    // One connection so every call lands on the same statement cache.
+    const auto dbPath = tempDbPath("kg_store_prepared_");
+    {
+        auto bootstrap =
+            makeSqliteKnowledgeGraphStore(dbPath.string(), KnowledgeGraphStoreConfig{});
+        REQUIRE(bootstrap.has_value());
+    }
+    ConnectionPoolConfig poolCfg;
+    poolCfg.minConnections = 1;
+    poolCfg.maxConnections = 1;
+    ConnectionPool pool(dbPath.string(), poolCfg);
+    REQUIRE(pool.initialize().has_value());
+    auto storeRes = makeSqliteKnowledgeGraphStore(pool, KnowledgeGraphStoreConfig{});
+    REQUIRE(storeRes.has_value());
+    auto& store = *storeRes.value();
+
+    std::vector<KGNode> nodes;
+    for (int i = 0; i < 64; ++i) {
+        nodes.push_back(KGNode{.nodeKey = "ent:" + std::to_string(i),
+                               .label = std::string("N" + std::to_string(i)),
+                               .type = std::string("entity")});
+    }
+    auto ids = store.upsertNodes(nodes);
+    REQUIRE(ids.has_value());
+    REQUIRE(ids.value().size() == 64u);
+    for (std::size_t i = 1; i < ids.value().size(); ++i) {
+        REQUIRE(store
+                    .addEdge(KGEdge{.srcNodeId = ids.value()[0],
+                                    .dstNodeId = ids.value()[i],
+                                    .relation = std::string("REL")})
+                    .has_value());
+    }
+
+    const auto uncached = [&]() {
+        std::size_t count = 0;
+        auto r = pool.withConnection([&](Database& db) -> Result<void> {
+            count = db.getStatementCacheStats().uncachedPrepares;
+            return Result<void>();
+        });
+        REQUIRE(r.has_value());
+        return count;
+    };
+
+    // Warm every path once, then measure.
+    REQUIRE(store.neighbors(ids.value()[0], 100).has_value());
+    REQUIRE(store.getDocumentIdByHash("missing").has_value());
+    REQUIRE(store.ensureDocumentNode("deadbeef", "doc").has_value());
+    const auto before = uncached();
+    REQUIRE(store.neighbors(ids.value()[1], 100).has_value());
+    const auto afterOneNeighbors = uncached();
+    INFO("uncached prepares for one warmed neighbors() call: " << (afterOneNeighbors - before));
+    for (std::size_t i = 0; i < ids.value().size(); ++i) {
+        auto nb = store.neighbors(ids.value()[i], 100);
+        REQUIRE(nb.has_value());
+    }
+    for (int i = 0; i < 16; ++i) {
+        REQUIRE(store.getDocumentIdByHash("missing-" + std::to_string(i)).has_value());
+        // Existing node: the select path, not the insert path.
+        REQUIRE(store.ensureDocumentNode("deadbeef", "doc").has_value());
+    }
+    CHECK(afterOneNeighbors - before == 0);
+    CHECK(uncached() - before == 0);
+    pool.shutdown();
+    std::error_code ec;
+    std::filesystem::remove(dbPath, ec);
+}

--- a/tests/unit/search/kg_scorer_simple_catch2_test.cpp
+++ b/tests/unit/search/kg_scorer_simple_catch2_test.cpp
@@ -8,6 +8,9 @@
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <vector>
+#include <yams/metadata/connection_pool.h>
+#include <yams/metadata/database.h>
 #include <yams/metadata/knowledge_graph_store.h>
 #include <yams/metadata/metadata_repository.h>
 #include <yams/search/kg_scorer.h>
@@ -139,4 +142,75 @@ TEST_CASE("SimpleKGScorer - ScoresEntityAndStructuralOverlap", "[search][kg_scor
     // Explanations best-effort: should be available for the hit
     auto expl = scorer->getLastExplanations();
     CHECK_FALSE(expl.empty());
+}
+
+TEST_CASE("SimpleKGScorer - neighbor union is one batched fetch", "[search][kg_scorer][catch2]") {
+    auto dbPath = tempDbPath("kg_scorer_batch_");
+    {
+        auto bootstrap =
+            makeSqliteKnowledgeGraphStore(dbPath.string(), KnowledgeGraphStoreConfig{});
+        REQUIRE(bootstrap.has_value());
+    }
+    ConnectionPoolConfig pcfg;
+    pcfg.minConnections = 1;
+    pcfg.maxConnections = 1;
+    auto pool = std::make_shared<ConnectionPool>(dbPath.string(), pcfg);
+    REQUIRE(pool->initialize().has_value());
+    auto sres = makeSqliteKnowledgeGraphStore(*pool, KnowledgeGraphStoreConfig{});
+    REQUIRE(sres.has_value());
+    std::shared_ptr<KnowledgeGraphStore> store(sres.value().release());
+
+    // Eight query nodes, each aliased by one query token, each with one outgoing edge.
+    std::vector<KGNode> nodes;
+    for (int i = 0; i < 9; ++i) {
+        nodes.push_back(KGNode{.nodeKey = "ent:q" + std::to_string(i),
+                               .label = std::string("Q" + std::to_string(i)),
+                               .type = std::string("entity")});
+    }
+    auto ids = store->upsertNodes(nodes);
+    REQUIRE(ids.has_value());
+    std::string query;
+    for (int i = 0; i < 8; ++i) {
+        REQUIRE(store
+                    ->addAlias(KGAlias{.nodeId = ids.value()[i],
+                                       .alias = std::string("term" + std::to_string(i)),
+                                       .source = std::string("test"),
+                                       .confidence = 1.0f})
+                    .has_value());
+        REQUIRE(store
+                    ->addEdge(KGEdge{.srcNodeId = ids.value()[i],
+                                     .dstNodeId = ids.value()[8],
+                                     .relation = std::string("REL")})
+                    .has_value());
+        query += "term" + std::to_string(i) + " ";
+    }
+
+    auto scorer = makeSimpleKGScorer(store);
+    REQUIRE(scorer != nullptr);
+    KGScoringConfig scfg;
+    scfg.max_neighbors = 16;
+    scfg.max_hops = 1;
+    scfg.budget = std::chrono::milliseconds(1000);
+    scorer->setConfig(scfg);
+
+    const auto uncached = [&]() {
+        std::size_t count = 0;
+        auto r = pool->withConnection([&](Database& db) -> Result<void> {
+            count = db.getStatementCacheStats().uncachedPrepares;
+            return Result<void>();
+        });
+        REQUIRE(r.has_value());
+        return count;
+    };
+    std::vector<std::string> cands = {"1", "2"};
+    REQUIRE(scorer->score(query, cands).has_value()); // warm-up
+    const auto before = uncached();
+    REQUIRE(scorer->score(query, cands).has_value());
+    // Per-node neighbors() re-prepared once per query node (8); a batch is one IN query.
+    CHECK(uncached() - before < 8);
+    scorer.reset();
+    store.reset();
+    pool->shutdown();
+    std::error_code ec;
+    std::filesystem::remove(dbPath, ec);
 }


### PR DESCRIPTION
perf(metadata): cache KG statements and batch the scorer's neighbor fetch

Measured with the new uncachedPrepares counter on a single-connection
pool. Before: 64 warmed neighbors() calls plus 32 document lookups cost
306 uncached statement compilations, and one SimpleKGScorer::score()
over eight query terms cost 620. After: 0 and 1.

Three things were compiling SQL per call on the search path:

- The sqlite KG store used Database::prepare() for fixed SQL in
  neighbors, getDocumentIdByHash/ByPath, ensureBlobNode,
  ensureDocumentNode, ensurePathNode (both lookups), selectKgNodeIdByKey,
  getNodeById, resolveAliasExact/Fuzzy, getEdgesFrom/To,
  getDocEntitiesForDocument, and searchNodesByLabel. All now use
  prepareCached (85 -> 70 raw prepares in the file; the rest are
  dynamic IN-list or maintenance queries).
- ConnectionPool::isConnectionValid ran prepare("SELECT 1") on every
  acquire and again on every release, so each pooled call paid two
  compilations before doing any work. The probe is now cached.
- Database::tableExists compiled its sqlite_master probe every time;
  the fuzzy alias resolver calls it per query token.

SimpleKGScorer builds its 1-hop neighbor union with one
getEdgesFromBatch call instead of neighbors() per query node.

kMaxCacheSize rises from 64 to 128: 90 cached call sites now share a
connection when KG and repository work interleave, and the cache
evicts first-found, not least-recently-used.

Tests pin both numbers: the store test asserts zero uncached prepares
across 96 warmed lookups; the scorer test asserts fewer than eight on
a second run (previously one per query node from neighbors() alone).
portability_allowlist.txt: two anchors reflowed.

---
Stack position 14 of 29; base branch `stack/21-uncached-prepare-counter` (merge in order).
