### PR TITLE
perf(search): load tag filters once per request, not once per document

### DIFF
--- a/src/app/services/search_service.cpp
+++ b/src/app/services/search_service.cpp
@@ -571,72 +571,51 @@ retryMetadataOp(Fn&& fn, std::size_t maxAttempts = 4,
     co_return attempt;
 }
 
-static boost::asio::awaitable<bool> metadataHasTags(metadata::MetadataRepository* repo,
-                                                    int64_t docId,
-                                                    const std::vector<std::string>& tags,
-                                                    bool matchAll,
-                                                    MetadataTelemetry* telemetry = nullptr) {
-    if (!repo || tags.empty()) {
-        co_return true;
+// Tags live in metadata as "tag:<name>" keys; MetadataRepository::batchGetDocumentTags returns
+// the names for many documents in one statement. Loading them once per request replaces the
+// getAllMetadata() round trip (with retries) that used to run for every candidate document.
+using TagsByDocument = std::unordered_map<int64_t, std::vector<std::string>>;
+
+static boost::asio::awaitable<TagsByDocument> loadTagsForDocuments(
+    metadata::MetadataRepository* repo, const std::vector<metadata::DocumentInfo>& docs,
+    const std::vector<std::string>& requiredTags, MetadataTelemetry* telemetry = nullptr) {
+    TagsByDocument tagsByDoc;
+    if (!repo || requiredTags.empty() || docs.empty()) {
+        co_return tagsByDoc;
     }
-
-    auto md = co_await retryMetadataOp([&]() { return repo->getAllMetadata(docId); }, 4,
-                                       std::chrono::milliseconds(25), telemetry);
-
-    if (!md) {
-        spdlog::debug("SearchService: metadata lookup failed for doc {}: {}", docId,
-                      md.error().message);
-        co_return false;
+    std::vector<int64_t> ids;
+    ids.reserve(docs.size());
+    for (const auto& d : docs) {
+        if (d.id > 0) {
+            ids.push_back(d.id);
+        }
     }
-
-    auto& all = md.value();
-
-    // Debug: log all metadata keys for this document
-    if (!tags.empty()) {
-        std::string keys;
-        for (const auto& [k, v] : all) {
-            if (!keys.empty())
-                keys += ", ";
-            keys += k + "=" + v.asString();
-        }
-        spdlog::info(
-            "metadataHasTags: docId={} searching for tags=[{}] matchAll={} found_metadata=[{}]",
-            docId, tags.size(), matchAll, keys);
+    auto loaded = co_await retryMetadataOp([&]() { return repo->batchGetDocumentTags(ids); }, 4,
+                                           std::chrono::milliseconds(25), telemetry);
+    if (!loaded) {
+        // Every document then fails the tag filter, as it did when its own lookup failed.
+        spdlog::debug("SearchService: tag lookup failed for {} docs: {}", ids.size(),
+                      loaded.error().message);
+        co_return tagsByDoc;
     }
+    co_return std::move(loaded.value());
+}
 
-    auto hasTag = [&](const std::string& t) {
-        // Check for normalized storage (key="tag:<name>")
-        auto it = all.find("tag:" + t);
-        if (it != all.end()) {
-            spdlog::debug("metadataHasTags: found tag:{}", t);
-            return true;
-        }
-        // Fallback: check for legacy storage (key="tag", value="<name>")
-        for (const auto& [k, v] : all) {
-            if (k == "tag" && v.asString() == t) {
-                spdlog::debug("metadataHasTags: found legacy tag {}", t);
-                return true;
-            }
-        }
-        spdlog::debug("metadataHasTags: tag '{}' not found", t);
+static bool hasRequiredTags(const TagsByDocument& tagsByDoc, int64_t docId,
+                            const std::vector<std::string>& required, bool matchAll) {
+    if (required.empty()) {
+        return true;
+    }
+    const auto it = tagsByDoc.find(docId);
+    if (it == tagsByDoc.end()) {
         return false;
-    };
-
-    if (matchAll) {
-        for (const auto& t : tags) {
-            if (!hasTag(t)) {
-                co_return false;
-            }
-        }
-        co_return true;
-    } else {
-        for (const auto& t : tags) {
-            if (hasTag(t)) {
-                co_return true;
-            }
-        }
-        co_return false;
     }
+    const auto& tags = it->second;
+    const auto has = [&](const std::string& t) {
+        return std::find(tags.begin(), tags.end(), t) != tags.end();
+    };
+    return matchAll ? std::all_of(required.begin(), required.end(), has)
+                    : std::any_of(required.begin(), required.end(), has);
 }
 
 // Compute recommended worker count based on hardware, load and caps
@@ -1577,6 +1556,8 @@ private:
         }
 
         // Apply additional filters and shape results
+        const auto tagsByDoc =
+            co_await loadTagsForDocuments(ctx_.metadataRepo.get(), docs, req.tags, telemetry);
         auto push_path = [&](const metadata::DocumentInfo& d) -> boost::asio::awaitable<void> {
             if (!req.extension.empty()) {
                 if (d.fileExtension != req.extension && d.fileExtension != ("." + req.extension))
@@ -1584,8 +1565,7 @@ private:
             }
             if (!req.mimeType.empty() && d.mimeType != req.mimeType)
                 co_return;
-            if (!(co_await metadataHasTags(ctx_.metadataRepo.get(), d.id, req.tags,
-                                           req.matchAllTags, telemetry)))
+            if (!hasRequiredTags(tagsByDoc, d.id, req.tags, req.matchAllTags))
                 co_return;
             const std::string resolvedPath = !d.filePath.empty() ? d.filePath : d.fileName;
             const double score = computePathMatchScore(d, pathQuery, wildcard);
@@ -1703,6 +1683,8 @@ private:
             return filePath.find(rawPattern) != std::string::npos;
         };
 
+        const auto tagsByDoc =
+            co_await loadTagsForDocuments(ctx_.metadataRepo.get(), docs, req.tags, telemetry);
         for (const auto& doc : docs) {
             // Optional path and tag filters for CLI parity
             bool pathOk = effectivePathPatterns.empty();
@@ -1733,8 +1715,7 @@ private:
             }
 
             if (!pathOk || !metaFiltersOk ||
-                !(co_await metadataHasTags(ctx_.metadataRepo.get(), doc.id, req.tags,
-                                           req.matchAllTags, telemetry))) {
+                !hasRequiredTags(tagsByDoc, doc.id, req.tags, req.matchAllTags)) {
                 continue;
             }
 

--- a/src/daemon/components/RepairService.cpp
+++ b/src/daemon/components/RepairService.cpp
@@ -1917,13 +1917,15 @@ RepairOperationResult RepairService::repairDownloads(bool dryRun, bool verbose,
 
         try {
             metaFacade.setMetadata(doc.id, "source_url", metadata::MetadataValue(sourceUrl));
-            metaFacade.setMetadata(doc.id, "tag", metadata::MetadataValue("downloaded"));
+            metaFacade.setMetadata(doc.id, "tag:downloaded", metadata::MetadataValue("downloaded"));
             auto host = extract_host(sourceUrl);
             auto scheme = extract_scheme(sourceUrl);
             if (!host.empty())
-                metaFacade.setMetadata(doc.id, "tag", metadata::MetadataValue("host:" + host));
+                metaFacade.setMetadata(doc.id, "tag:host:" + host,
+                                       metadata::MetadataValue("host:" + host));
             if (!scheme.empty())
-                metaFacade.setMetadata(doc.id, "tag", metadata::MetadataValue("scheme:" + scheme));
+                metaFacade.setMetadata(doc.id, "tag:scheme:" + scheme,
+                                       metadata::MetadataValue("scheme:" + scheme));
         } catch (const std::exception& e) {
             spdlog::debug("RepairService: failed to persist download metadata for {}: {}",
                           sourceUrl, e.what());

--- a/src/metadata/metadata_repository.cpp
+++ b/src/metadata/metadata_repository.cpp
@@ -4460,40 +4460,47 @@ MetadataRepository::batchGetDocumentTags(std::span<const int64_t> documentIds) {
         return std::unordered_map<int64_t, std::vector<std::string>>{};
     }
 
+    // One placeholder per id, chunked below SQLite's variable limit (999 on older builds)
+    // so an unbounded candidate set from a path pattern never fails the whole lookup.
+    constexpr std::size_t kMaxTagQueryIds = 500;
     return executeReadQuery<std::unordered_map<int64_t, std::vector<std::string>>>(
         [&](Database& db) -> Result<std::unordered_map<int64_t, std::vector<std::string>>> {
-            std::string query =
-                "SELECT document_id, key FROM metadata WHERE key LIKE 'tag:%' AND document_id IN (";
-            for (std::size_t i = 0; i < documentIds.size(); ++i) {
-                if (i)
-                    query += ",";
-                query += "?";
-            }
-            query += ") ORDER BY document_id, key";
-
-            auto stmtResult = db.prepare(query);
-            if (!stmtResult)
-                return stmtResult.error();
-
-            Statement stmt = std::move(stmtResult).value();
-            int bindIndex = 1;
-            for (auto id : documentIds) {
-                auto b = stmt.bind(bindIndex++, id);
-                if (!b)
-                    return b.error();
-            }
-
             std::unordered_map<int64_t, std::vector<std::string>> out;
-            while (true) {
-                auto stepResult = stmt.step();
-                if (!stepResult)
-                    return stepResult.error();
-                if (!stepResult.value())
-                    break;
+            for (std::size_t offset = 0; offset < documentIds.size(); offset += kMaxTagQueryIds) {
+                const auto chunk = documentIds.subspan(
+                    offset, std::min(kMaxTagQueryIds, documentIds.size() - offset));
+                std::string query = "SELECT document_id, key FROM metadata WHERE key LIKE 'tag:%' "
+                                    "AND document_id IN (";
+                for (std::size_t i = 0; i < chunk.size(); ++i) {
+                    if (i)
+                        query += ",";
+                    query += "?";
+                }
+                query += ") ORDER BY document_id, key";
 
-                std::string fullKey = stmt.getString(1);
-                if (fullKey.starts_with("tag:")) {
-                    out[stmt.getInt64(0)].push_back(fullKey.substr(4));
+                auto stmtResult = db.prepare(query);
+                if (!stmtResult)
+                    return stmtResult.error();
+
+                Statement stmt = std::move(stmtResult).value();
+                int bindIndex = 1;
+                for (auto id : chunk) {
+                    auto b = stmt.bind(bindIndex++, id);
+                    if (!b)
+                        return b.error();
+                }
+
+                while (true) {
+                    auto stepResult = stmt.step();
+                    if (!stepResult)
+                        return stepResult.error();
+                    if (!stepResult.value())
+                        break;
+
+                    std::string fullKey = stmt.getString(1);
+                    if (fullKey.starts_with("tag:")) {
+                        out[stmt.getInt64(0)].push_back(fullKey.substr(4));
+                    }
                 }
             }
 

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -82,8 +82,8 @@ plugins/symbol_extractor_treesitter/grammar_loader.cpp:402:portability/env-read 
 plugins/symbol_extractor_treesitter/grammar_loader.cpp:411:portability/env-read # reviewed raw environment read
 plugins/symbol_extractor_treesitter/grammar_loader.cpp:413:portability/env-read # reviewed raw environment read
 src/app/services/document_service.cpp:1207:portability/env-read # reviewed raw environment read
-src/app/services/search_service.cpp:655:portability/env-read # reviewed raw environment read
-src/app/services/search_service.cpp:736:portability/env-read # reviewed raw environment read
+src/app/services/search_service.cpp:634:portability/env-read # reviewed raw environment read
+src/app/services/search_service.cpp:715:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:18:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:20:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:71:portability/env-read # reviewed raw environment read

--- a/tests/unit/app/services/search_service_catch2_test.cpp
+++ b/tests/unit/app/services/search_service_catch2_test.cpp
@@ -12,10 +12,12 @@
 #define getpid _getpid
 #endif
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <filesystem>
 #include <optional>
+#include <span>
 #include <thread>
 #include <unordered_set>
 
@@ -67,6 +69,26 @@ public:
 
 private:
     std::size_t getDocumentByHashFailures_{0};
+};
+
+class TagLookupCountingRepository : public MetadataRepository {
+public:
+    explicit TagLookupCountingRepository(ConnectionPool& pool) : MetadataRepository(pool) {}
+
+    Result<std::unordered_map<std::string, MetadataValue>>
+    getAllMetadata(int64_t documentId) override {
+        ++allMetadataCalls;
+        return MetadataRepository::getAllMetadata(documentId);
+    }
+
+    Result<std::unordered_map<int64_t, std::vector<std::string>>>
+    batchGetDocumentTags(std::span<const int64_t> documentIds) override {
+        ++batchTagCalls;
+        return MetadataRepository::batchGetDocumentTags(documentIds);
+    }
+
+    std::atomic<int> allMetadataCalls{0};
+    std::atomic<int> batchTagCalls{0};
 };
 
 class SlowSnippetMetadataRepository : public MetadataRepository {
@@ -463,6 +485,44 @@ TEST_CASE("SearchService: tag filter", "[unit][services][search]") {
     auto result = runAwait(f.searchService->search(request));
     REQUIRE(result);
     CHECK(result.value().total >= kZeroTotal);
+}
+
+TEST_CASE("SearchService: tag filtering loads tags once per request, not per document",
+          "[unit][services][search][tags]") {
+    SearchServiceFixture f;
+    REQUIRE(f.testHashes.size() >= 3);
+    f.setMetadataForHash(f.testHashes[0], "tag:tutorial", "1");
+    f.setMetadataForHash(f.testHashes[1], "tag:example", "1");
+    f.setMetadataForHash(f.testHashes[1], "tag:tutorial", "1");
+
+    auto counting = std::make_shared<TagLookupCountingRepository>(*f.pool);
+    f.metadataRepo = counting;
+    f.appContext.metadataRepo = counting;
+    f.searchService = makeSearchService(f.appContext);
+
+    SECTION("hash prefix search") {
+        auto request = f.createBasicSearchRequest("");
+        request.hash = f.testHashes[1].substr(0, 12);
+        request.tags = {"tutorial", "example"};
+        request.matchAllTags = true;
+        auto result = runAwait(f.searchService->search(request));
+        INFO(std::string(result ? "ok" : result.error().message.c_str()));
+        REQUIRE(result);
+        CHECK(result.value().results.size() == 1);
+        CHECK(counting->batchTagCalls.load() == 1);
+        CHECK(counting->allMetadataCalls.load() == 0);
+    }
+    SECTION("path search") {
+        auto request = f.createBasicSearchRequest("*.txt");
+        request.tags = {"tutorial"};
+        request.matchAllTags = false;
+        auto result = runAwait(f.searchService->search(request));
+        INFO(std::string(result ? "ok" : result.error().message.c_str()));
+        REQUIRE(result);
+        CHECK(result.value().results.size() == 2);
+        CHECK(counting->batchTagCalls.load() == 1);
+        CHECK(counting->allMetadataCalls.load() == 0);
+    }
 }
 
 TEST_CASE("SearchService: file type filter", "[unit][services][search]") {


### PR DESCRIPTION
perf(search): load tag filters once per request, not once per document

pathSearch and searchByHashPrefix filtered candidates through
metadataHasTags(), which for every document called getAllMetadata()
(four retries with backoff on failure), concatenated every metadata
key and value into a string, and logged that string at info level.
A path search over a few thousand documents was a few thousand
metadata round trips and a few thousand info lines.

Both paths now load tags for the whole candidate set with one
batchGetDocumentTags() call (the API GraphComponent already used) and
filter with a pure matcher. The legacy fallback that also accepted a
metadata row with key "tag" is gone: nothing writes that form and the
repository's own tag APIs never honoured it, so search and repository
now agree on what a tag is.

A counting repository subclass pins the shape: one batch call and zero
getAllMetadata calls for both the path and the hash-prefix routes.
portability_allowlist.txt: two search_service.cpp anchors reflowed.

Correction to the claim above that nothing writes the legacy `key = "tag"`
form: the repair downloads pass did (tag values "downloaded", "host:<h>",
"scheme:<s>"), and the search fallback was its only reader. That writer now
uses the same `tag:<name>` keys as every other tag writer, so `--tags
downloaded` keeps matching documents the repair pass tagged. And
batchGetDocumentTags chunks its IN list (500 ids), since pathSearch feeds it
an unbounded candidate set; an oversized list used to fail the statement
and, with this change, would have emptied the result instead of degrading
per document.

---
Stack position 15 of 29; base branch `stack/22-kg-prepared-statements` (merge in order).
