### PR TITLE
perf(search): hydrate topology routing candidates in batches

### DIFF
--- a/src/search/topology_routing_session.cpp
+++ b/src/search/topology_routing_session.cpp
@@ -332,7 +332,25 @@ void collectGraphNeighborStageTrace(
     trace.eligibleCandidateCount = eligibleCandidates.size();
 
     std::unordered_map<std::string, std::optional<std::string>> documentIds;
-    documentIds.reserve(request.seedDocumentHashes.size() + relationCandidates.size());
+    documentIds.reserve(request.seedDocumentHashes.size() + relationCandidates.size() +
+                        fetchedCandidates.size() + eligibleCandidates.size());
+    {
+        std::vector<std::string> allHashes;
+        allHashes.reserve(documentIds.bucket_count());
+        for (const auto* stage : {&request.seedDocumentHashes, &relationCandidates,
+                                  &fetchedCandidates, &eligibleCandidates}) {
+            for (const auto& hash : *stage) {
+                if (documentIds.try_emplace(hash).second) {
+                    allHashes.push_back(hash);
+                }
+            }
+        }
+        if (auto hydrated = metadataRepo->batchGetDocumentsByHash(allHashes)) {
+            for (auto& [hash, document] : hydrated.value()) {
+                documentIds[hash] = documentIdForTrace(document.filePath, hash);
+            }
+        }
+    }
     auto resolveDocumentId = [&](const std::string& hash) -> const std::optional<std::string>& {
         auto [it, inserted] = documentIds.try_emplace(hash);
         if (!inserted) {
@@ -517,11 +535,18 @@ void admitRankedCandidates(TopologyRoutingSessionResult& result,
     }
     candidateHashes.reserve(candidateHashes.size() + ranked.size());
 
+    // One statement for the whole ranked set; a hash the corpus no longer holds is stale.
+    const auto docLookupStart = std::chrono::steady_clock::now();
+    auto hydrated = metadataRepo->batchGetDocumentsByHash(ranked);
+    result.timings.docLookupMicros += microsSince(docLookupStart);
     for (const auto& hash : ranked) {
-        const auto docLookupStart = std::chrono::steady_clock::now();
-        auto docLookup = metadataRepo->getDocumentByHash(hash);
-        result.timings.docLookupMicros += microsSince(docLookupStart);
-        if (!docLookup || !docLookup.value().has_value()) {
+        const yams::metadata::DocumentInfo* document = nullptr;
+        if (hydrated) {
+            if (const auto it = hydrated.value().find(hash); it != hydrated.value().end()) {
+                document = &it->second;
+            }
+        }
+        if (!document) {
             ++result.staleCandidates;
             continue;
         }
@@ -529,8 +554,7 @@ void admitRankedCandidates(TopologyRoutingSessionResult& result,
             result.certificate.allowedDocumentHashes.insert(hash);
         }
         result.routedCandidateHashes.insert(hash);
-        result.routedCandidateDocIds.push_back(
-            documentIdForTrace(docLookup.value()->filePath, hash));
+        result.routedCandidateDocIds.push_back(documentIdForTrace(document->filePath, hash));
         const auto insertStart = std::chrono::steady_clock::now();
         const auto [_, inserted] = candidateHashes.insert(hash);
         result.timings.candidateInsertMicros += microsSince(insertStart);
@@ -1072,16 +1096,30 @@ runClusterArtifactExpansion(const TopologyRoutingSessionRequest& request,
         if (request.options.collectRouteMembership) {
             continue;
         }
-        const auto expansionHashes = selectClusterExpansionHashes(route);
-        for (const auto& hash : expansionHashes) {
-            if (request.options.maxDocs > 0 && result.routedDocs >= request.options.maxDocs) {
-                break;
+        auto expansionHashes = selectClusterExpansionHashes(route);
+        if (request.options.maxDocs > 0) {
+            // Same cut the per-document loop applied, taken before hydration.
+            const std::size_t remaining = result.routedDocs >= request.options.maxDocs
+                                              ? 0
+                                              : request.options.maxDocs - result.routedDocs;
+            if (expansionHashes.size() > remaining) {
+                expansionHashes.resize(remaining);
             }
+        }
+        const auto docLookupStart = std::chrono::steady_clock::now();
+        auto hydrated = expansionHashes.empty()
+                            ? decltype(metadataRepo->batchGetDocumentsByHash(expansionHashes)){}
+                            : metadataRepo->batchGetDocumentsByHash(expansionHashes);
+        result.timings.docLookupMicros += microsSince(docLookupStart);
+        for (const auto& hash : expansionHashes) {
             ++result.routedDocs;
-            const auto docLookupStart = std::chrono::steady_clock::now();
-            auto docLookup = metadataRepo->getDocumentByHash(hash);
-            result.timings.docLookupMicros += microsSince(docLookupStart);
-            if (!docLookup || !docLookup.value().has_value()) {
+            const yams::metadata::DocumentInfo* document = nullptr;
+            if (hydrated) {
+                if (const auto it = hydrated.value().find(hash); it != hydrated.value().end()) {
+                    document = &it->second;
+                }
+            }
+            if (!document) {
                 ++result.staleCandidates;
                 continue;
             }
@@ -1089,8 +1127,7 @@ runClusterArtifactExpansion(const TopologyRoutingSessionRequest& request,
                 continue;
             }
             result.routedCandidateHashes.insert(hash);
-            result.routedCandidateDocIds.push_back(
-                documentIdForTrace(docLookup.value()->filePath, hash));
+            result.routedCandidateDocIds.push_back(documentIdForTrace(document->filePath, hash));
             const auto insertStart = std::chrono::steady_clock::now();
             const auto [_, inserted] = candidateHashes.insert(hash);
             result.timings.candidateInsertMicros += microsSince(insertStart);

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -501,7 +501,7 @@ tests/unit/search/graph_expansion_catch2_test.cpp:18:portability/env-read # revi
 tests/unit/search/hybrid_search_comprehensive_test.cpp:272:portability/env-read # reviewed raw environment read
 tests/unit/search/kg_scorer_simple_catch2_test.cpp:35:portability/env-read # reviewed raw environment read
 tests/unit/search/search_engine_simeon_lexical_catch2_test.cpp:25:portability/env-read # reviewed raw environment read
-tests/unit/search/search_engine_topology_catch2_test.cpp:43:portability/env-read # reviewed raw environment read
+tests/unit/search/search_engine_topology_catch2_test.cpp:44:portability/env-read # reviewed raw environment read
 tests/unit/search/simeon_bandit_backend_catch2_test.cpp:30:portability/env-read # reviewed raw environment read
 tests/unit/search/simeon_lexical_backend_catch2_test.cpp:27:portability/env-read # reviewed raw environment read
 tests/unit/topology/topology_baseline_catch2_test.cpp:64:portability/env-read # reviewed raw environment read

--- a/tests/unit/search/search_engine_topology_catch2_test.cpp
+++ b/tests/unit/search/search_engine_topology_catch2_test.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
@@ -80,6 +81,25 @@ public:
 private:
     std::vector<float> embedding_;
     bool initialized_{false};
+};
+
+class HashLookupCountingRepository : public MetadataRepository {
+public:
+    explicit HashLookupCountingRepository(ConnectionPool& pool) : MetadataRepository(pool) {}
+
+    Result<std::optional<DocumentInfo>> getDocumentByHash(const std::string& hash) override {
+        ++singleLookups;
+        return MetadataRepository::getDocumentByHash(hash);
+    }
+
+    Result<std::unordered_map<std::string, DocumentInfo>>
+    batchGetDocumentsByHash(const std::vector<std::string>& hashes) override {
+        ++batchLookups;
+        return MetadataRepository::batchGetDocumentsByHash(hashes);
+    }
+
+    std::atomic<int> singleLookups{0};
+    std::atomic<int> batchLookups{0};
 };
 
 struct TopologySearchFixture {
@@ -2208,4 +2228,48 @@ TEST_CASE("Graph-neighbor trace separates stored relation from the selected cap"
           std::vector<std::string>{"near", "far"});
     REQUIRE(result.routedCandidateDocIds.size() == 1);
     CHECK(result.routedCandidateDocIds.front() == "near");
+}
+
+TEST_CASE("Topology routing hydrates ranked candidates and trace stages in batches",
+          "[unit][search][topology][graph_neighbors][hydration]") {
+    TopologySearchFixture fix;
+    auto counting = std::make_shared<HashLookupCountingRepository>(*fix.pool);
+    fix.repo = counting;
+    fix.addDocument("seed", "seed", {1.0F, 0.0F});
+    std::vector<KGNode> nodes{KGNode{.nodeKey = "doc:seed", .type = "document"}};
+    for (int i = 0; i < 8; ++i) {
+        const auto hash = "near" + std::to_string(i);
+        fix.addDocument(hash, hash, {0.9F, 0.1F});
+        nodes.push_back(KGNode{.nodeKey = "doc:" + hash, .type = "document"});
+    }
+    const auto nodeIds = fix.kgStore->upsertNodes(nodes);
+    REQUIRE(nodeIds.has_value());
+    REQUIRE(nodeIds.value().size() == 9);
+    for (std::size_t i = 1; i < nodeIds.value().size(); ++i) {
+        REQUIRE(fix.kgStore
+                    ->addEdge(KGEdge{.srcNodeId = nodeIds.value()[0],
+                                     .dstNodeId = nodeIds.value()[i],
+                                     .relation = "semantic_neighbor",
+                                     .weight = 0.9F})
+                    .has_value());
+    }
+    TopologyRoutingSessionRequest request;
+    request.seedDocumentHashes = {"seed"};
+    request.options.routingMode = SearchEngineConfig::TopologyRoutingMode::HybridAssist;
+    request.options.expansionSource = SearchEngineConfig::TopologyExpansionSource::GraphNeighbors;
+    request.options.maxDocs = 8;
+    request.options.collectRouteMembership = true;
+    request.options.collectGraphDiagnostics = true;
+    request.options.graphNeighborMinScore = 0.0F;
+    request.options.graphNeighborReciprocalOnly = false;
+
+    counting->singleLookups = 0;
+    counting->batchLookups = 0;
+    const auto result = runTopologyRoutingSession(request, fix.repo, fix.kgStore);
+    REQUIRE(result.graphNeighborTrace.collected);
+    CHECK(result.graphNeighborTrace.relationCandidateCount == 8);
+    REQUIRE(result.routedCandidateDocIds.size() == 8);
+    // Trace stages resolve in one batch and ranked admission in another; nothing goes per hash.
+    CHECK(counting->batchLookups.load() >= 1);
+    CHECK(counting->singleLookups.load() == 0);
 }


### PR DESCRIPTION
perf(search): hydrate topology routing candidates in batches

The routing session called getDocumentByHash once per hash in three
places on the product routing path: ranked-candidate admission, cluster
expansion, and the graph-neighbor diagnostic trace (memoized, but still
one statement per distinct hash across four stages). Each now issues
one batchGetDocumentsByHash for its whole set, the same API the
topology input extractor already used, and the docLookupMicros timing
covers the batch. Cluster expansion applies the maxDocs cut before
hydrating so no document is fetched only to be discarded.

A session-level test with one seed and eight graph neighbours under a
counting repository fails on the previous code (17 single lookups, no
batch) and passes now (0 single lookups). The full topology suite is
unchanged.

portability_allowlist.txt: one topology test anchor reflowed.

---
Stack position 16 of 29; base branch `stack/23-batched-tag-filters` (merge in order).
