### PR TITLE
perf(search): hold Simeon concept mining to the corpus byte budget

### DIFF
--- a/src/search/simeon_lexical_backend.cpp
+++ b/src/search/simeon_lexical_backend.cpp
@@ -510,19 +510,38 @@ Result<void> SimeonLexicalBackend::buildAsync(std::shared_ptr<metadata::Metadata
         if (cfg_.concept_mining_enabled && ids.size() >= 100) {
             try {
                 const auto cmt0 = std::chrono::steady_clock::now();
+                // Unlike the BM25 pass, which streams one chunked document at a time, concept
+                // mining needs every document's raw text resident at once. Hold it to the same
+                // corpus byte budget or the build's peak memory is the whole corpus.
                 std::vector<std::string> conceptTexts;
                 conceptTexts.reserve(ids.size());
+                std::size_t conceptCorpusBytes = 0;
+                bool conceptBudgetExceeded = false;
                 for (auto docId : ids) {
                     if (stop.stop_requested())
                         break;
                     auto contentResult = repo->getContent(docId);
                     if (contentResult && contentResult.value()) {
-                        conceptTexts.emplace_back(std::move(contentResult.value()->contentText));
+                        auto& text = contentResult.value()->contentText;
+                        if (exceedsBudget(conceptCorpusBytes, text.size(), cfg_.max_corpus_bytes)) {
+                            conceptBudgetExceeded = true;
+                            break;
+                        }
+                        conceptCorpusBytes += text.size();
+                        conceptTexts.emplace_back(std::move(text));
                     } else {
                         conceptTexts.emplace_back();
                     }
                 }
-                if (!stop.stop_requested() && conceptTexts.size() == ids.size()) {
+                if (conceptBudgetExceeded) {
+                    spdlog::warn("[simeon-lexical] concept mining skipped: raw corpus exceeds "
+                                 "max_corpus_bytes (docs_loaded={} bytes={} cap={})",
+                                 conceptTexts.size(), conceptCorpusBytes, cfg_.max_corpus_bytes);
+                    conceptTexts.clear();
+                    conceptTexts.shrink_to_fit();
+                }
+                if (!conceptBudgetExceeded && !stop.stop_requested() &&
+                    conceptTexts.size() == ids.size()) {
                     YAMS_ZONE_SCOPED_N("simeon::mine_concepts");
                     std::vector<std::string_view> docViews;
                     docViews.reserve(conceptTexts.size());

--- a/tests/unit/search/simeon_lexical_backend_catch2_test.cpp
+++ b/tests/unit/search/simeon_lexical_backend_catch2_test.cpp
@@ -215,6 +215,50 @@ TEST_CASE("SimeonLexicalBackend chunks oversized docs before applying corpus byt
     CHECK(backend.doc_count() == 1u);
 }
 
+TEST_CASE("SimeonLexicalBackend concept mining honours the corpus byte budget",
+          "[search][simeon][concepts][catch2]") {
+    // 120 documents of ~4 KiB each. Chunking keeps the BM25 pass under 64 KiB of processed
+    // text, but concept mining used to re-read every raw document into memory at once.
+    // A strongly associated pair ("quantum entanglement") near the front of each document,
+    // so both the chunked BM25 pass and the raw concept pass see it, followed by a wide filler
+    // vocabulary whose bigrams carry no association.
+    std::vector<std::pair<std::string, std::string>> docs;
+    docs.reserve(120);
+    std::uint32_t lcg = 12345u;
+    for (int i = 0; i < 120; ++i) {
+        std::string text = "quantum entanglement quantum entanglement quantum entanglement ";
+        while (text.size() < 4096) {
+            lcg = lcg * 1664525u + 1013904223u;
+            text += "w" + std::to_string(lcg % 397) + " ";
+        }
+        docs.emplace_back("hash_concept_" + std::to_string(i), std::move(text));
+    }
+    auto corpus = makeCorpus(docs);
+
+    SimeonLexicalBackend::Config cfg;
+    cfg.concept_mining_enabled = true;
+    cfg.build_doc_chunk_bytes = 128;
+    cfg.build_doc_max_chunks = 2;
+    cfg.fragment_geometry_enabled = false;
+
+    SECTION("raw corpus over budget skips concept mining but keeps the index") {
+        cfg.max_corpus_bytes = 64ULL * 1024ULL;
+        SimeonLexicalBackend backend(cfg);
+        REQUIRE(backend.buildAsync(corpus.repo).has_value());
+        REQUIRE(waitReady(backend, std::chrono::seconds(30)));
+        CHECK(backend.doc_count() == 120u);
+        CHECK(backend.concept_count() == 0u);
+    }
+    SECTION("raw corpus within budget mines concepts") {
+        cfg.max_corpus_bytes = 4ULL * 1024ULL * 1024ULL;
+        SimeonLexicalBackend backend(cfg);
+        REQUIRE(backend.buildAsync(corpus.repo).has_value());
+        REQUIRE(waitReady(backend, std::chrono::seconds(30)));
+        CHECK(backend.doc_count() == 120u);
+        CHECK(backend.concept_count() > 0u);
+    }
+}
+
 TEST_CASE("SimeonLexicalBackend score returns one float per candidate",
           "[search][simeon][catch2]") {
     auto corpus = makeCorpus({


### PR DESCRIPTION
perf(search): hold Simeon concept mining to the corpus byte budget

The BM25 pass streams one chunked document at a time and stops when
processed text would exceed max_corpus_bytes. The concept-mining pass
that follows re-read every document's raw text into one vector and
kept it all resident for mine_concepts(), with no budget at all: on a
large corpus the build's peak memory was the whole corpus, regardless
of the cap the first pass had just enforced. This is the likeliest
single contributor to the daemon's multi-gigabyte footprint.

The concept pass now applies the same budget to raw bytes as it loads.
When the corpus exceeds it, mining is skipped with a warning and the
BM25 index is kept; the partially loaded text is released. A corpus
within budget is mined exactly as before.

Test: 120 documents of 4 KiB with a chunk cap that keeps the BM25 pass
under 64 KiB. Over budget, the build completes with zero concepts
(previously 81 were mined from ~480 KiB of resident text); with a
4 MiB budget the same corpus mines concepts.

---
Stack position 17 of 29; base branch `stack/24-topology-batch-hydration` (merge in order).
