### PR TITLE
perf(ingest): bound the pending KG job overflow

### DIFF
--- a/docs/architecture/environment-overrides.md
+++ b/docs/architecture/environment-overrides.md
@@ -55,7 +55,8 @@ Named decisions from the tuning migration:
   `model_evict_critical_threshold`, `model_evict_emergency_threshold`,
   `indexing_workers_max`, `store_document_channel_capacity`, `work_coordinator_threads`,
   `embed_channel_capacity`, `connection_lifetime_s`. The matching environment names remain
-  deprecated compatibility inputs.
+  deprecated compatibility inputs. `post_ingest_pending_kg_max` bounds the overflow FIFO
+  behind the `kg_jobs` channel (default 16384) and has no environment counterpart.
 - New typed product sections are `[tuning.ipc]` (`timeout_ms`,
   `stream_chunk_timeout_ms`), `[tuning.resource]` (`enabled`, `admission_control`, memory thresholds,
   budgets, and hysteresis), and `[tuning.post_ingest]` (stage concurrency, batch, RPC queue, and RPC

--- a/include/yams/daemon/components/PostIngestQueue.h
+++ b/include/yams/daemon/components/PostIngestQueue.h
@@ -426,6 +426,11 @@ public:
     }
     void testing_schedulePendingKgDrain() { schedulePendingKgDrain(); }
     void testing_enqueueKgJob(InternalEventBus::KgJob job) { enqueueKgJob(std::move(job)); }
+    // Route every KG job to the pending FIFO, as a full channel does in production.
+    void testing_detachKgChannel() {
+        std::lock_guard<std::mutex> lock(pendingKgMutex_);
+        kgChannel_.reset();
+    }
     void testing_processEntityExtractionBatch(
         std::vector<InternalEventBus::EntityExtractionJob>&& jobs) {
         processEntityExtractionBatch(std::move(jobs));
@@ -627,6 +632,7 @@ private:
     std::shared_ptr<SpscQueue<InternalEventBus::KgJob>> kgChannel_;
     mutable std::mutex pendingKgMutex_;
     std::deque<InternalEventBus::KgJob> pendingKgJobs_;
+    std::atomic<std::uint64_t> pendingKgDropped_{0};
     std::atomic<bool> pendingKgDrainScheduled_{false};
     std::shared_ptr<SpscQueue<InternalEventBus::SymbolExtractionJob>> symbolChannel_;
     std::shared_ptr<SpscQueue<InternalEventBus::EntityExtractionJob>> entityChannel_;

--- a/include/yams/daemon/components/TuneAdvisor.h
+++ b/include/yams/daemon/components/TuneAdvisor.h
@@ -302,6 +302,7 @@ public:
         ioConnPerThreadOverride_.store(0, std::memory_order_relaxed);
         postIngestThreads_.store(0, std::memory_order_relaxed);
         postIngestQueueMaxOverride_.store(0, std::memory_order_relaxed);
+        postIngestPendingKgMaxOverride_.store(0, std::memory_order_relaxed);
         listInflightLimitOverride_.store(0, std::memory_order_relaxed);
         listAdmissionWaitMsOverride_.store(0, std::memory_order_relaxed);
         grepInflightLimitOverride_.store(0, std::memory_order_relaxed);
@@ -1290,6 +1291,19 @@ public:
     }
     static void setPostIngestQueueMax(uint32_t v) {
         postIngestQueueMaxOverride_.store(v, std::memory_order_relaxed);
+    }
+
+    // Overflow FIFO behind the bounded kg_jobs channel. Each pending job may hold document
+    // bytes, so this bound is what keeps a KG stall from growing ingest memory without limit.
+    // Typed key only: tuning.post_ingest_pending_kg_max.
+    static uint32_t postIngestPendingKgMax() {
+        uint32_t ov = postIngestPendingKgMaxOverride_.load(std::memory_order_relaxed);
+        if (ov != 0)
+            return ov;
+        return 16384;
+    }
+    static void setPostIngestPendingKgMax(uint32_t v) {
+        postIngestPendingKgMaxOverride_.store(v, std::memory_order_relaxed);
     }
 
     // Post-ingest RPC queue capacity (high-priority channel). Env override:
@@ -2597,6 +2611,7 @@ private:
     static inline std::atomic<uint32_t> postIngestStageActiveMaskOverride_{0};
     static inline std::array<std::atomic<uint32_t>, 6> postIngestStageOwnerCounts_{};
     static inline std::atomic<uint32_t> postIngestQueueMaxOverride_{0};
+    static inline std::atomic<uint32_t> postIngestPendingKgMaxOverride_{0};
     static inline std::atomic<uint32_t> postIngestBatchSizeOverride_{0};
     static inline std::atomic<uint32_t> postIngestRpcQueueMaxOverride_{0};
     static inline std::atomic<uint32_t> storeDocumentChannelCapacityOverride_{0};

--- a/src/daemon/components/ConfigResolver.cpp
+++ b/src/daemon/components/ConfigResolver.cpp
@@ -1410,6 +1410,7 @@ TuningConfig ConfigResolver::applyRuntimeTuning(const ConfigSections& sections,
     applyUint32("io_conn_per_thread", &TuneAdvisor::setIoConnPerThread);
     applyUint32("post_ingest_threads", &TuneAdvisor::setPostIngestThreads);
     applyUint32("post_ingest_queue_max", &TuneAdvisor::setPostIngestQueueMax);
+    applyUint32("post_ingest_pending_kg_max", &TuneAdvisor::setPostIngestPendingKgMax);
     applyUint32("list_inflight_limit", &TuneAdvisor::setListInflightLimit);
     applyUint32("list_admission_wait_ms", &TuneAdvisor::setListAdmissionWaitMs);
     applyUint32("grep_inflight_limit", &TuneAdvisor::setGrepInflightLimit);

--- a/src/daemon/components/PostIngestQueue.cpp
+++ b/src/daemon/components/PostIngestQueue.cpp
@@ -1,6 +1,4 @@
 #include <nlohmann/json.hpp>
-#include "title_enrichment_policy.h"
-#include "embedding_derivation_policy.h"
 #include <spdlog/spdlog.h>
 #include <algorithm>
 #include <atomic>
@@ -11,7 +9,9 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include "embedding_derivation_policy.h"
 #include "post_ingest_nl_graph_builder.h"
+#include "title_enrichment_policy.h"
 #include <boost/asio.hpp>
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
@@ -1629,6 +1629,19 @@ void PostIngestQueue::enqueueKgJob(InternalEventBus::KgJob job) {
         } else {
             // Keep full-channel backpressure off WorkCoordinator threads. One coroutine drains the
             // pending FIFO as the KG poller creates capacity; producers only append and return.
+            // The FIFO is bounded: each entry can pin document bytes, so an unbounded overflow
+            // would turn a KG stall into unbounded ingest memory.
+            const std::size_t pendingCap = TuneAdvisor::postIngestPendingKgMax();
+            if (pendingKgJobs_.size() >= pendingCap) {
+                InternalEventBus::instance().incKgDropped();
+                const auto dropped = pendingKgDropped_.fetch_add(1, std::memory_order_relaxed) + 1;
+                if (dropped == 1 || (dropped % 1000) == 0) {
+                    spdlog::warn("[PostIngestQueue] pending KG overflow full ({}), dropping job "
+                                 "for {} (dropped={})",
+                                 pendingCap, job.hash.substr(0, 12), dropped);
+                }
+                return;
+            }
             pendingKgJobs_.push_back(std::move(job));
         }
     }

--- a/tests/unit/daemon/components/post_ingest_queue_unit_catch2_test.cpp
+++ b/tests/unit/daemon/components/post_ingest_queue_unit_catch2_test.cpp
@@ -12,6 +12,8 @@
 
 #include "src/daemon/components/post_ingest_nl_graph_builder.h"
 #include <yams/daemon/components/PostIngestQueue.h>
+#include <yams/daemon/components/TuneAdvisor.h>
+#include <yams/daemon/components/WorkCoordinator.h>
 #include <yams/daemon/resource/external_entity_provider_adapter.h>
 #include <yams/metadata/path_utils.h>
 
@@ -176,6 +178,31 @@ TEST_CASE("PostIngestQueue entity stage leaves the shared content buffer intact"
     queue.testing_processEntityExtractionBatch(std::move(jobs));
 
     CHECK(shared->size() == expectedSize);
+}
+
+TEST_CASE("PostIngestQueue bounds the pending KG overflow and accounts drops",
+          "[daemon][post-ingest][kg][backpressure][catch2]") {
+    // With the channel detached every job lands in the overflow FIFO; a running coordinator
+    // keeps the drain coroutine alive so pending jobs are neither cancelled nor consumed.
+    WorkCoordinator coordinator;
+    coordinator.start(1);
+    PostIngestQueue queue{nullptr, nullptr, {}, nullptr, nullptr, &coordinator, nullptr, 8};
+    queue.testing_detachKgChannel();
+    TuneAdvisor::setPostIngestPendingKgMax(2);
+
+    auto& bus = InternalEventBus::instance();
+    const auto droppedBefore = bus.kgDropped();
+    for (int i = 0; i < 3; ++i) {
+        InternalEventBus::KgJob job;
+        job.hash = "pending-" + std::to_string(i);
+        queue.testing_enqueueKgJob(std::move(job));
+    }
+    CHECK(queue.testing_pendingKgJobs() == 2);
+    CHECK(bus.kgDropped() == droppedBefore + 1);
+
+    TuneAdvisor::setPostIngestPendingKgMax(0);
+    queue.stop();
+    coordinator.stop();
 }
 
 TEST_CASE("PostIngestQueue stage constants", "[daemon][post-ingest][catch2]") {


### PR DESCRIPTION
perf(ingest): bound the pending KG job overflow

When the bounded kg_jobs channel (16384 slots) is full, enqueueKgJob
parks jobs in pendingKgJobs_, a std::deque with no limit. Each KgJob
can carry the document's content bytes, so a stalled or slow KG stage
turned into unbounded ingest memory on top of the ~36k entries the
symbol, entity and KG channels already hold.

The overflow FIFO now has a cap, tuning.post_ingest_pending_kg_max
(typed key on TuneAdvisor, default 16384, no environment twin per
AGENTS.md). At the cap the job is dropped: the document's KG stage is skipped for
this ingest, the drop is counted through the existing kgDropped bus
counter (shared with shutdown cancellations), and a throttled warning
names the cap. Nothing re-derives the per-document entity graph for a
dropped job today; the structural repair pass rebuilds document nodes
and orphans but not that stage, so an operator who sees the warning
should raise the cap or re-ingest. Bounded memory with a visible drop
beats unbounded memory with an invisible stall.

Test: with the channel detached and a live coordinator (so the drain
coroutine neither cancels nor consumes), three enqueues against a cap
of two leave two pending and one dropped; before the cap all three
were pending.

---
Stack position 18 of 29; base branch `stack/25-simeon-concept-budget` (merge in order).
