### PR TITLE
perf(search): parse edge anchor properties once, lower the path query once

### DIFF
--- a/include/yams/search/graph_expansion.h
+++ b/include/yams/search/graph_expansion.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -32,6 +33,17 @@ struct GraphExpansionConfig {
 };
 
 std::vector<std::string> tokenizeKgQuery(std::string_view query);
+
+// Region/scope hints carried in an edge's JSON properties. The text is parsed only when it
+// can contain either key, and each distinct properties string is parsed once per thread
+// (bounded cache), instead of once per edge visit.
+struct EdgeAnchorHints {
+    std::string region;
+    std::string scope;
+};
+EdgeAnchorHints edgeAnchorHints(const std::optional<std::string>& properties);
+// Process-wide count of JSON parses performed by edgeAnchorHints (diagnostics; tests pin it).
+std::uint64_t edgeAnchorParseCount() noexcept;
 
 float graphNodeExpansionWeight(const std::optional<std::string>& typeOpt,
                                std::string_view labelView);

--- a/src/app/services/search_service.cpp
+++ b/src/app/services/search_service.cpp
@@ -450,12 +450,13 @@ static std::string_view basenameView(std::string_view path) {
     return path.substr(pos + 1);
 }
 
-static double computePathMatchScore(const metadata::DocumentInfo& doc, const std::string& query,
-                                    bool wildcard) {
+// queryLower is the trimmed, lowercased query, computed once by the caller for the whole
+// candidate set rather than once per document.
+static double computePathMatchScore(const metadata::DocumentInfo& doc,
+                                    const std::string& queryLower, bool wildcard) {
     const std::string path = !doc.filePath.empty() ? doc.filePath : doc.fileName;
     const std::string pathLower = yams::common::asciiToLowerCopy(path);
     const std::string nameLower = yams::common::asciiToLowerCopy(doc.fileName);
-    const std::string queryLower = yams::common::asciiToLowerCopy(yams::common::trimCopy(query));
 
     if (queryLower.empty()) {
         return 0.01;
@@ -1535,6 +1536,8 @@ private:
         // Apply additional filters and shape results
         const auto tagsByDoc =
             co_await loadTagsForDocuments(ctx_.metadataRepo.get(), docs, req.tags, telemetry);
+        const std::string pathQueryLower =
+            yams::common::asciiToLowerCopy(yams::common::trimCopy(pathQuery));
         auto push_path = [&](const metadata::DocumentInfo& d) -> boost::asio::awaitable<void> {
             if (!req.extension.empty()) {
                 if (d.fileExtension != req.extension && d.fileExtension != ("." + req.extension))
@@ -1545,7 +1548,7 @@ private:
             if (!hasRequiredTags(tagsByDoc, d.id, req.tags, req.matchAllTags))
                 co_return;
             const std::string resolvedPath = !d.filePath.empty() ? d.filePath : d.fileName;
-            const double score = computePathMatchScore(d, pathQuery, wildcard);
+            const double score = computePathMatchScore(d, pathQueryLower, wildcard);
 
             if (req.pathsOnly) {
                 rankedPaths.emplace_back(resolvedPath, score);

--- a/src/search/graph_expansion.cpp
+++ b/src/search/graph_expansion.cpp
@@ -5,13 +5,51 @@
 
 #include <nlohmann/json.hpp>
 #include <algorithm>
+#include <atomic>
 #include <cctype>
+#include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
 
 #include <yams/search/query_text_utils.h>
 
 namespace yams::search {
+
+namespace {
+std::atomic<std::uint64_t> g_edgeAnchorParses{0};
+} // namespace
+
+// Returned by value: the memo below clears itself when full, so a reference into it would
+// dangle across calls.
+EdgeAnchorHints edgeAnchorHints(const std::optional<std::string>& properties) {
+    if (!properties || properties->empty()) {
+        return {};
+    }
+    const std::string& text = *properties;
+    if (text.find("region") == std::string::npos && text.find("scope") == std::string::npos) {
+        return {};
+    }
+    thread_local std::unordered_map<std::string, EdgeAnchorHints> cache;
+    if (auto it = cache.find(text); it != cache.end()) {
+        return it->second;
+    }
+    if (cache.size() >= 1024) {
+        cache.clear();
+    }
+    EdgeAnchorHints hints;
+    g_edgeAnchorParses.fetch_add(1, std::memory_order_relaxed);
+    try {
+        auto props = nlohmann::json::parse(text);
+        hints.region = props.value("region", "");
+        hints.scope = props.value("scope", "");
+    } catch (...) {
+    }
+    return cache.emplace(text, std::move(hints)).first->second;
+}
+
+std::uint64_t edgeAnchorParseCount() noexcept {
+    return g_edgeAnchorParses.load(std::memory_order_relaxed);
+}
 
 namespace {
 
@@ -64,10 +102,10 @@ float relationExpansionWeight(const metadata::KGEdge& edge) {
     }
 
     if (edge.properties.has_value()) {
-        try {
-            auto props = nlohmann::json::parse(*edge.properties);
-            const std::string region = props.value("region", "");
-            const std::string scope = props.value("scope", "");
+        {
+            const auto hints = edgeAnchorHints(edge.properties);
+            const std::string& region = hints.region;
+            const std::string& scope = hints.scope;
             if (region == "body_claim" || scope == "body_segment") {
                 base *= 1.25f;
             } else if (region == "title" || scope == "title") {
@@ -75,7 +113,6 @@ float relationExpansionWeight(const metadata::KGEdge& edge) {
             } else if (region == "summary" || scope == "summary") {
                 base *= 0.90f;
             }
-        } catch (...) {
         }
     }
 
@@ -615,9 +652,8 @@ std::vector<GraphExpansionTerm> generateGraphExpansionTermsFromDocuments(
                     }
                 }
                 if (edge.relation == "mentioned_in_segment" && edge.properties.has_value()) {
-                    try {
-                        auto props = nlohmann::json::parse(*edge.properties);
-                        const std::string region = props.value("region", "");
+                    {
+                        const std::string region = edgeAnchorHints(edge.properties).region;
                         if (region == "body_claim") {
                             anchoredToBodyClaim = true;
                             anchorBoost = std::max(anchorBoost, 1.15f);
@@ -625,7 +661,6 @@ std::vector<GraphExpansionTerm> generateGraphExpansionTermsFromDocuments(
                             anchoredToTitleOrPrimary = true;
                             anchorBoost = std::max(anchorBoost, 1.20f);
                         }
-                    } catch (...) {
                     }
                 }
             }
@@ -732,15 +767,14 @@ std::vector<GraphExpansionTerm> generateGraphExpansionTermsFromDocuments(
                             }
                             if (edge.relation == "mentioned_in_segment" &&
                                 edge.properties.has_value()) {
-                                try {
-                                    auto props = nlohmann::json::parse(*edge.properties);
-                                    const std::string region = props.value("region", "");
+                                {
+                                    const std::string region =
+                                        edgeAnchorHints(edge.properties).region;
                                     if (region == "body_claim" || region == "title") {
                                         neighborAnchored = true;
                                         neighborAnchorBoost = std::max(
                                             neighborAnchorBoost, region == "title" ? 1.20f : 1.15f);
                                     }
-                                } catch (...) {
                                 }
                             }
                         }

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -82,8 +82,8 @@ plugins/symbol_extractor_treesitter/grammar_loader.cpp:402:portability/env-read 
 plugins/symbol_extractor_treesitter/grammar_loader.cpp:411:portability/env-read # reviewed raw environment read
 plugins/symbol_extractor_treesitter/grammar_loader.cpp:413:portability/env-read # reviewed raw environment read
 src/app/services/document_service.cpp:1207:portability/env-read # reviewed raw environment read
-src/app/services/search_service.cpp:611:portability/env-read # reviewed raw environment read
-src/app/services/search_service.cpp:692:portability/env-read # reviewed raw environment read
+src/app/services/search_service.cpp:612:portability/env-read # reviewed raw environment read
+src/app/services/search_service.cpp:693:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:18:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:20:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:71:portability/env-read # reviewed raw environment read

--- a/tests/unit/search/graph_expansion_catch2_test.cpp
+++ b/tests/unit/search/graph_expansion_catch2_test.cpp
@@ -188,3 +188,26 @@ TEST_CASE("Graph expansion term merge: no duplicates in result",
     }
     CHECK(existing.size() == 3); // alpha, beta, gamma
 }
+
+TEST_CASE("Graph expansion parses edge anchor properties once per distinct string",
+          "[search][graph-expansion][anchors]") {
+    const auto before = edgeAnchorParseCount();
+    const std::optional<std::string> anchored{R"({"region":"body_claim","scope":"body_segment"})"};
+    for (int i = 0; i < 100; ++i) {
+        const auto& hints = edgeAnchorHints(anchored);
+        CHECK(hints.region == "body_claim");
+        CHECK(hints.scope == "body_segment");
+    }
+    CHECK(edgeAnchorParseCount() - before == 1);
+
+    // Properties that cannot carry an anchor are never parsed at all.
+    const auto mid = edgeAnchorParseCount();
+    const std::optional<std::string> plain{R"({"weight":0.5,"offset":42})"};
+    CHECK(edgeAnchorHints(plain).region.empty());
+    CHECK(edgeAnchorHints(std::nullopt).scope.empty());
+    CHECK(edgeAnchorParseCount() == mid);
+
+    // Malformed JSON degrades to no hints instead of throwing.
+    const std::optional<std::string> broken{"{region: nope"};
+    CHECK(edgeAnchorHints(broken).region.empty());
+}


### PR DESCRIPTION
perf(search): parse edge anchor properties once, lower the path query once

Graph expansion parsed every visited edge's JSON properties with
nlohmann::json::parse to read at most two strings, region and scope,
in three places (relation weighting, seed anchoring, and neighbour
anchoring). Properties strings repeat heavily across edges and most
carry no anchor at all. edgeAnchorHints() now returns immediately when
the text cannot contain either key and otherwise parses each distinct
string once per thread through a small bounded cache. A process-wide
parse counter lets the test pin it: one hundred lookups of the same
anchored string cost one parse, and un-anchored or malformed strings
cost none.

computePathMatchScore lowercased and trimmed the query for every
candidate document; pathSearch now does that once and passes the
lowered query down. The existing path-search tests cover the scoring.

portability_allowlist.txt: two search_service.cpp anchors reflowed.

edgeAnchorHints returns its two short strings by value: the per-thread memo
clears itself at 1024 entries, so a reference into it could dangle across
calls even though today's three callers consume the result immediately.

---
Stack position 20 of 29; base branch `stack/27-rerank-preview-and-glob-cache` (merge in order).
