### PR TITLE
test(memory-sync): give the CLI fixture the shared corpus scope it needs

### DIFF
--- a/tests/unit/memory_sync/memory_sync_cli_catch2_test.cpp
+++ b/tests/unit/memory_sync/memory_sync_cli_catch2_test.cpp
@@ -25,6 +25,7 @@ std::unique_ptr<MemorySyncService> makeService(const std::filesystem::path& dir)
     cfg.nodeId = "123e4567-e89b-42d3-a456-426614174000";
     cfg.corpusId = "cli-corpus";
     cfg.corpusEpoch = 1;
+    cfg.corpusScope = CorpusScope::Shared; // replication requires an explicit shared scope
     cfg.backend = "filesystem";
     cfg.path = dir.string();
     cfg.syncIntervalMs = 50;


### PR DESCRIPTION
test(memory-sync): give the CLI fixture the shared corpus scope it needs

94e948c6 made createMemorySyncService fail closed unless
memory_sync.corpus_scope is "shared" and updated the service-manager
test, but not the p2p CLI fixture, whose eight cases have failed at
construction ever since ("replication requires
memory_sync.corpus_scope=shared"). The fixture now sets the scope; the
cases run again and pass.

---
Stack position 21 of 29; base branch `stack/28-graph-expansion-anchor-parse` (merge in order).
