### PR TITLE
refactor(app): one home for hash predicates, path aliasing, and metadata qualifiers

### DIFF
--- a/include/yams/app/services/services.hpp
+++ b/include/yams/app/services/services.hpp
@@ -55,9 +55,6 @@ namespace yams::app::services::utils {
 /// week") Returns Unix epoch seconds, or error if parsing fails
 Result<std::int64_t> parseTimeExpression(const std::string& timeExpr);
 
-/// Check if a string looks like a content hash (hex string, 8-64 chars)
-bool looksLikeHash(const std::string& str);
-
 /// Classify file type from MIME type and extension for enhanced filtering
 /// Returns: "text", "binary", "image", "document", "archive", "audio", "video", "executable"
 std::string classifyFileType(const std::string& mimeType, const std::string& extension);

--- a/include/yams/common/delete_resolver/resolver.hpp
+++ b/include/yams/common/delete_resolver/resolver.hpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include <yams/common/fs_utils.h>
 #include <yams/common/pattern_utils.h>
 #include <yams/core/types.h>
 #include <yams/metadata/metadata_repository.h>
@@ -61,19 +62,8 @@ struct FilesystemBackend {
             return Error{ErrorCode::FileNotFound, "Path not found: " + abs.string()};
         }
 
-        auto normalize_display = [](const std::string& p) -> std::string {
-#ifdef __APPLE__
-            // On macOS, /var is a symlink to /private/var; tests expect the /var variant.
-            const std::string prefix = "/private/var/";
-            if (p.rfind(prefix, 0) == 0) {
-                return std::string{"/var/"} + p.substr(prefix.size());
-            }
-#endif
-            return p;
-        };
-
         const auto absStr = abs.string();
-        const auto disp = normalize_display(absStr);
+        const auto disp = yams::common::displayMacPathAlias(absStr);
         // For files: return the absolute file; for directories: return the absolute directory.
         // Recursion and include/exclude are applied by the caller/daemon.
         return std::vector<Target>{{disp, disp}};
@@ -101,17 +91,8 @@ struct FilesystemBackend {
         if (!fs::exists(abs) || !fs::is_directory(abs)) {
             return Error{ErrorCode::InvalidArgument, "Not a directory: " + abs.string()};
         }
-        auto normalize_display = [](const std::string& p) -> std::string {
-#ifdef __APPLE__
-            const std::string prefix = "/private/var/";
-            if (p.rfind(prefix, 0) == 0) {
-                return std::string{"/var/"} + p.substr(prefix.size());
-            }
-#endif
-            return p;
-        };
         const auto absStr = abs.string();
-        const auto disp = normalize_display(absStr);
+        const auto disp = yams::common::displayMacPathAlias(absStr);
         return std::vector<Target>{{disp, disp}};
     }
 };

--- a/include/yams/common/fs_utils.h
+++ b/include/yams/common/fs_utils.h
@@ -6,8 +6,112 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <vector>
 
 namespace yams::common {
+
+/**
+ * macOS mounts /var and /tmp as symlinks into /private, so a document can be indexed under
+ * either spelling. Everything that compares, displays, or expands stored paths goes through
+ * this one table; the helpers are purely lexical and never touch the filesystem.
+ */
+namespace path_alias {
+
+struct AliasPair {
+    std::string_view shortForm;
+    std::string_view privateForm;
+};
+
+inline constexpr AliasPair kAliases[] = {
+    {"/var", "/private/var"},
+    {"/tmp", "/private/tmp"},
+};
+
+/// True when `path` is exactly `root` or lives under it as a whole component.
+[[nodiscard]] inline bool hasRoot(std::string_view path, std::string_view root) noexcept {
+    return path.size() >= root.size() && path.compare(0, root.size(), root) == 0 &&
+           (path.size() == root.size() || path[root.size()] == '/');
+}
+
+/// The other spelling of `path` (/var/x <-> /private/var/x), or empty when it has none.
+[[nodiscard]] inline std::string otherSpelling(std::string_view path) {
+    for (const auto& alias : kAliases) {
+        if (hasRoot(path, alias.privateForm)) {
+            return std::string(alias.shortForm) +
+                   std::string(path.substr(alias.privateForm.size()));
+        }
+        if (hasRoot(path, alias.shortForm)) {
+            return std::string(alias.privateForm) +
+                   std::string(path.substr(alias.shortForm.size()));
+        }
+    }
+    return {};
+}
+
+/// The /private spelling, used when comparing paths. Identity for anything else.
+[[nodiscard]] inline std::string canonicalSpelling(std::string path) {
+    for (const auto& alias : kAliases) {
+        if (hasRoot(path, alias.shortForm)) {
+            return std::string(alias.privateForm) + path.substr(alias.shortForm.size());
+        }
+    }
+    return path;
+}
+
+/// The short spelling, used when showing a path back to the operator. Identity otherwise.
+[[nodiscard]] inline std::string displaySpelling(std::string path) {
+    for (const auto& alias : kAliases) {
+        if (hasRoot(path, alias.privateForm)) {
+            return std::string(alias.shortForm) + path.substr(alias.privateForm.size());
+        }
+    }
+    return path;
+}
+
+} // namespace path_alias
+
+/// Canonical (/private) spelling on macOS; identity on every other platform.
+[[nodiscard]] inline std::string canonicalizeMacPathAlias(std::string path) {
+#if defined(__APPLE__)
+    return path_alias::canonicalSpelling(std::move(path));
+#else
+    return path;
+#endif
+}
+
+/// Display (short) spelling on macOS; identity on every other platform.
+[[nodiscard]] inline std::string displayMacPathAlias(std::string path) {
+#if defined(__APPLE__)
+    return path_alias::displaySpelling(std::move(path));
+#else
+    return path;
+#endif
+}
+
+/// On macOS, append the other spelling of every pattern that has one (deduplicated), so a
+/// pattern written as /var/... also matches documents stored as /private/var/... and vice
+/// versa. No-op on every other platform.
+inline void appendMacPathAliases(std::vector<std::string>& patterns) {
+#if defined(__APPLE__)
+    const std::size_t original = patterns.size();
+    for (std::size_t i = 0; i < original; ++i) {
+        std::string alias = path_alias::otherSpelling(patterns[i]);
+        if (alias.empty())
+            continue;
+        bool seen = false;
+        for (const auto& existing : patterns) {
+            if (existing == alias) {
+                seen = true;
+                break;
+            }
+        }
+        if (!seen)
+            patterns.push_back(std::move(alias));
+    }
+#else
+    (void)patterns;
+#endif
+}
 
 /**
  * Ensure parent directories exist for the given path.

--- a/include/yams/common/hash_predicates.h
+++ b/include/yams/common/hash_predicates.h
@@ -1,0 +1,32 @@
+// yams/common/hash_predicates.h - shared "does this look like a content hash" predicates
+#pragma once
+
+#include <cctype>
+#include <string_view>
+
+namespace yams::common {
+
+/// True when every character is a hexadecimal digit (an empty string qualifies).
+[[nodiscard]] inline bool isHexDigits(std::string_view value) noexcept {
+    for (unsigned char ch : value) {
+        if (std::isxdigit(ch) == 0)
+            return false;
+    }
+    return true;
+}
+
+/// A bare search token is only treated as a hash prefix once it reaches 8 hex characters, so
+/// short code-like tokens ("cafe", "add") keep routing to text search. Upper bound is a full
+/// SHA-256 (64 characters).
+[[nodiscard]] inline bool looksLikeHashQueryToken(std::string_view value) noexcept {
+    return value.size() >= 8 && value.size() <= 64 && isHexDigits(value);
+}
+
+/// An explicit hash argument (--hash, a resolver target the caller marked as a hash) may be as
+/// short as 6 hex characters: the operator asked for a hash, so ambiguity is reported rather
+/// than silently ignored. Upper bound is a full SHA-256 (64 characters).
+[[nodiscard]] inline bool looksLikePartialHashArgument(std::string_view value) noexcept {
+    return value.size() >= 6 && value.size() <= 64 && isHexDigits(value);
+}
+
+} // namespace yams::common

--- a/include/yams/search/query_qualifiers.hpp
+++ b/include/yams/search/query_qualifiers.hpp
@@ -24,8 +24,11 @@
 
 #include <algorithm>
 #include <cctype>
+#include <map>
 #include <sstream>
 #include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 namespace yams::search {
@@ -51,6 +54,30 @@ struct ParsedQuery {
     std::string normalizedQuery;
     ExtractScope scope;
 };
+
+// Structured metadata filters written inline as key=value tokens ("task=alpha phase=done").
+// Shared by SearchService's keyword path and SearchEngine's metadata component so both agree
+// on what counts as a filter.
+struct StructuredMetadataQuery {
+    std::string residualQuery;                                // tokens that were not filters
+    std::vector<std::pair<std::string, std::string>> filters; // sorted by key, last value wins
+};
+
+// A token is a filter when it has exactly one '=', a non-empty key and value, and none of the
+// characters that mark quoting, grouping, or shell-like syntax.
+inline bool isStructuredMetadataToken(std::string_view token) {
+    const auto pos = token.find('=');
+    if (pos == std::string_view::npos || pos == 0 || pos + 1 >= token.size()) {
+        return false;
+    }
+    if (token.find('=', pos + 1) != std::string_view::npos) {
+        return false;
+    }
+    static constexpr std::string_view kDisallowed = "\"'()[]{}<>|&";
+    return token.find_first_of(kDisallowed) == std::string_view::npos;
+}
+
+inline StructuredMetadataQuery extractStructuredMetadataQuery(std::string_view query);
 
 namespace detail {
 
@@ -361,6 +388,38 @@ inline ParsedQuery parseQueryQualifiers(const std::string& raw) {
     }
 
     return ParsedQuery{std::move(normalized), std::move(scope)};
+}
+
+inline StructuredMetadataQuery extractStructuredMetadataQuery(std::string_view query) {
+    StructuredMetadataQuery parsed;
+    std::istringstream stream{std::string{query}};
+    std::vector<std::string> residualTokens;
+    std::map<std::string, std::string> dedupedFilters;
+    for (std::string token; stream >> token;) {
+        if (!isStructuredMetadataToken(token)) {
+            residualTokens.push_back(std::move(token));
+            continue;
+        }
+        const auto pos = token.find('=');
+        std::string key = detail::trim_copy(token.substr(0, pos));
+        std::string value = detail::trim_copy(token.substr(pos + 1));
+        if (key.empty() || value.empty()) {
+            residualTokens.push_back(std::move(token));
+            continue;
+        }
+        dedupedFilters[std::move(key)] = std::move(value);
+    }
+
+    for (const auto& [key, value] : dedupedFilters) {
+        parsed.filters.emplace_back(key, value);
+    }
+    for (std::size_t i = 0; i < residualTokens.size(); ++i) {
+        if (i > 0) {
+            parsed.residualQuery += ' ';
+        }
+        parsed.residualQuery += residualTokens[i];
+    }
+    return parsed;
 }
 
 } // namespace yams::search

--- a/src/app/services/document_service.cpp
+++ b/src/app/services/document_service.cpp
@@ -1,5 +1,6 @@
 #include <yams/app/services/services.hpp>
 #include <yams/common/fs_utils.h>
+#include <yams/common/hash_predicates.h>
 #include <yams/common/time_utils.h>
 #include <yams/core/assert.hpp>
 #include <yams/core/checked_arithmetic.h>
@@ -192,18 +193,6 @@ inline void addMetadataToMap(const std::unordered_map<std::string, std::string>&
     }
 }
 
-// Returns true if s consists only of hex digits
-inline bool isHex(const std::string& s) {
-    return std::all_of(s.begin(), s.end(), [](unsigned char c) { return std::isxdigit(c) != 0; });
-}
-
-// Heuristic: treat as hash when it looks like a hex string of reasonable length (6-64)
-inline bool looksLikePartialHash(const std::string& s) {
-    if (s.size() < 6 || s.size() >= 64)
-        return false;
-    return isHex(s);
-}
-
 bool canForceCleanupAfterStorageError(const Error& error) {
     return error.code == ErrorCode::CorruptedData || error.code == ErrorCode::ManifestInvalid ||
            error.code == ErrorCode::DataCorruption;
@@ -267,7 +256,8 @@ public:
         }
 
         // Strategy 5: Hash prefix (only if explicitly requested)
-        if (opts.tryHashPrefix && looksLikePartialHash(query)) {
+        if (opts.tryHashPrefix && query.size() != 64 &&
+            yams::common::looksLikePartialHashArgument(query)) {
             auto hashMatches = tryHashPrefix(query);
             if (!hashMatches.empty()) {
                 if (hashMatches.size() == 1) {
@@ -314,7 +304,8 @@ public:
         addUnique(tryPathPatterns(query));
 
         // Try hash prefix if requested
-        if (opts.tryHashPrefix && looksLikePartialHash(query)) {
+        if (opts.tryHashPrefix && query.size() != 64 &&
+            yams::common::looksLikePartialHashArgument(query)) {
             addUnique(tryHashPrefix(query));
         }
 
@@ -884,7 +875,7 @@ private:
                 auto docRes = ctx_.metadataRepo->getDocumentByHash(req.hash);
                 if (docRes && docRes.value().has_value()) {
                     addUniqueDeleteTargets(targets, seenHashes, {docRes.value().value()});
-                } else if (docRes && isHex(req.hash)) {
+                } else if (docRes && yams::common::isHexDigits(req.hash)) {
                     rawFullHashWithoutMetadata = true;
                 }
             } else {
@@ -2016,7 +2007,7 @@ public:
 
         // Resolve hash (handle partial hashes)
         if (!resolvedHash.empty() && resolvedHash.size() != 64 &&
-            looksLikePartialHash(resolvedHash)) {
+            yams::common::looksLikePartialHashArgument(resolvedHash)) {
             if (!ctx_.metadataRepo) {
                 return Error{ErrorCode::NotInitialized,
                              "Metadata repository not available for partial hash resolution"};

--- a/src/app/services/grep_service.cpp
+++ b/src/app/services/grep_service.cpp
@@ -6,6 +6,7 @@
 #include <yams/app/services/service_utils.hpp>
 #include <yams/app/services/services.hpp>
 #include <yams/app/services/simd_newline_scanner.hpp>
+#include <yams/common/fs_utils.h>
 #include <yams/common/string_utils.h>
 #include <yams/common/utf8_utils.h>
 #include <yams/config/config_helpers.h>
@@ -108,25 +109,7 @@ static std::string normalizePathForCompare(const std::string& path) {
     if (out.empty()) {
         out = fs.generic_string();
     }
-#if defined(__APPLE__)
-    // Canonicalize common macOS path aliases so comparisons/globs are consistent
-    auto canonApple = [](const std::string& s) -> std::string {
-        if (s.rfind("/private/var/", 0) == 0 || s == "/private/var")
-            return s; // already canonical
-        if (s.rfind("/private/tmp/", 0) == 0 || s == "/private/tmp")
-            return s; // already canonical
-        if (s.rfind("/var/", 0) == 0)
-            return std::string("/private") + s; // "/var/..." -> "/private/var/..."
-        if (s == "/var")
-            return std::string("/private/var");
-        if (s.rfind("/tmp/", 0) == 0)
-            return std::string("/private") + s; // "/tmp/..." -> "/private/tmp/..."
-        if (s == "/tmp")
-            return std::string("/private/tmp");
-        return s;
-    };
-    out = canonApple(out);
-#endif
+    out = yams::common::canonicalizeMacPathAlias(std::move(out));
 #if defined(_WIN32) || defined(__APPLE__)
     std::transform(out.begin(), out.end(), out.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
@@ -139,25 +122,7 @@ static std::string normalizeForGlobMatch(const std::string& value) {
 #if defined(_WIN32)
     std::replace(out.begin(), out.end(), '\\', '/');
 #endif
-#if defined(__APPLE__)
-    // Canonicalize macOS path aliases for consistent glob matching
-    auto canonApple = [](const std::string& s) -> std::string {
-        if (s.rfind("/private/var/", 0) == 0 || s == "/private/var")
-            return s;
-        if (s.rfind("/private/tmp/", 0) == 0 || s == "/private/tmp")
-            return s;
-        if (s.rfind("/var/", 0) == 0)
-            return std::string("/private") + s;
-        if (s == "/var")
-            return std::string("/private/var");
-        if (s.rfind("/tmp/", 0) == 0)
-            return std::string("/private") + s;
-        if (s == "/tmp")
-            return std::string("/private/tmp");
-        return s;
-    };
-    out = canonApple(out);
-#endif
+    out = yams::common::canonicalizeMacPathAlias(std::move(out));
 #if defined(_WIN32) || defined(__APPLE__)
     std::transform(out.begin(), out.end(), out.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });

--- a/src/app/services/search_service.cpp
+++ b/src/app/services/search_service.cpp
@@ -10,6 +10,8 @@
 #include <yams/app/services/service_utils.hpp>
 #include <yams/app/services/services.hpp>
 #include <yams/app/services/session_service.hpp>
+#include <yams/common/fs_utils.h>
+#include <yams/common/hash_predicates.h>
 #include <yams/common/string_utils.h>
 #include <yams/detection/file_type_detector.h>
 #include <yams/metadata/kg_relation_summary.h>
@@ -84,110 +86,6 @@ void annotateRecentLexicalDeltaHits(SearchResponse& resp,
         }
     }
     resp.searchStats["lexical_delta_recent_hits"] = std::to_string(recentHits);
-}
-
-// Returns true if s consists only of hex digits
-bool isHex(const std::string& s) {
-    return std::all_of(s.begin(), s.end(), [](unsigned char c) { return std::isxdigit(c) != 0; });
-}
-
-// Heuristic: treat as hash when it looks like a hex string of reasonable length (8-64)
-bool looksLikeHash(const std::string& s) {
-    if (s.size() < 8 || s.size() > 64)
-        return false;
-    return isHex(s);
-}
-
-static void appendMacPathAliases(std::vector<std::string>& patterns) {
-#if defined(__APPLE__)
-    if (patterns.empty()) {
-        return;
-    }
-
-    std::unordered_set<std::string> seen(patterns.begin(), patterns.end());
-    std::vector<std::string> aliases;
-    aliases.reserve(patterns.size());
-
-    for (const auto& pattern : patterns) {
-        std::string alias;
-        if (pattern == "/var") {
-            alias = "/private/var";
-        } else if (pattern.rfind("/var/", 0) == 0) {
-            alias = "/private" + pattern;
-        } else if (pattern == "/private/var") {
-            alias = "/var";
-        } else if (pattern.rfind("/private/var/", 0) == 0) {
-            alias = pattern.substr(std::string("/private").size());
-        }
-
-        if (!alias.empty() && seen.insert(alias).second) {
-            aliases.push_back(std::move(alias));
-        }
-    }
-
-    if (!aliases.empty()) {
-        patterns.insert(patterns.end(), aliases.begin(), aliases.end());
-    }
-#else
-    (void)patterns;
-#endif
-}
-
-// Helper function to escape regex special characters
-struct ParsedMetadataQuery {
-    std::string residualQuery;
-    std::vector<std::pair<std::string, std::string>> filters;
-};
-
-std::string trimAscii(std::string value) {
-    auto notSpace = [](unsigned char c) { return !std::isspace(c); };
-    value.erase(value.begin(), std::find_if(value.begin(), value.end(), notSpace));
-    value.erase(std::find_if(value.rbegin(), value.rend(), notSpace).base(), value.end());
-    return value;
-}
-
-bool isStructuredMetadataToken(std::string_view token) {
-    const auto pos = token.find('=');
-    if (pos == std::string_view::npos || pos == 0 || pos + 1 >= token.size()) {
-        return false;
-    }
-    if (token.find('=', pos + 1) != std::string_view::npos) {
-        return false;
-    }
-    static constexpr std::string_view kDisallowed = "\"'()[]{}<>|&";
-    return token.find_first_of(kDisallowed) == std::string_view::npos;
-}
-
-ParsedMetadataQuery extractStructuredMetadataQuery(std::string_view query) {
-    ParsedMetadataQuery parsed;
-    std::istringstream stream{std::string{query}};
-    std::vector<std::string> residualTokens;
-    std::map<std::string, std::string> dedupedFilters;
-    for (std::string token; stream >> token;) {
-        if (!isStructuredMetadataToken(token)) {
-            residualTokens.push_back(std::move(token));
-            continue;
-        }
-        const auto pos = token.find('=');
-        std::string key = trimAscii(token.substr(0, pos));
-        std::string value = trimAscii(token.substr(pos + 1));
-        if (key.empty() || value.empty()) {
-            residualTokens.push_back(std::move(token));
-            continue;
-        }
-        dedupedFilters[std::move(key)] = std::move(value);
-    }
-
-    for (const auto& [key, value] : dedupedFilters) {
-        parsed.filters.emplace_back(key, value);
-    }
-    for (std::size_t i = 0; i < residualTokens.size(); ++i) {
-        if (i > 0) {
-            parsed.residualQuery += ' ';
-        }
-        parsed.residualQuery += residualTokens[i];
-    }
-    return parsed;
 }
 
 std::size_t annotateResultRelations(std::vector<SearchItem>& results,
@@ -346,19 +244,19 @@ bool looksLikeHashQuery(const std::string& raw) {
     };
 
     if (auto v = stripPrefix("hash:"); !v.empty()) {
-        return looksLikeHash(yams::common::trimCopy(std::move(v)));
+        return yams::common::looksLikeHashQueryToken(yams::common::trimCopy(std::move(v)));
     }
     if (auto v = stripPrefix("sha1:"); !v.empty()) {
-        return looksLikeHash(yams::common::trimCopy(std::move(v)));
+        return yams::common::looksLikeHashQueryToken(yams::common::trimCopy(std::move(v)));
     }
     if (auto v = stripPrefix("sha256:"); !v.empty()) {
-        return looksLikeHash(yams::common::trimCopy(std::move(v)));
+        return yams::common::looksLikeHashQueryToken(yams::common::trimCopy(std::move(v)));
     }
     if (auto v = stripPrefix("md5:"); !v.empty()) {
-        return looksLikeHash(yams::common::trimCopy(std::move(v)));
+        return yams::common::looksLikeHashQueryToken(yams::common::trimCopy(std::move(v)));
     }
 
-    if (!looksLikeHash(trimmed))
+    if (!yams::common::looksLikeHashQueryToken(trimmed))
         return false;
 
     // Require at least 8 chars for hash prefix searches (matches looksLikeHash minimum).
@@ -386,16 +284,20 @@ std::optional<std::string> extractHashPrefix(const std::string& raw) {
     };
 
     if (auto v = stripPrefix("hash:"); !v.empty()) {
-        return looksLikeHash(v) ? std::optional<std::string>(v) : std::nullopt;
+        return yams::common::looksLikeHashQueryToken(v) ? std::optional<std::string>(v)
+                                                        : std::nullopt;
     }
     if (auto v = stripPrefix("sha1:"); !v.empty()) {
-        return looksLikeHash(v) ? std::optional<std::string>(v) : std::nullopt;
+        return yams::common::looksLikeHashQueryToken(v) ? std::optional<std::string>(v)
+                                                        : std::nullopt;
     }
     if (auto v = stripPrefix("sha256:"); !v.empty()) {
-        return looksLikeHash(v) ? std::optional<std::string>(v) : std::nullopt;
+        return yams::common::looksLikeHashQueryToken(v) ? std::optional<std::string>(v)
+                                                        : std::nullopt;
     }
     if (auto v = stripPrefix("md5:"); !v.empty()) {
-        return looksLikeHash(v) ? std::optional<std::string>(v) : std::nullopt;
+        return yams::common::looksLikeHashQueryToken(v) ? std::optional<std::string>(v)
+                                                        : std::nullopt;
     }
 
     if (looksLikeHashQuery(trimmed)) {
@@ -719,7 +621,7 @@ public:
         SearchRequest normalizedReq = req;
         normalizedReq.query = std::move(parsed.normalizedQuery);
         if (normalizedReq.type == "keyword") {
-            auto structured = extractStructuredMetadataQuery(normalizedReq.query);
+            auto structured = yams::search::extractStructuredMetadataQuery(normalizedReq.query);
             if (!structured.filters.empty()) {
                 normalizedReq.metadataFilters = std::move(structured.filters);
                 normalizedReq.query = std::move(structured.residualQuery);
@@ -775,7 +677,7 @@ public:
             normalizedReq.pathPatterns.insert(normalizedReq.pathPatterns.end(),
                                               scopePatterns.begin(), scopePatterns.end());
         }
-        appendMacPathAliases(normalizedReq.pathPatterns);
+        yams::common::appendMacPathAliases(normalizedReq.pathPatterns);
 
         if (normalizedReq.extension.empty() && !parsed.scope.ext.empty()) {
             normalizedReq.extension = parsed.scope.ext;
@@ -801,7 +703,7 @@ public:
 
         if (!normalizedReq.hash.empty()) {
             YAMS_ZONE_SCOPED_N("search_service::hash_lookup");
-            if (!looksLikeHash(normalizedReq.hash)) {
+            if (!yams::common::looksLikeHashQueryToken(normalizedReq.hash)) {
                 co_return Error{ErrorCode::InvalidArgument,
                                 "Invalid hash format (expected hex, 8-64 chars)"};
             }

--- a/src/cli/commands/cat_command.cpp
+++ b/src/cli/commands/cat_command.cpp
@@ -11,22 +11,13 @@
 #include <yams/cli/daemon_helpers.h>
 #include <yams/cli/ui_helpers.hpp>
 #include <yams/cli/yams_cli.h>
+#include <yams/common/hash_predicates.h>
 #include <yams/daemon/ipc/ipc_protocol.h>
 #include <yams/extraction/html_text_extractor.h>
 #include <yams/extraction/text_extractor.h>
 #include <yams/profiling.h>
 
 namespace yams::cli {
-
-namespace {
-
-bool looksLikeHashPrefix(const std::string& input) {
-    if (input.size() < 6 || input.size() > 64)
-        return false;
-    return std::ranges::all_of(input, [](unsigned char c) { return std::isxdigit(c) != 0; });
-}
-
-} // namespace
 
 class CatCommand : public ICommand {
 public:
@@ -46,8 +37,9 @@ public:
         selector->add_option("--hash", hash_, "Document hash or unambiguous hash prefix")
             ->check(CLI::Validator(
                 [](const std::string& value) {
-                    return looksLikeHashPrefix(value) ? std::string{}
-                                                      : "Expected 6 to 64 hexadecimal characters";
+                    return yams::common::looksLikePartialHashArgument(value)
+                               ? std::string{}
+                               : "Expected 6 to 64 hexadecimal characters";
                 },
                 "HASH"));
         // Disambiguation flags: select newest/oldest when multiple matches exist
@@ -82,7 +74,7 @@ public:
             if (!hash_.empty()) {
                 hashCandidate = hash_;
             } else if (!target_.empty() && name_.empty()) {
-                if (looksLikeHashPrefix(target_)) {
+                if (yams::common::looksLikePartialHashArgument(target_)) {
                     hashCandidate = target_;
                 } else {
                     name_ = target_;

--- a/src/search/search_engine.cpp
+++ b/src/search/search_engine.cpp
@@ -20,6 +20,7 @@
 #include <yams/search/kg_scorer_simple.h>
 #include <yams/search/lexical_scoring.h>
 #include <yams/search/query_expansion.h>
+#include <yams/search/query_qualifiers.hpp>
 #include <yams/search/query_router.h>
 #include <yams/search/query_text_utils.h>
 #include <yams/search/search_execution_context.h>
@@ -996,39 +997,6 @@ std::vector<std::string> tokenizeQueryTerms(std::string_view query) {
         }
     }
     return terms;
-}
-
-std::vector<std::pair<std::string, std::string>>
-parseMetadataFiltersFromQuery(std::string_view query) {
-    std::vector<std::pair<std::string, std::string>> filters;
-    std::size_t pos = 0;
-    while (pos < query.size()) {
-        while (pos < query.size() && std::isspace(static_cast<unsigned char>(query[pos]))) {
-            ++pos;
-        }
-        const std::size_t keyStart = pos;
-        while (pos < query.size() && query[pos] != '=' &&
-               !std::isspace(static_cast<unsigned char>(query[pos]))) {
-            ++pos;
-        }
-        if (pos >= query.size() || query[pos] != '=' || pos == keyStart) {
-            while (pos < query.size() && !std::isspace(static_cast<unsigned char>(query[pos]))) {
-                ++pos;
-            }
-            continue;
-        }
-        std::string key(query.substr(keyStart, pos - keyStart));
-        ++pos; // '='
-        const std::size_t valueStart = pos;
-        while (pos < query.size() && !std::isspace(static_cast<unsigned char>(query[pos]))) {
-            ++pos;
-        }
-        if (pos > valueStart) {
-            filters.emplace_back(std::move(key),
-                                 std::string(query.substr(valueStart, pos - valueStart)));
-        }
-    }
-    return filters;
 }
 
 struct PathQuerySeed {
@@ -5397,7 +5365,7 @@ Result<std::vector<ComponentResult>> SearchEngine::Impl::queryMetadata(const std
     if (!metadataRepo_)
         return results;
 
-    const auto queryFilters = parseMetadataFiltersFromQuery(query);
+    const auto queryFilters = yams::search::extractStructuredMetadataQuery(query).filters;
     bool hasStructFilters = params.mimeType.has_value() || params.extension.has_value() ||
                             params.modifiedAfter.has_value() || params.modifiedBefore.has_value();
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1702,6 +1702,8 @@ if catch2_dep.found()
     files(
       'unit/common/format_catch2_test.cpp',
       'unit/common/crc32_catch2_test.cpp',
+      'unit/common/hash_predicates_catch2_test.cpp',
+      'unit/common/path_alias_catch2_test.cpp',
       'unit/common/pattern_utils_catch2_test.cpp',
       'unit/common/string_utils_catch2_test.cpp',
       'unit/common/test_utils_catch2_test.cpp',

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -81,9 +81,9 @@ plugins/symbol_extractor_treesitter/grammar_loader.cpp:399:portability/env-read 
 plugins/symbol_extractor_treesitter/grammar_loader.cpp:402:portability/env-read # reviewed raw environment read
 plugins/symbol_extractor_treesitter/grammar_loader.cpp:411:portability/env-read # reviewed raw environment read
 plugins/symbol_extractor_treesitter/grammar_loader.cpp:413:portability/env-read # reviewed raw environment read
-src/app/services/document_service.cpp:1207:portability/env-read # reviewed raw environment read
-src/app/services/search_service.cpp:612:portability/env-read # reviewed raw environment read
-src/app/services/search_service.cpp:693:portability/env-read # reviewed raw environment read
+src/app/services/document_service.cpp:1198:portability/env-read # reviewed raw environment read
+src/app/services/search_service.cpp:514:portability/env-read # reviewed raw environment read
+src/app/services/search_service.cpp:595:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:18:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:20:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:71:portability/env-read # reviewed raw environment read
@@ -163,9 +163,9 @@ src/metadata/repository/search_query_helpers.cpp:293:portability/env-read # revi
 src/metadata/repository/search_query_helpers.cpp:480:portability/env-read # reviewed raw environment read
 src/metadata/versioning_util.cpp:101:portability/env-read # reviewed raw environment read
 src/plugins/plugin_repo_client.cpp:62:portability/env-read # reviewed raw environment read
-src/search/search_engine.cpp:378:portability/env-read # reviewed raw environment read
-src/search/search_engine.cpp:391:portability/env-read # reviewed raw environment read
-src/search/search_engine.cpp:3134:portability/env-read # reviewed raw environment read
+src/search/search_engine.cpp:379:portability/env-read # reviewed raw environment read
+src/search/search_engine.cpp:392:portability/env-read # reviewed raw environment read
+src/search/search_engine.cpp:3102:portability/env-read # reviewed raw environment read
 src/search/search_lexical_pipeline.cpp:601:portability/env-read # reviewed raw environment read
 src/storage/compressed_storage_engine.cpp:632:portability/env-read # reviewed raw environment read
 src/storage/object_storage_plugin_loader.cpp:126:portability/env-read # reviewed raw environment read

--- a/tests/unit/common/hash_predicates_catch2_test.cpp
+++ b/tests/unit/common/hash_predicates_catch2_test.cpp
@@ -1,0 +1,40 @@
+// The two hash-prefix thresholds are a deliberate product choice (D3): a bare search token
+// must reach 8 hex characters before it is treated as a hash, while an explicit hash argument
+// (--hash, a resolver target) may be as short as 6. Both live in one header so the numbers
+// cannot drift apart again.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <yams/common/hash_predicates.h>
+
+using yams::common::isHexDigits;
+using yams::common::looksLikeHashQueryToken;
+using yams::common::looksLikePartialHashArgument;
+
+TEST_CASE("isHexDigits accepts hex in either case and rejects anything else",
+          "[common][hash][catch2]") {
+    CHECK(isHexDigits("0123456789abcdefABCDEF"));
+    CHECK(isHexDigits(""));
+    CHECK_FALSE(isHexDigits("deadbeeg"));
+    CHECK_FALSE(isHexDigits("dead beef"));
+    CHECK_FALSE(isHexDigits("0x1234"));
+}
+
+TEST_CASE("query tokens need 8 hex characters before they look like a hash",
+          "[common][hash][catch2]") {
+    CHECK_FALSE(looksLikeHashQueryToken("abcdef"));
+    CHECK_FALSE(looksLikeHashQueryToken("abcdef1"));
+    CHECK(looksLikeHashQueryToken("abcdef12"));
+    CHECK(looksLikeHashQueryToken(std::string(64, 'a')));
+    CHECK_FALSE(looksLikeHashQueryToken(std::string(65, 'a')));
+    CHECK_FALSE(looksLikeHashQueryToken("abcdefg1"));
+}
+
+TEST_CASE("explicit hash arguments may be as short as 6 hex characters", "[common][hash][catch2]") {
+    CHECK_FALSE(looksLikePartialHashArgument("abcde"));
+    CHECK(looksLikePartialHashArgument("abcdef"));
+    CHECK(looksLikePartialHashArgument("abcdef1"));
+    CHECK(looksLikePartialHashArgument(std::string(64, 'f')));
+    CHECK_FALSE(looksLikePartialHashArgument(std::string(65, 'f')));
+    CHECK_FALSE(looksLikePartialHashArgument("abcdez"));
+}

--- a/tests/unit/common/path_alias_catch2_test.cpp
+++ b/tests/unit/common/path_alias_catch2_test.cpp
@@ -1,0 +1,64 @@
+// macOS spells /var and /tmp as symlinks into /private. Documents can be indexed under either
+// spelling, so every consumer that compares, displays, or expands paths must agree on one alias
+// table. These tests pin that table and the three policies built on it.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <yams/common/fs_utils.h>
+
+#include <string>
+#include <vector>
+
+using yams::common::path_alias::canonicalSpelling;
+using yams::common::path_alias::displaySpelling;
+using yams::common::path_alias::otherSpelling;
+
+TEST_CASE("otherSpelling maps between the /private and short forms of var and tmp",
+          "[common][fs][alias][catch2]") {
+    CHECK(otherSpelling("/var") == "/private/var");
+    CHECK(otherSpelling("/var/folders/x") == "/private/var/folders/x");
+    CHECK(otherSpelling("/private/var") == "/var");
+    CHECK(otherSpelling("/private/var/folders/x") == "/var/folders/x");
+    CHECK(otherSpelling("/tmp") == "/private/tmp");
+    CHECK(otherSpelling("/tmp/a.txt") == "/private/tmp/a.txt");
+    CHECK(otherSpelling("/private/tmp/a.txt") == "/tmp/a.txt");
+
+    SECTION("only whole path components alias") {
+        CHECK(otherSpelling("/variable/x").empty());
+        CHECK(otherSpelling("/tmpfs/x").empty());
+        CHECK(otherSpelling("/private/varnish").empty());
+        CHECK(otherSpelling("/home/user/var/x").empty());
+        CHECK(otherSpelling("").empty());
+        CHECK(otherSpelling("relative/var/x").empty());
+    }
+}
+
+TEST_CASE("canonical spelling is the /private form and display spelling is the short form",
+          "[common][fs][alias][catch2]") {
+    CHECK(canonicalSpelling("/var/folders/x") == "/private/var/folders/x");
+    CHECK(canonicalSpelling("/tmp/a") == "/private/tmp/a");
+    CHECK(canonicalSpelling("/private/tmp/a") == "/private/tmp/a");
+    CHECK(canonicalSpelling("/usr/local/a") == "/usr/local/a");
+
+    CHECK(displaySpelling("/private/var/folders/x") == "/var/folders/x");
+    CHECK(displaySpelling("/private/tmp/a") == "/tmp/a");
+    CHECK(displaySpelling("/tmp/a") == "/tmp/a");
+    CHECK(displaySpelling("/usr/local/a") == "/usr/local/a");
+}
+
+TEST_CASE("platform wrappers alias only on macOS", "[common][fs][alias][catch2]") {
+    const std::string canon = yams::common::canonicalizeMacPathAlias("/var/x");
+    const std::string disp = yams::common::displayMacPathAlias("/private/var/x");
+    std::vector<std::string> patterns{"/var/x", "/usr/y"};
+    yams::common::appendMacPathAliases(patterns);
+#if defined(__APPLE__)
+    CHECK(canon == "/private/var/x");
+    CHECK(disp == "/var/x");
+    REQUIRE(patterns.size() == 3);
+    CHECK(patterns[2] == "/private/var/x");
+#else
+    CHECK(canon == "/var/x");
+    CHECK(disp == "/private/var/x");
+    CHECK(patterns.size() == 2);
+#endif
+}

--- a/tests/unit/search/query_qualifiers_catch2_test.cpp
+++ b/tests/unit/search/query_qualifiers_catch2_test.cpp
@@ -112,3 +112,43 @@ TEST_CASE("Query Qualifiers - MultipleScopesLastOneWinsForType", "[search][quali
     CHECK(parsed.scope.range == "3-4");
     CHECK(parsed.normalizedQuery == "foo bar");
 }
+
+// ---------------------------------------------------------------------------
+// Structured metadata (key=value) extraction shared by SearchService (keyword path) and
+// SearchEngine's metadata component.
+// ---------------------------------------------------------------------------
+
+using yams::search::extractStructuredMetadataQuery;
+
+TEST_CASE("Structured metadata - splits key=value tokens from the residual query",
+          "[search][qualifiers][metadata][catch2]") {
+    auto parsed = extractStructuredMetadataQuery("  task=alpha   report phase=checkpoint  ");
+    REQUIRE(parsed.filters.size() == 2);
+    CHECK(parsed.filters[0].first == "phase");
+    CHECK(parsed.filters[0].second == "checkpoint");
+    CHECK(parsed.filters[1].first == "task");
+    CHECK(parsed.filters[1].second == "alpha");
+    CHECK(parsed.residualQuery == "report");
+}
+
+TEST_CASE("Structured metadata - duplicate keys keep the last value",
+          "[search][qualifiers][metadata][catch2]") {
+    auto parsed = extractStructuredMetadataQuery("task=one task=two");
+    REQUIRE(parsed.filters.size() == 1);
+    CHECK(parsed.filters[0].second == "two");
+    CHECK(parsed.residualQuery.empty());
+}
+
+TEST_CASE("Structured metadata - malformed or quoted tokens stay in the query",
+          "[search][qualifiers][metadata][catch2]") {
+    auto parsed = extractStructuredMetadataQuery("=x key= a=b=c name=\"quoted\" k[0]=v plain");
+    CHECK(parsed.filters.empty());
+    CHECK(parsed.residualQuery == "=x key= a=b=c name=\"quoted\" k[0]=v plain");
+}
+
+TEST_CASE("Structured metadata - filters only leaves an empty residual query",
+          "[search][qualifiers][metadata][catch2]") {
+    auto parsed = extractStructuredMetadataQuery("owner=codex source=decision");
+    REQUIRE(parsed.filters.size() == 2);
+    CHECK(parsed.residualQuery.empty());
+}


### PR DESCRIPTION
refactor(app): one home for hash predicates, path aliasing, and metadata qualifiers

Three small helpers had grown parallel copies with quietly different
rules:

- "does this look like a hash" existed four times: search_service
  (8-64 hex), document_service (6-63), cat_command (6-64), plus a
  never-defined utils::looksLikeHash declaration in services.hpp. The
  8 vs 6 threshold is deliberate (D3): a bare query token must reach
  8 hex characters before it stops being text, while an explicit hash
  argument may be 6. yams/common/hash_predicates.h now names the two
  predicates apart (looksLikeHashQueryToken, looksLikePartialHashArgument)
  over one isHexDigits; document_service's 6..63 bound was deliberate
  for the name resolver (a full 64-hex name must not resolve as a prefix
  and delete by hash), so its two resolver sites now guard size() != 64
  explicitly, as the partial-hash resolution site already did.

- macOS /private aliasing had three incompatible policies: search
  appended the alias of /var only, grep canonicalized /var and /tmp
  to the /private spelling, and the delete resolver displayed
  /private/var as /var. yams/common/fs_utils.h now carries one alias
  table ({/var,/tmp} <-> /private/...) with three lexical policies over
  it (otherSpelling, canonicalSpelling, displaySpelling) and the
  platform-gated wrappers callers use. Declared behavior change, macOS
  only: search patterns under /tmp now also match their /private/tmp
  spelling, and the resolver displays /private/tmp/... as /tmp/....

- Inline key=value metadata filters were parsed twice: SearchService's
  extractStructuredMetadataQuery (exactly one '=', no quoting/grouping
  characters, deduplicated by key) and SearchEngine's
  parseMetadataFiltersFromQuery (any '=' token, duplicates kept). The
  stricter, tested parser moves into yams/search/query_qualifiers.hpp
  and both call it. Declared behavior change for the hybrid metadata
  component: tokens like name="x" or a=b=c stay in the query instead
  of becoming filters, and repeated keys collapse to the last value.

Tests: hash_predicates_catch2_test.cpp pins both thresholds and the
64-character bound; path_alias_catch2_test.cpp pins the alias table,
the three policies, and the platform gating; query_qualifiers_catch2_test.cpp
gains the structured-metadata cases (split, dedupe, malformed tokens,
filters-only). search_service, document_service, grep_service,
service_utilities, and resolve_submodule pass unchanged. Portability
allowlist anchors reflowed for the four files whose lines moved.

---
Stack position 25 of 29; base branch `stack/32-daemon-status-renderer` (merge in order).
