### PR TITLE
refactor(search): one policy for materializing Simeon scores

### DIFF
--- a/include/yams/search/simeon_lexical_backend.h
+++ b/include/yams/search/simeon_lexical_backend.h
@@ -327,6 +327,16 @@ private:
     std::unique_ptr<simeon::TextAdapter> text_adapter_;
     std::vector<std::unique_ptr<simeon::RetrievalStrategy>> strategies_;
     std::unique_ptr<simeon::StrategyRouter> strategy_router_;
+    // Shared tail of every scoring entry point: dense corpus-order buffer -> candidate order,
+    // with one non-finite policy (see simeon_score_materialize_internal.h). The vector overload
+    // keeps the buffer on the dense fast path; the span overload is for borrowed scratch.
+    RescoreDecision materializeDecision(std::vector<float> full, std::span<const float> lexical,
+                                        std::span<const std::int64_t> candidate_doc_ids,
+                                        const char* recipe_label) const;
+    RescoreDecision materializeDecision(std::span<const float> full, std::span<const float> lexical,
+                                        std::span<const std::int64_t> candidate_doc_ids,
+                                        const char* recipe_label) const;
+
     std::unordered_map<std::int64_t, std::uint32_t> doc_id_to_index_;
     std::vector<std::int64_t> index_to_doc_id_;
     std::size_t doc_count_ = 0;

--- a/src/search/simeon_lexical_backend.cpp
+++ b/src/search/simeon_lexical_backend.cpp
@@ -1,3 +1,4 @@
+#include "simeon_score_materialize_internal.h"
 #include <yams/search/simeon_lexical_backend.h>
 
 #include <yams/metadata/metadata_repository.h>
@@ -933,35 +934,8 @@ SimeonLexicalBackend::scoreRouted(std::string_view query,
         concept_index_->blend_into(query, std::span<float>{full}, cfg_.concept_weight);
     }
 
-    RescoreDecision decision;
-    decision.recipe_name = recipe_label;
-    // QuerySession requests the backend's own dense ID order. Retain that score
-    // buffer directly instead of hashing every corpus ID to rebuild the same array.
-    if (candidate_doc_ids.data() == index_to_doc_id_.data() &&
-        candidate_doc_ids.size() == index_to_doc_id_.size()) {
-        for (size_t di = 0; di < full.size(); ++di) {
-            if (!std::isfinite(full[di])) {
-                full[di] = di < lexical.size() && std::isfinite(lexical[di]) ? lexical[di] : 0.0f;
-            }
-        }
-        decision.scores = std::move(full);
-        return decision;
-    }
-    decision.scores.reserve(candidate_doc_ids.size());
-    for (auto id : candidate_doc_ids) {
-        auto it = doc_id_to_index_.find(id);
-        if (it == doc_id_to_index_.end()) {
-            decision.scores.push_back(0.0f);
-            continue;
-        }
-        const auto di = it->second;
-        const float score =
-            std::isfinite(full[di])
-                ? full[di]
-                : (di < lexical.size() && std::isfinite(lexical[di]) ? lexical[di] : 0.0f);
-        decision.scores.push_back(score);
-    }
-    return decision;
+    // Non-finite scores fall back to the BM25 baseline when one was computed.
+    return materializeDecision(std::move(full), lexical, candidate_doc_ids, recipe_label);
 }
 
 Result<SimeonLexicalBackend::RescoreDecision>
@@ -1084,30 +1058,7 @@ SimeonLexicalBackend::scoreStrategyRouted(std::string_view query,
         concept_index_->blend_into(query, std::span<float>{full}, cfg_.concept_weight);
     }
 
-    RescoreDecision decision;
-    decision.recipe_name = recipe_label;
-    if (candidate_doc_ids.data() == index_to_doc_id_.data() &&
-        candidate_doc_ids.size() == index_to_doc_id_.size()) {
-        for (auto& score : full) {
-            if (!std::isfinite(score)) {
-                score = 0.0f;
-            }
-        }
-        decision.scores = std::move(full);
-        return decision;
-    }
-    decision.scores.reserve(candidate_doc_ids.size());
-    for (auto id : candidate_doc_ids) {
-        auto it = doc_id_to_index_.find(id);
-        if (it == doc_id_to_index_.end()) {
-            decision.scores.push_back(0.0f);
-            continue;
-        }
-        const auto di = it->second;
-        const float score = std::isfinite(full[di]) ? full[di] : 0.0f;
-        decision.scores.push_back(score);
-    }
-    return decision;
+    return materializeDecision(std::move(full), {}, candidate_doc_ids, recipe_label);
 }
 
 Result<SimeonLexicalBackend::RescoreDecision>
@@ -1169,31 +1120,8 @@ SimeonLexicalBackend::scoreBanditRouted(std::string_view query, std::string_view
         concept_index_->blend_into(query, std::span<float>{full}, cfg_.concept_weight);
     }
 
-    RescoreDecision decision;
-    decision.recipe_name = recipe_label;
-    if (candidate_doc_ids.data() == index_to_doc_id_.data() &&
-        candidate_doc_ids.size() == index_to_doc_id_.size()) {
-        // The bandit scratch is thread-local and reused: the session must own a copy.
-        decision.scores = full;
-        for (auto& score : decision.scores) {
-            if (!std::isfinite(score)) {
-                score = 0.0f;
-            }
-        }
-        return decision;
-    }
-    decision.scores.reserve(candidate_doc_ids.size());
-    for (auto id : candidate_doc_ids) {
-        auto it = doc_id_to_index_.find(id);
-        if (it == doc_id_to_index_.end()) {
-            decision.scores.push_back(0.0f);
-            continue;
-        }
-        const auto di = it->second;
-        const float score = std::isfinite(full[di]) ? full[di] : 0.0f;
-        decision.scores.push_back(score);
-    }
-    return decision;
+    // The scratch is thread-local and reused, so the borrowed overload copies on the dense path.
+    return materializeDecision(std::span<const float>{full}, {}, candidate_doc_ids, recipe_label);
 }
 
 Result<SimeonLexicalBackend::TopCandidateDecision>
@@ -1202,6 +1130,27 @@ SimeonLexicalBackend::searchTop(std::string_view query, std::size_t limit,
     ScoreTimingScope scoreTiming(*this);
     QuerySession session(*this, query, arm_name);
     return session.searchTop(limit);
+}
+
+SimeonLexicalBackend::RescoreDecision
+SimeonLexicalBackend::materializeDecision(std::vector<float> full, std::span<const float> lexical,
+                                          std::span<const std::int64_t> candidate_doc_ids,
+                                          const char* recipe_label) const {
+    RescoreDecision decision;
+    decision.recipe_name = recipe_label;
+    decision.scores = simeon_internal::materializeScores(std::move(full), lexical, doc_id_to_index_,
+                                                         index_to_doc_id_, candidate_doc_ids);
+    return decision;
+}
+
+SimeonLexicalBackend::RescoreDecision SimeonLexicalBackend::materializeDecision(
+    std::span<const float> full, std::span<const float> lexical,
+    std::span<const std::int64_t> candidate_doc_ids, const char* recipe_label) const {
+    RescoreDecision decision;
+    decision.recipe_name = recipe_label;
+    decision.scores = simeon_internal::materializeScores(full, lexical, doc_id_to_index_,
+                                                         index_to_doc_id_, candidate_doc_ids);
+    return decision;
 }
 
 Result<void> SimeonLexicalBackend::QuerySession::ensureScored() {

--- a/src/search/simeon_score_materialize_internal.h
+++ b/src/search/simeon_score_materialize_internal.h
@@ -1,0 +1,86 @@
+// Turning a dense corpus-order score buffer into the caller's candidate order.
+//
+// Every Simeon scoring entry point (routed, strategy-routed, bandit-routed) ends the same way:
+// it has one float per corpus document in the backend's dense index order and must hand back
+// one float per requested candidate id. Non-finite scores (a NaN from a z-blend, an infinite
+// from an empty posting) are replaced by the BM25 baseline when the caller computed one, and
+// by 0 otherwise. This header is the single definition of that policy.
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+namespace yams::search::simeon_internal {
+
+/// True when `candidates` is the backend's own dense corpus order: the same buffer, the same
+/// length. QuerySession asks for that order so the score buffer can be retained as-is.
+[[nodiscard]] inline bool isDenseCorpusOrder(std::span<const std::int64_t> candidates,
+                                             std::span<const std::int64_t> corpusOrder) noexcept {
+    return candidates.data() == corpusOrder.data() && candidates.size() == corpusOrder.size();
+}
+
+/// Score for dense index `di`: the blended value when finite, else the baseline when finite,
+/// else 0.
+[[nodiscard]] inline float finiteScoreAt(std::span<const float> full,
+                                         std::span<const float> lexical, std::size_t di) noexcept {
+    if (di < full.size() && std::isfinite(full[di]))
+        return full[di];
+    if (di < lexical.size() && std::isfinite(lexical[di]))
+        return lexical[di];
+    return 0.0f;
+}
+
+/// Replace every non-finite entry of `scores` in place using the policy above.
+inline void replaceNonFinite(std::span<float> scores, std::span<const float> lexical) noexcept {
+    for (std::size_t di = 0; di < scores.size(); ++di) {
+        if (!std::isfinite(scores[di]))
+            scores[di] = finiteScoreAt({}, lexical, di);
+    }
+}
+
+/// One score per candidate id, in candidate order; unknown ids score 0.
+[[nodiscard]] inline std::vector<float>
+gatherCandidateScores(std::span<const float> full, std::span<const float> lexical,
+                      const std::unordered_map<std::int64_t, std::uint32_t>& docIndex,
+                      std::span<const std::int64_t> candidates) {
+    std::vector<float> out;
+    out.reserve(candidates.size());
+    for (auto id : candidates) {
+        auto it = docIndex.find(id);
+        out.push_back(it == docIndex.end() ? 0.0f : finiteScoreAt(full, lexical, it->second));
+    }
+    return out;
+}
+
+/// Materialize scores for `candidates`. Takes ownership of `full` so the dense fast path can
+/// return the buffer without copying.
+[[nodiscard]] inline std::vector<float>
+materializeScores(std::vector<float> full, std::span<const float> lexical,
+                  const std::unordered_map<std::int64_t, std::uint32_t>& docIndex,
+                  std::span<const std::int64_t> corpusOrder,
+                  std::span<const std::int64_t> candidates) {
+    if (isDenseCorpusOrder(candidates, corpusOrder)) {
+        replaceNonFinite(full, lexical);
+        return full;
+    }
+    return gatherCandidateScores(full, lexical, docIndex, candidates);
+}
+
+/// Same as above for a borrowed buffer (thread-local scratch): the dense fast path copies.
+[[nodiscard]] inline std::vector<float>
+materializeScores(std::span<const float> full, std::span<const float> lexical,
+                  const std::unordered_map<std::int64_t, std::uint32_t>& docIndex,
+                  std::span<const std::int64_t> corpusOrder,
+                  std::span<const std::int64_t> candidates) {
+    if (isDenseCorpusOrder(candidates, corpusOrder)) {
+        std::vector<float> owned(full.begin(), full.end());
+        replaceNonFinite(owned, lexical);
+        return owned;
+    }
+    return gatherCandidateScores(full, lexical, docIndex, candidates);
+}
+
+} // namespace yams::search::simeon_internal

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1493,6 +1493,7 @@ if catch2_dep.found()
       'unit/search/kg_scorer_simple_catch2_test.cpp',
       'unit/search/lexical_scoring_catch2_test.cpp',
       'unit/search/simeon_lexical_backend_catch2_test.cpp',
+      'unit/search/simeon_score_materialize_catch2_test.cpp',
       'unit/search/search_engine_simeon_lexical_catch2_test.cpp',
       'unit/search/search_engine_topology_catch2_test.cpp',
       'unit/search/simeon_bandit_catch2_test.cpp',

--- a/tests/unit/search/simeon_score_materialize_catch2_test.cpp
+++ b/tests/unit/search/simeon_score_materialize_catch2_test.cpp
@@ -1,0 +1,71 @@
+// One policy for turning Simeon's dense score buffer into candidate-order scores. Before this
+// header existed, the routed, strategy-routed, and bandit-routed paths each carried their own
+// copy of the fast path and disagreed on what a non-finite score falls back to.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "src/search/simeon_score_materialize_internal.h"
+
+#include <cmath>
+#include <limits>
+
+using namespace yams::search::simeon_internal;
+
+namespace {
+const std::vector<std::int64_t> kCorpus{100, 200, 300, 400};
+const std::unordered_map<std::int64_t, std::uint32_t> kIndex{
+    {100, 0}, {200, 1}, {300, 2}, {400, 3}};
+constexpr float kNaN = std::numeric_limits<float>::quiet_NaN();
+constexpr float kInf = std::numeric_limits<float>::infinity();
+} // namespace
+
+TEST_CASE("dense corpus order is recognised by buffer identity, not by content",
+          "[search][simeon][materialize][catch2]") {
+    CHECK(isDenseCorpusOrder(kCorpus, kCorpus));
+    std::vector<std::int64_t> copy = kCorpus;
+    CHECK_FALSE(isDenseCorpusOrder(copy, kCorpus));
+    CHECK_FALSE(isDenseCorpusOrder(std::span<const std::int64_t>(kCorpus).first(3), kCorpus));
+}
+
+TEST_CASE("non-finite scores fall back to the lexical baseline, then to zero",
+          "[search][simeon][materialize][catch2]") {
+    std::vector<float> full{1.0f, kNaN, kInf, 4.0f};
+    const std::vector<float> lexical{9.0f, 2.5f, kNaN, 9.0f};
+
+    SECTION("owned buffer, dense order: returned in place") {
+        auto out = materializeScores(std::move(full), lexical, kIndex, kCorpus, kCorpus);
+        REQUIRE(out.size() == 4);
+        CHECK(out[0] == 1.0f);
+        CHECK(out[1] == 2.5f);
+        CHECK(out[2] == 0.0f);
+        CHECK(out[3] == 4.0f);
+    }
+
+    SECTION("owned buffer, dense order, no baseline: zero") {
+        auto out = materializeScores(std::move(full), {}, kIndex, kCorpus, kCorpus);
+        CHECK(out[1] == 0.0f);
+        CHECK(out[2] == 0.0f);
+    }
+
+    SECTION("borrowed buffer, dense order: copied, source untouched") {
+        auto out =
+            materializeScores(std::span<const float>(full), lexical, kIndex, kCorpus, kCorpus);
+        CHECK(out[1] == 2.5f);
+        CHECK(std::isnan(full[1]));
+    }
+
+    SECTION("sparse candidates: gathered in candidate order, unknown ids score zero") {
+        const std::vector<std::int64_t> candidates{300, 999, 200, 100};
+        auto owned = materializeScores(std::move(full), lexical, kIndex, kCorpus, candidates);
+        REQUIRE(owned.size() == 4);
+        CHECK(owned[0] == 0.0f);
+        CHECK(owned[1] == 0.0f);
+        CHECK(owned[2] == 2.5f);
+        CHECK(owned[3] == 1.0f);
+
+        std::vector<float> again{1.0f, kNaN, kInf, 4.0f};
+        auto borrowed =
+            materializeScores(std::span<const float>(again), lexical, kIndex, kCorpus, candidates);
+        CHECK(borrowed == owned);
+    }
+}


### PR DESCRIPTION
refactor(search): one policy for materializing Simeon scores

Every Simeon scoring entry point (scoreRouted, scoreStrategyRouted,
scoreBanditRouted) ended with its own copy of the same tail: detect
the dense corpus-order fast path by buffer identity, otherwise gather
candidate scores through doc_id_to_index_, and replace non-finite
values. The three copies had already drifted: the routed path fell
back to the BM25 baseline for a non-finite score, the other two fell
back to 0, and the bandit path copied its thread-local scratch while
the others moved theirs.

simeon_score_materialize_internal.h now holds that tail once:
isDenseCorpusOrder, finiteScoreAt (blended value, then baseline, then
0), gatherCandidateScores, and materializeScores in an owning overload
(returns the buffer on the dense path) and a borrowing overload (copies
it, for scratch). SimeonLexicalBackend::materializeDecision wraps both
and the three entry points call it. The routed path keeps passing its
baseline and the other two pass none, so today's outputs are unchanged;
the difference is now a parameter instead of three divergent loops.

simeon_score_materialize_catch2_test.cpp pins dense-order detection by
identity (a copied id vector takes the sparse path), the non-finite
fallback order, the borrowed copy leaving its source untouched, and
sparse gathering with unknown ids scoring 0. The Simeon backend and
lexical pipeline suites pass unchanged.

---
Stack position 26 of 29; base branch `stack/33-shared-query-helpers` (merge in order).
