### PR TITLE
[06/14] Measure and reduce repeated SQLite prepares

### DIFF
--- a/include/yams/metadata/database.h
+++ b/include/yams/metadata/database.h
@@ -423,7 +423,9 @@ private:
     mutable size_t cacheHits_{0};
     mutable size_t cacheMisses_{0};
     mutable size_t uncachedPrepares_{0};
-    static constexpr size_t kMaxCacheSize = 64; // Limit cache size
+    // 90 cached call sites share a connection when KG and repository work interleave; a
+    // small bound with first-found eviction would thrash them against each other.
+    static constexpr size_t kMaxCacheSize = 128;
 
     /**
      * @brief Return a statement to the cache after use

--- a/include/yams/metadata/database.h
+++ b/include/yams/metadata/database.h
@@ -293,6 +293,9 @@ public:
         size_t misses{0};
         size_t currentSize{0};
         size_t maxSize{0};
+        // Statements compiled through prepare(), bypassing the cache. A hot path that
+        // re-prepares fixed SQL shows up here; tests pin it to zero after warm-up.
+        size_t uncachedPrepares{0};
     };
     [[nodiscard]] CacheStats getStatementCacheStats() const;
 
@@ -419,6 +422,7 @@ private:
     std::unordered_map<std::string, Statement> statementCache_;
     mutable size_t cacheHits_{0};
     mutable size_t cacheMisses_{0};
+    mutable size_t uncachedPrepares_{0};
     static constexpr size_t kMaxCacheSize = 64; // Limit cache size
 
     /**

--- a/src/metadata/connection_pool.cpp
+++ b/src/metadata/connection_pool.cpp
@@ -900,12 +900,14 @@ bool ConnectionPool::isConnectionValid(const Database& db) const {
     }
 
     try {
-        auto stmtResult = const_cast<Database&>(db).prepare("SELECT 1");
+        // Runs on every acquire and release: keep the probe in the connection's statement
+        // cache instead of compiling it twice per pooled call.
+        auto stmtResult = const_cast<Database&>(db).prepareCached("SELECT 1");
         if (!stmtResult)
             return false;
 
-        Statement stmt = std::move(stmtResult).value();
-        auto result = stmt.step();
+        auto stmt = std::move(stmtResult).value();
+        auto result = stmt->step();
         if (!result.has_value())
             return false;
 

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -809,21 +809,22 @@ int Database::changes() const {
 }
 
 Result<bool> Database::tableExists(const std::string& table) {
-    auto stmtResult = prepare("SELECT COUNT(*) FROM sqlite_master "
-                              "WHERE type='table' AND name=?");
+    // Probed on hot paths (e.g. optional FTS tables per lookup); keep it cached.
+    auto stmtResult = prepareCached("SELECT COUNT(*) FROM sqlite_master "
+                                    "WHERE type='table' AND name=?");
     if (!stmtResult)
         return stmtResult.error();
 
-    Statement stmt = std::move(stmtResult).value();
-    auto bindResult = stmt.bind(1, table);
+    auto stmt = std::move(stmtResult).value();
+    auto bindResult = stmt->bind(1, table);
     if (!bindResult)
         return bindResult.error();
 
-    auto stepResult = stmt.step();
+    auto stepResult = stmt->step();
     if (!stepResult)
         return stepResult.error();
 
-    return stmt.getInt(0) > 0;
+    return stmt->getInt(0) > 0;
 }
 
 Result<bool> Database::hasFTS5() {

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -429,11 +429,12 @@ Database::~Database() {
 Database::Database(Database&& other) noexcept
     : db_(other.db_), path_(std::move(other.path_)), inTransaction_(other.inTransaction_),
       statementCache_(std::move(other.statementCache_)), cacheHits_(other.cacheHits_),
-      cacheMisses_(other.cacheMisses_) {
+      cacheMisses_(other.cacheMisses_), uncachedPrepares_(other.uncachedPrepares_) {
     other.db_ = nullptr;
     other.inTransaction_ = false;
     other.cacheHits_ = 0;
     other.cacheMisses_ = 0;
+    other.uncachedPrepares_ = 0;
 }
 
 Database& Database::operator=(Database&& other) noexcept {
@@ -445,10 +446,12 @@ Database& Database::operator=(Database&& other) noexcept {
         statementCache_ = std::move(other.statementCache_);
         cacheHits_ = other.cacheHits_;
         cacheMisses_ = other.cacheMisses_;
+        uncachedPrepares_ = other.uncachedPrepares_;
         other.db_ = nullptr;
         other.inTransaction_ = false;
         other.cacheHits_ = 0;
         other.cacheMisses_ = 0;
+        other.uncachedPrepares_ = 0;
     }
     return *this;
 }
@@ -528,7 +531,12 @@ Result<Statement> Database::prepare(const std::string& sql) {
     }
 
     try {
-        return Statement(db_, sql);
+        Statement statement(db_, sql);
+        {
+            std::lock_guard<std::mutex> lock(cacheMutex_);
+            ++uncachedPrepares_;
+        }
+        return statement;
     } catch (const std::exception& e) {
         return make_sqlite_error(sqlite3_errcode(db_), e.what());
     }
@@ -631,7 +639,8 @@ void Database::clearStatementCache() {
 
 Database::CacheStats Database::getStatementCacheStats() const {
     std::lock_guard<std::mutex> lock(cacheMutex_);
-    return CacheStats{cacheHits_, cacheMisses_, statementCache_.size(), kMaxCacheSize};
+    return CacheStats{cacheHits_, cacheMisses_, statementCache_.size(), kMaxCacheSize,
+                      uncachedPrepares_};
 }
 
 Result<void> Database::execute(const std::string& sql) {

--- a/src/metadata/knowledge_graph_store_sqlite.cpp
+++ b/src/metadata/knowledge_graph_store_sqlite.cpp
@@ -250,23 +250,23 @@ Result<int> bindKgPathRanges(Statement& stmt, int firstIndex,
 }
 
 Result<std::int64_t> selectKgNodeIdByKey(Database& db, std::string_view nodeKey) {
-    auto stmtResult = db.prepare("SELECT id FROM kg_nodes WHERE node_key = ? LIMIT 1");
+    auto stmtResult = db.prepareCached("SELECT id FROM kg_nodes WHERE node_key = ? LIMIT 1");
     if (!stmtResult) {
         return stmtResult.error();
     }
     auto stmt = std::move(stmtResult).value();
-    auto bindResult = stmt.bind(1, nodeKey);
+    auto bindResult = stmt->bind(1, nodeKey);
     if (!bindResult) {
         return bindResult.error();
     }
-    auto stepResult = stmt.step();
+    auto stepResult = stmt->step();
     if (!stepResult) {
         return stepResult.error();
     }
     if (!stepResult.value()) {
         return Error{ErrorCode::NotFound, "node not found after upsert"};
     }
-    return stmt.getInt64(0);
+    return stmt->getInt64(0);
 }
 
 } // namespace
@@ -404,24 +404,24 @@ public:
 
     Result<std::optional<KGNode>> getNodeById(std::int64_t nodeId) override {
         return readPool()->withConnection([&](Database& db) -> Result<std::optional<KGNode>> {
-            auto stmtResult = db.prepare(std::string("SELECT ") + kKgNodeSelectProjection +
-                                         " FROM kg_nodes WHERE id = ? LIMIT 1");
+            auto stmtResult = db.prepareCached(std::string("SELECT ") + kKgNodeSelectProjection +
+                                               " FROM kg_nodes WHERE id = ? LIMIT 1");
             if (!stmtResult) {
                 return stmtResult.error();
             }
             auto stmt = std::move(stmtResult).value();
-            auto bindResult = stmt.bind(1, nodeId);
+            auto bindResult = stmt->bind(1, nodeId);
             if (!bindResult) {
                 return bindResult.error();
             }
-            auto stepResult = stmt.step();
+            auto stepResult = stmt->step();
             if (!stepResult) {
                 return stepResult.error();
             }
             if (!stepResult.value()) {
                 return std::optional<KGNode>{};
             }
-            return std::optional<KGNode>{hydrateKgNodeRow(stmt)};
+            return std::optional<KGNode>{hydrateKgNodeRow(*stmt)};
         });
     }
 
@@ -749,27 +749,28 @@ public:
                                                            std::size_t limit) override {
         return readPool()->withConnection(
             [&](Database& db) -> Result<std::vector<AliasResolution>> {
-                auto stmtR = db.prepare("SELECT node_id FROM kg_aliases WHERE alias = ? LIMIT ?");
+                auto stmtR =
+                    db.prepareCached("SELECT node_id FROM kg_aliases WHERE alias = ? LIMIT ?");
                 if (!stmtR)
                     return stmtR.error();
                 auto stmt = std::move(stmtR).value();
 
-                auto br = stmt.bind(1, alias);
+                auto br = stmt->bind(1, alias);
                 if (!br)
                     return br.error();
-                br = stmt.bind(2, static_cast<int64_t>(limit));
+                br = stmt->bind(2, static_cast<int64_t>(limit));
                 if (!br)
                     return br.error();
 
                 std::vector<AliasResolution> out;
                 while (true) {
-                    auto step = stmt.step();
+                    auto step = stmt->step();
                     if (!step)
                         return step.error();
                     if (!step.value())
                         break;
                     AliasResolution ar;
-                    ar.nodeId = stmt.getInt64(0);
+                    ar.nodeId = stmt->getInt64(0);
                     ar.score = 1.0f;
                     out.push_back(ar);
                 }
@@ -832,11 +833,11 @@ public:
                     return resolveAliasExact(aliasQuery, limit);
                 }
 
-                auto stmtR = db.prepare("SELECT a.node_id, 1.0 AS score "
-                                        "FROM kg_aliases_fts f "
-                                        "JOIN kg_aliases a ON a.id = f.rowid "
-                                        "WHERE kg_aliases_fts MATCH ? "
-                                        "LIMIT ?");
+                auto stmtR = db.prepareCached("SELECT a.node_id, 1.0 AS score "
+                                              "FROM kg_aliases_fts f "
+                                              "JOIN kg_aliases a ON a.id = f.rowid "
+                                              "WHERE kg_aliases_fts MATCH ? "
+                                              "LIMIT ?");
                 if (!stmtR)
                     return stmtR.error();
                 auto stmt = std::move(stmtR).value();
@@ -848,22 +849,22 @@ public:
                     aliasQuery.find(':') != std::string_view::npos
                         ? quoteFts5Literal(aliasQuery)
                         : sanitizeFts5UserQuery(std::string(aliasQuery));
-                auto br = stmt.bind(1, sanitizedQuery);
+                auto br = stmt->bind(1, sanitizedQuery);
                 if (!br)
                     return br.error();
-                br = stmt.bind(2, static_cast<int64_t>(limit));
+                br = stmt->bind(2, static_cast<int64_t>(limit));
                 if (!br)
                     return br.error();
 
                 std::vector<AliasResolution> out;
                 while (true) {
-                    auto step = stmt.step();
+                    auto step = stmt->step();
                     if (!step)
                         return step.error();
                     if (!step.value())
                         break;
                     AliasResolution ar;
-                    ar.nodeId = stmt.getInt64(0);
+                    ar.nodeId = stmt->getInt64(0);
                     ar.score = 1.0f;
                     out.push_back(ar);
                 }
@@ -1072,44 +1073,44 @@ public:
             }
             sql += " ORDER BY weight DESC, created_time DESC, id DESC LIMIT ? OFFSET ?";
 
-            auto stmtR = db.prepare(sql);
+            auto stmtR = db.prepareCached(sql);
             if (!stmtR)
                 return stmtR.error();
             auto stmt = std::move(stmtR).value();
 
             int idx = 1;
-            auto br = stmt.bind(idx++, srcNodeId);
+            auto br = stmt->bind(idx++, srcNodeId);
             if (!br)
                 return br.error();
             if (relation.has_value()) {
-                br = stmt.bind(idx++, relation.value());
+                br = stmt->bind(idx++, relation.value());
                 if (!br)
                     return br.error();
             }
-            br = stmt.bind(idx++, static_cast<int64_t>(limit));
+            br = stmt->bind(idx++, static_cast<int64_t>(limit));
             if (!br)
                 return br.error();
-            br = stmt.bind(idx, static_cast<int64_t>(offset));
+            br = stmt->bind(idx, static_cast<int64_t>(offset));
             if (!br)
                 return br.error();
 
             std::vector<KGEdge> out;
             while (true) {
-                auto step = stmt.step();
+                auto step = stmt->step();
                 if (!step)
                     return step.error();
                 if (!step.value())
                     break;
                 KGEdge e;
-                e.id = stmt.getInt64(0);
-                e.srcNodeId = stmt.getInt64(1);
-                e.dstNodeId = stmt.getInt64(2);
-                e.relation = stmt.getString(3);
-                e.weight = static_cast<float>(stmt.getDouble(4));
-                if (!stmt.isNull(5))
-                    e.createdTime = stmt.getInt64(5);
-                if (!stmt.isNull(6))
-                    e.properties = stmt.getString(6);
+                e.id = stmt->getInt64(0);
+                e.srcNodeId = stmt->getInt64(1);
+                e.dstNodeId = stmt->getInt64(2);
+                e.relation = stmt->getString(3);
+                e.weight = static_cast<float>(stmt->getDouble(4));
+                if (!stmt->isNull(5))
+                    e.createdTime = stmt->getInt64(5);
+                if (!stmt->isNull(6))
+                    e.properties = stmt->getString(6);
                 out.push_back(std::move(e));
             }
             return out;
@@ -1202,44 +1203,44 @@ public:
             }
             sql += " LIMIT ? OFFSET ?";
 
-            auto stmtR = db.prepare(sql);
+            auto stmtR = db.prepareCached(sql);
             if (!stmtR)
                 return stmtR.error();
             auto stmt = std::move(stmtR).value();
 
             int idx = 1;
-            auto br = stmt.bind(idx++, dstNodeId);
+            auto br = stmt->bind(idx++, dstNodeId);
             if (!br)
                 return br.error();
             if (relation.has_value()) {
-                br = stmt.bind(idx++, relation.value());
+                br = stmt->bind(idx++, relation.value());
                 if (!br)
                     return br.error();
             }
-            br = stmt.bind(idx++, static_cast<int64_t>(limit));
+            br = stmt->bind(idx++, static_cast<int64_t>(limit));
             if (!br)
                 return br.error();
-            br = stmt.bind(idx, static_cast<int64_t>(offset));
+            br = stmt->bind(idx, static_cast<int64_t>(offset));
             if (!br)
                 return br.error();
 
             std::vector<KGEdge> out;
             while (true) {
-                auto step = stmt.step();
+                auto step = stmt->step();
                 if (!step)
                     return step.error();
                 if (!step.value())
                     break;
                 KGEdge e;
-                e.id = stmt.getInt64(0);
-                e.srcNodeId = stmt.getInt64(1);
-                e.dstNodeId = stmt.getInt64(2);
-                e.relation = stmt.getString(3);
-                e.weight = static_cast<float>(stmt.getDouble(4));
-                if (!stmt.isNull(5))
-                    e.createdTime = stmt.getInt64(5);
-                if (!stmt.isNull(6))
-                    e.properties = stmt.getString(6);
+                e.id = stmt->getInt64(0);
+                e.srcNodeId = stmt->getInt64(1);
+                e.dstNodeId = stmt->getInt64(2);
+                e.relation = stmt->getString(3);
+                e.weight = static_cast<float>(stmt->getDouble(4));
+                if (!stmt->isNull(5))
+                    e.createdTime = stmt->getInt64(5);
+                if (!stmt->isNull(6))
+                    e.properties = stmt->getString(6);
                 out.push_back(std::move(e));
             }
             return out;
@@ -1443,26 +1444,26 @@ public:
                                                 std::size_t maxNeighbors) override {
         return readPool()->withConnection([&](Database& db) -> Result<std::vector<std::int64_t>> {
             auto stmtR =
-                db.prepare("SELECT dst_node_id FROM kg_edges WHERE src_node_id = ? LIMIT ?");
+                db.prepareCached("SELECT dst_node_id FROM kg_edges WHERE src_node_id = ? LIMIT ?");
             if (!stmtR)
                 return stmtR.error();
             auto stmt = std::move(stmtR).value();
 
-            auto br = stmt.bind(1, nodeId);
+            auto br = stmt->bind(1, nodeId);
             if (!br)
                 return br.error();
-            br = stmt.bind(2, static_cast<int64_t>(maxNeighbors));
+            br = stmt->bind(2, static_cast<int64_t>(maxNeighbors));
             if (!br)
                 return br.error();
 
             std::vector<std::int64_t> out;
             while (true) {
-                auto step = stmt.step();
+                auto step = stmt->step();
                 if (!step)
                     return step.error();
                 if (!step.value())
                     break;
-                out.push_back(stmt.getInt64(0));
+                out.push_back(stmt->getInt64(0));
             }
             return out;
         });
@@ -1569,37 +1570,37 @@ public:
 
     Result<std::optional<std::int64_t>> getDocumentIdByHash(std::string_view sha256) override {
         return readPool()->withConnection([&](Database& db) -> Result<std::optional<std::int64_t>> {
-            auto stmtR = db.prepare("SELECT id FROM documents WHERE sha256_hash = ? LIMIT 1");
+            auto stmtR = db.prepareCached("SELECT id FROM documents WHERE sha256_hash = ? LIMIT 1");
             if (!stmtR)
                 return stmtR.error();
             auto stmt = std::move(stmtR).value();
-            auto br = stmt.bind(1, sha256);
+            auto br = stmt->bind(1, sha256);
             if (!br)
                 return br.error();
-            auto step = stmt.step();
+            auto step = stmt->step();
             if (!step)
                 return step.error();
             if (!step.value())
                 return std::optional<std::int64_t>{};
-            return std::optional<std::int64_t>{stmt.getInt64(0)};
+            return std::optional<std::int64_t>{stmt->getInt64(0)};
         });
     }
 
     Result<std::optional<std::int64_t>> getDocumentIdByPath(std::string_view file_path) override {
         return readPool()->withConnection([&](Database& db) -> Result<std::optional<std::int64_t>> {
-            auto stmtR = db.prepare("SELECT id FROM documents WHERE file_path = ? LIMIT 1");
+            auto stmtR = db.prepareCached("SELECT id FROM documents WHERE file_path = ? LIMIT 1");
             if (!stmtR)
                 return stmtR.error();
             auto stmt = std::move(stmtR).value();
-            auto br = stmt.bind(1, file_path);
+            auto br = stmt->bind(1, file_path);
             if (!br)
                 return br.error();
-            auto step = stmt.step();
+            auto step = stmt->step();
             if (!step)
                 return step.error();
             if (!step.value())
                 return std::optional<std::int64_t>{};
-            return std::optional<std::int64_t>{stmt.getInt64(0)};
+            return std::optional<std::int64_t>{stmt->getInt64(0)};
         });
     }
 
@@ -1643,44 +1644,45 @@ public:
                                                              std::size_t limit,
                                                              std::size_t offset) override {
         return readPool()->withConnection([&](Database& db) -> Result<std::vector<DocEntity>> {
-            auto stmtR = db.prepare("SELECT id, document_id, entity_text, node_id, start_offset, "
-                                    "end_offset, confidence, extractor "
-                                    "FROM kg_doc_entities WHERE document_id = ? LIMIT ? OFFSET ?");
+            auto stmtR =
+                db.prepareCached("SELECT id, document_id, entity_text, node_id, start_offset, "
+                                 "end_offset, confidence, extractor "
+                                 "FROM kg_doc_entities WHERE document_id = ? LIMIT ? OFFSET ?");
             if (!stmtR)
                 return stmtR.error();
             auto stmt = std::move(stmtR).value();
 
-            auto br = stmt.bind(1, documentId);
+            auto br = stmt->bind(1, documentId);
             if (!br)
                 return br.error();
-            br = stmt.bind(2, static_cast<int64_t>(limit));
+            br = stmt->bind(2, static_cast<int64_t>(limit));
             if (!br)
                 return br.error();
-            br = stmt.bind(3, static_cast<int64_t>(offset));
+            br = stmt->bind(3, static_cast<int64_t>(offset));
             if (!br)
                 return br.error();
 
             std::vector<DocEntity> out;
             while (true) {
-                auto step = stmt.step();
+                auto step = stmt->step();
                 if (!step)
                     return step.error();
                 if (!step.value())
                     break;
                 DocEntity de;
-                de.id = stmt.getInt64(0);
-                de.documentId = stmt.getInt64(1);
-                de.entityText = stmt.getString(2);
-                if (!stmt.isNull(3))
-                    de.nodeId = stmt.getInt64(3);
-                if (!stmt.isNull(4))
-                    de.startOffset = stmt.getInt64(4);
-                if (!stmt.isNull(5))
-                    de.endOffset = stmt.getInt64(5);
-                if (!stmt.isNull(6))
-                    de.confidence = static_cast<float>(stmt.getDouble(6));
-                if (!stmt.isNull(7))
-                    de.extractor = stmt.getString(7);
+                de.id = stmt->getInt64(0);
+                de.documentId = stmt->getInt64(1);
+                de.entityText = stmt->getString(2);
+                if (!stmt->isNull(3))
+                    de.nodeId = stmt->getInt64(3);
+                if (!stmt->isNull(4))
+                    de.startOffset = stmt->getInt64(4);
+                if (!stmt->isNull(5))
+                    de.endOffset = stmt->getInt64(5);
+                if (!stmt->isNull(6))
+                    de.confidence = static_cast<float>(stmt->getDouble(6));
+                if (!stmt->isNull(7))
+                    de.extractor = stmt->getString(7);
                 out.push_back(std::move(de));
             }
             return out;
@@ -2232,7 +2234,7 @@ public:
             }
             sqlPattern += "%";
 
-            auto stmtR = db.prepare(R"(
+            auto stmtR = db.prepareCached(R"(
                 SELECT id, node_key, label, type, created_time, updated_time, properties
                 FROM kg_nodes
                 WHERE label LIKE ? COLLATE NOCASE
@@ -2243,32 +2245,32 @@ public:
                 return stmtR.error();
 
             auto stmt = std::move(stmtR).value();
-            auto bindRes = stmt.bindAll(sqlPattern, static_cast<std::int64_t>(limit),
-                                        static_cast<std::int64_t>(offset));
+            auto bindRes = stmt->bindAll(sqlPattern, static_cast<std::int64_t>(limit),
+                                         static_cast<std::int64_t>(offset));
             if (!bindRes)
                 return bindRes.error();
 
             std::vector<KGNode> results;
             while (true) {
-                auto step = stmt.step();
+                auto step = stmt->step();
                 if (!step)
                     return step.error();
                 if (!step.value())
                     break;
 
                 KGNode node;
-                node.id = stmt.getInt64(0);
-                node.nodeKey = stmt.getString(1);
-                if (!stmt.isNull(2))
-                    node.label = stmt.getString(2);
-                if (!stmt.isNull(3))
-                    node.type = stmt.getString(3);
-                if (!stmt.isNull(4))
-                    node.createdTime = stmt.getInt64(4);
-                if (!stmt.isNull(5))
-                    node.updatedTime = stmt.getInt64(5);
-                if (!stmt.isNull(6))
-                    node.properties = stmt.getString(6);
+                node.id = stmt->getInt64(0);
+                node.nodeKey = stmt->getString(1);
+                if (!stmt->isNull(2))
+                    node.label = stmt->getString(2);
+                if (!stmt->isNull(3))
+                    node.type = stmt->getString(3);
+                if (!stmt->isNull(4))
+                    node.createdTime = stmt->getInt64(4);
+                if (!stmt->isNull(5))
+                    node.updatedTime = stmt->getInt64(5);
+                if (!stmt->isNull(6))
+                    node.properties = stmt->getString(6);
 
                 results.push_back(std::move(node));
             }
@@ -2294,11 +2296,11 @@ public:
         return pool_->withConnection([&](Database& db) -> Result<std::int64_t> {
             // Check if blob node exists
             auto selectStmt =
-                db.prepare("SELECT id FROM kg_nodes WHERE node_key = ? AND type = 'blob'");
+                db.prepareCached("SELECT id FROM kg_nodes WHERE node_key = ? AND type = 'blob'");
             if (!selectStmt)
                 return selectStmt.error();
 
-            auto& stmt = selectStmt.value();
+            auto& stmt = *selectStmt.value();
             std::string nodeKey = std::string("blob:") + std::string(sha256);
             auto bindRes = stmt.bindAll(nodeKey);
             if (!bindRes)
@@ -2337,12 +2339,12 @@ public:
     Result<std::int64_t> ensureDocumentNode(std::string_view sha256,
                                             std::string_view label = std::string_view{}) override {
         return pool_->withConnection([&](Database& db) -> Result<std::int64_t> {
-            auto selectStmt = db.prepare(
+            auto selectStmt = db.prepareCached(
                 "SELECT id, label FROM kg_nodes WHERE node_key = ? AND type = 'document'");
             if (!selectStmt)
                 return selectStmt.error();
 
-            auto& stmt = selectStmt.value();
+            auto& stmt = *selectStmt.value();
             std::string nodeKey = std::string("doc:") + std::string(sha256);
             auto bindRes = stmt.bindAll(nodeKey);
             if (!bindRes)
@@ -2399,11 +2401,11 @@ public:
 
             // Check if path node exists
             auto selectStmt =
-                db.prepare("SELECT id FROM kg_nodes WHERE node_key = ? AND type = 'path'");
+                db.prepareCached("SELECT id FROM kg_nodes WHERE node_key = ? AND type = 'path'");
             if (!selectStmt)
                 return selectStmt.error();
 
-            auto& stmt = selectStmt.value();
+            auto& stmt = *selectStmt.value();
             auto bindRes = stmt.bindAll(nodeKey);
             if (!bindRes)
                 return bindRes.error();
@@ -2450,11 +2452,11 @@ public:
             // Logical path node to group snapshot path nodes.
             std::string logicalKey = "path:logical:" + descriptor.path;
             auto logicalSelect =
-                db.prepare("SELECT id FROM kg_nodes WHERE node_key = ? AND type = 'path'");
+                db.prepareCached("SELECT id FROM kg_nodes WHERE node_key = ? AND type = 'path'");
             if (!logicalSelect)
                 return logicalSelect.error();
 
-            auto& logicalStmt = logicalSelect.value();
+            auto& logicalStmt = *logicalSelect.value();
             auto logicalBind = logicalStmt.bindAll(logicalKey);
             if (!logicalBind)
                 return logicalBind.error();

--- a/src/metadata/knowledge_graph_store_sqlite.cpp
+++ b/src/metadata/knowledge_graph_store_sqlite.cpp
@@ -1120,77 +1120,120 @@ public:
     Result<std::unordered_map<std::int64_t, std::vector<KGEdge>>>
     getEdgesFromBatch(const std::vector<std::int64_t>& srcNodeIds,
                       std::optional<std::string_view> relation, std::size_t limitPerNode) override {
+        return getEdgesBatch(srcNodeIds, relation, limitPerNode, false);
+    }
+
+private:
+    Result<std::unordered_map<std::int64_t, std::vector<KGEdge>>>
+    getEdgesBatch(const std::vector<std::int64_t>& nodeIds,
+                  std::optional<std::string_view> relation, std::size_t limitPerNode,
+                  bool incoming) {
         using ResultMap = std::unordered_map<std::int64_t, std::vector<KGEdge>>;
-
-        if (srcNodeIds.empty()) {
+        if (nodeIds.empty() || limitPerNode == 0)
             return ResultMap{};
+        if (limitPerNode > static_cast<std::size_t>(std::numeric_limits<int64_t>::max())) {
+            return Error{ErrorCode::InvalidArgument,
+                         "Per-node edge limit exceeds SQLite integer range"};
         }
-
+        auto uniqueIds = nodeIds;
+        std::sort(uniqueIds.begin(), uniqueIds.end());
+        uniqueIds.erase(std::unique(uniqueIds.begin(), uniqueIds.end()), uniqueIds.end());
         return readPool()->withConnection([&](Database& db) -> Result<ResultMap> {
-            std::string placeholders;
-            for (size_t i = 0; i < srcNodeIds.size(); ++i) {
-                if (i > 0)
-                    placeholders += ",";
-                placeholders += "?";
+            const int fixedParameters = relation ? 2 : 1;
+            const int variableLimit =
+                sqlite3_limit(db.rawHandle(), SQLITE_LIMIT_VARIABLE_NUMBER, -1);
+            if (variableLimit <= fixedParameters) {
+                return Error{ErrorCode::InvalidArgument,
+                             "SQLite variable limit cannot fit an edge query"};
             }
-
-            std::string sql =
-                "SELECT id, src_node_id, dst_node_id, relation, weight, created_time, properties "
-                "FROM ("
-                "  SELECT *, ROW_NUMBER() OVER (PARTITION BY src_node_id "
-                "    ORDER BY weight DESC, created_time DESC, id DESC) as rn "
-                "  FROM kg_edges "
-                "  WHERE src_node_id IN (" +
-                placeholders + ")";
-            if (relation.has_value()) {
-                sql += " AND relation = ?";
-            }
-            sql += ") WHERE rn <= ?";
-
-            auto stmtR = db.prepare(sql);
-            if (!stmtR)
-                return stmtR.error();
-            auto stmt = std::move(stmtR).value();
-
-            int idx = 1;
-            for (const auto& nodeId : srcNodeIds) {
-                auto br = stmt.bind(idx++, nodeId);
-                if (!br)
-                    return br.error();
-            }
-            if (relation.has_value()) {
-                auto br = stmt.bind(idx++, relation.value());
-                if (!br)
-                    return br.error();
-            }
-            auto br = stmt.bind(idx, static_cast<int64_t>(limitPerNode));
-            if (!br)
-                return br.error();
-
+            // Bound SQL size even on connections configured with very large variable limits.
+            const auto batchSize = std::min<std::size_t>(512, variableLimit - fixedParameters);
+            // Keep the original single-query snapshot across all chunks; savepoints also
+            // work when this connection already belongs to a caller-owned transaction.
+            auto started = db.execute("SAVEPOINT yams_edge_batch_read");
+            if (!started)
+                return started.error();
+            struct Savepoint {
+                Database& db;
+                bool active{true};
+                ~Savepoint() {
+                    if (active) {
+                        (void)db.execute("ROLLBACK TO yams_edge_batch_read");
+                        (void)db.execute("RELEASE yams_edge_batch_read");
+                    }
+                }
+            } savepoint{db};
+            const std::string column = incoming ? "dst_node_id" : "src_node_id";
+            // Preserve the two APIs' existing, distinct selection policies.
+            const std::string ordering =
+                incoming ? "id" : "weight DESC, created_time DESC, id DESC";
             ResultMap out;
-            out.reserve(srcNodeIds.size());
-            while (true) {
-                auto step = stmt.step();
-                if (!step)
-                    return step.error();
-                if (!step.value())
-                    break;
-                KGEdge e;
-                e.id = stmt.getInt64(0);
-                e.srcNodeId = stmt.getInt64(1);
-                e.dstNodeId = stmt.getInt64(2);
-                e.relation = stmt.getString(3);
-                e.weight = static_cast<float>(stmt.getDouble(4));
-                if (!stmt.isNull(5))
-                    e.createdTime = stmt.getInt64(5);
-                if (!stmt.isNull(6))
-                    e.properties = stmt.getString(6);
-                out[e.srcNodeId].push_back(std::move(e));
+            out.reserve(uniqueIds.size());
+            for (std::size_t offset = 0; offset < uniqueIds.size();) {
+                const auto count = std::min(batchSize, uniqueIds.size() - offset);
+                std::string placeholders;
+                for (std::size_t i = 0; i < count; ++i) {
+                    if (i)
+                        placeholders += ',';
+                    placeholders += '?';
+                }
+                std::string sql = "SELECT id, src_node_id, dst_node_id, relation, weight, "
+                                  "created_time, properties "
+                                  "FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY " +
+                                  column + " ORDER BY " + ordering +
+                                  ") as rn FROM kg_edges WHERE " + column + " IN (" + placeholders +
+                                  ")";
+                if (relation)
+                    sql += " AND relation = ?";
+                sql += ") WHERE rn <= ? ORDER BY " + column + ", rn";
+                auto stmtR = db.prepare(sql);
+                if (!stmtR)
+                    return stmtR.error();
+                auto stmt = std::move(stmtR).value();
+                int idx = 1;
+                for (std::size_t i = 0; i < count; ++i) {
+                    auto bound = stmt.bind(idx++, uniqueIds[offset + i]);
+                    if (!bound)
+                        return bound.error();
+                }
+                if (relation) {
+                    auto bound = stmt.bind(idx++, *relation);
+                    if (!bound)
+                        return bound.error();
+                }
+                auto bound = stmt.bind(idx, static_cast<int64_t>(limitPerNode));
+                if (!bound)
+                    return bound.error();
+                while (true) {
+                    auto step = stmt.step();
+                    if (!step)
+                        return step.error();
+                    if (!step.value())
+                        break;
+                    KGEdge edge;
+                    edge.id = stmt.getInt64(0);
+                    edge.srcNodeId = stmt.getInt64(1);
+                    edge.dstNodeId = stmt.getInt64(2);
+                    edge.relation = stmt.getString(3);
+                    edge.weight = static_cast<float>(stmt.getDouble(4));
+                    if (!stmt.isNull(5))
+                        edge.createdTime = stmt.getInt64(5);
+                    if (!stmt.isNull(6))
+                        edge.properties = stmt.getString(6);
+                    const auto key = incoming ? edge.dstNodeId : edge.srcNodeId;
+                    out[key].push_back(std::move(edge));
+                }
+                offset += count;
             }
+            auto released = db.execute("RELEASE yams_edge_batch_read");
+            if (!released)
+                return released.error();
+            savepoint.active = false;
             return out;
         });
     }
 
+public:
     Result<std::vector<KGEdge>> getEdgesTo(std::int64_t dstNodeId,
                                            std::optional<std::string_view> relation,
                                            std::size_t limit, std::size_t offset) override {
@@ -1250,80 +1293,7 @@ public:
     Result<std::unordered_map<std::int64_t, std::vector<KGEdge>>>
     getEdgesToBatch(const std::vector<std::int64_t>& dstNodeIds,
                     std::optional<std::string_view> relation, std::size_t limitPerNode) override {
-        using ResultMap = std::unordered_map<std::int64_t, std::vector<KGEdge>>;
-
-        if (dstNodeIds.empty()) {
-            return ResultMap{};
-        }
-
-        return readPool()->withConnection([&](Database& db) -> Result<ResultMap> {
-            // Build SQL with IN clause for batch lookup
-            // Using window function to limit results per destination node
-            std::string placeholders;
-            for (size_t i = 0; i < dstNodeIds.size(); ++i) {
-                if (i > 0)
-                    placeholders += ",";
-                placeholders += "?";
-            }
-
-            std::string sql =
-                "SELECT id, src_node_id, dst_node_id, relation, weight, created_time, properties "
-                "FROM ("
-                "  SELECT *, ROW_NUMBER() OVER (PARTITION BY dst_node_id ORDER BY id) as rn "
-                "  FROM kg_edges "
-                "  WHERE dst_node_id IN (" +
-                placeholders + ")";
-            if (relation.has_value()) {
-                sql += " AND relation = ?";
-            }
-            sql += ") WHERE rn <= ?";
-
-            auto stmtR = db.prepare(sql);
-            if (!stmtR)
-                return stmtR.error();
-            auto stmt = std::move(stmtR).value();
-
-            int idx = 1;
-            // Bind all destination node IDs
-            for (const auto& nodeId : dstNodeIds) {
-                auto br = stmt.bind(idx++, nodeId);
-                if (!br)
-                    return br.error();
-            }
-            // Bind relation filter if provided
-            if (relation.has_value()) {
-                auto br = stmt.bind(idx++, relation.value());
-                if (!br)
-                    return br.error();
-            }
-            // Bind limit per node
-            auto br = stmt.bind(idx, static_cast<int64_t>(limitPerNode));
-            if (!br)
-                return br.error();
-
-            ResultMap out;
-            out.reserve(dstNodeIds.size());
-
-            while (true) {
-                auto step = stmt.step();
-                if (!step)
-                    return step.error();
-                if (!step.value())
-                    break;
-                KGEdge e;
-                e.id = stmt.getInt64(0);
-                e.srcNodeId = stmt.getInt64(1);
-                e.dstNodeId = stmt.getInt64(2);
-                e.relation = stmt.getString(3);
-                e.weight = static_cast<float>(stmt.getDouble(4));
-                if (!stmt.isNull(5))
-                    e.createdTime = stmt.getInt64(5);
-                if (!stmt.isNull(6))
-                    e.properties = stmt.getString(6);
-                out[e.dstNodeId].push_back(std::move(e));
-            }
-            return out;
-        });
+        return getEdgesBatch(dstNodeIds, relation, limitPerNode, true);
     }
 
     Result<std::vector<KGEdge>> getEdgesBidirectional(std::int64_t nodeId,

--- a/src/search/kg_scorer_simple.cpp
+++ b/src/search/kg_scorer_simple.cpp
@@ -129,16 +129,18 @@ public:
             }
         }
 
-        // Pre-compute 1-hop neighbor set for structural scoring (budget-aware)
+        // Pre-compute the 1-hop neighbor union for structural scoring in one batched
+        // fetch instead of one statement per query node.
         std::unordered_set<std::int64_t> query_neighbor_union;
-        for (auto nid : query_nodes) {
-            if (timedOut(t0))
-                break;
-            auto nb = store_->neighbors(nid, cfg_.max_neighbors);
-            if (!nb)
-                return nb.error();
-            for (auto v : nb.value()) {
-                query_neighbor_union.insert(v);
+        if (!query_nodes.empty() && !timedOut(t0)) {
+            std::vector<std::int64_t> sources(query_nodes.begin(), query_nodes.end());
+            auto edges = store_->getEdgesFromBatch(sources, std::nullopt, cfg_.max_neighbors);
+            if (!edges)
+                return edges.error();
+            for (const auto& [src, outgoing] : edges.value()) {
+                for (const auto& e : outgoing) {
+                    query_neighbor_union.insert(e.dstNodeId);
+                }
             }
         }
 

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -153,7 +153,7 @@ src/detection/file_type_detector.cpp:655:portability/env-read # reviewed raw env
 src/mcp/stdio_transport.cpp:46:portability/env-read # reviewed raw environment read
 src/metadata/connection_pool.cpp:921:portability/jthread # feature-test guarded std::jthread
 src/metadata/database.cpp:29:portability/env-read # reviewed raw environment read
-src/metadata/database.cpp:473:portability/path-cstr # std::string filename, not filesystem::path
+src/metadata/database.cpp:476:portability/path-cstr # std::string filename, not filesystem::path
 src/metadata/metadata_repository.cpp:1546:portability/env-read # reviewed raw environment read
 src/metadata/migration.cpp:1559:portability/env-read # reviewed raw environment read
 src/metadata/repository/search_ops.cpp:89:portability/env-read # reviewed raw environment read

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -151,7 +151,7 @@ src/daemon/components/dispatcher/request_dispatcher_models.cpp:38:portability/en
 src/detection/file_type_detector.cpp:612:portability/env-read # reviewed raw environment read
 src/detection/file_type_detector.cpp:655:portability/env-read # reviewed raw environment read
 src/mcp/stdio_transport.cpp:46:portability/env-read # reviewed raw environment read
-src/metadata/connection_pool.cpp:921:portability/jthread # feature-test guarded std::jthread
+src/metadata/connection_pool.cpp:923:portability/jthread # feature-test guarded std::jthread
 src/metadata/database.cpp:29:portability/env-read # reviewed raw environment read
 src/metadata/database.cpp:476:portability/path-cstr # std::string filename, not filesystem::path
 src/metadata/metadata_repository.cpp:1546:portability/env-read # reviewed raw environment read
@@ -499,7 +499,7 @@ tests/unit/repair/embedding_repair_scan_catch2_test.cpp:187:portability/env-read
 tests/unit/repair/embedding_repair_scan_catch2_test.cpp:229:portability/env-read # reviewed raw environment read
 tests/unit/search/graph_expansion_catch2_test.cpp:18:portability/env-read # reviewed raw environment read
 tests/unit/search/hybrid_search_comprehensive_test.cpp:272:portability/env-read # reviewed raw environment read
-tests/unit/search/kg_scorer_simple_catch2_test.cpp:32:portability/env-read # reviewed raw environment read
+tests/unit/search/kg_scorer_simple_catch2_test.cpp:35:portability/env-read # reviewed raw environment read
 tests/unit/search/search_engine_simeon_lexical_catch2_test.cpp:25:portability/env-read # reviewed raw environment read
 tests/unit/search/search_engine_topology_catch2_test.cpp:43:portability/env-read # reviewed raw environment read
 tests/unit/search/simeon_bandit_backend_catch2_test.cpp:30:portability/env-read # reviewed raw environment read

--- a/tests/unit/metadata/database_catch2_test.cpp
+++ b/tests/unit/metadata/database_catch2_test.cpp
@@ -150,6 +150,30 @@ TEST_CASE("Database: prepared statements", "[unit][metadata][database]") {
     }
 }
 
+TEST_CASE("Database: cache stats count uncached prepares", "[unit][metadata][database]") {
+    DatabaseFixture fix;
+    Database db;
+    REQUIRE(db.open(fix.dbPath_.string(), ConnectionMode::Create).has_value());
+    REQUIRE(db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)").has_value());
+
+    const auto before = db.getStatementCacheStats();
+    REQUIRE(db.prepare("SELECT id FROM t").has_value());
+    REQUIRE(db.prepare("SELECT id FROM t").has_value());
+    {
+        auto cached = db.prepareCached("SELECT id FROM t WHERE id = ?");
+        REQUIRE(cached.has_value());
+    }
+    {
+        auto cached = db.prepareCached("SELECT id FROM t WHERE id = ?");
+        REQUIRE(cached.has_value());
+    }
+    const auto after = db.getStatementCacheStats();
+    // prepare() bypasses the cache: this is the count a hot path must drive to zero.
+    CHECK(after.uncachedPrepares - before.uncachedPrepares == 2);
+    CHECK(after.misses - before.misses == 1);
+    CHECK(after.hits - before.hits == 1);
+}
+
 TEST_CASE("Database: statement failures include sqlite error detail",
           "[unit][metadata][database]") {
     DatabaseFixture fix;

--- a/tests/unit/metadata/kg_store_catch2_test.cpp
+++ b/tests/unit/metadata/kg_store_catch2_test.cpp
@@ -1474,7 +1474,7 @@ TEST_CASE("KG Store: write batch cleanup helpers commit scoped deletions", "[uni
 }
 
 TEST_CASE("KG Store hot lookups reuse prepared statements after warm-up",
-          "[unit][metadata][kg][statements][catch2]") {
+          "[unit][metadata][kg][statements][batch-bind-limit][catch2]") {
     // One connection so every call lands on the same statement cache.
     const auto dbPath = tempDbPath("kg_store_prepared_");
     {
@@ -1537,6 +1537,65 @@ TEST_CASE("KG Store hot lookups reuse prepared statements after warm-up",
     }
     CHECK(afterOneNeighbors - before == 0);
     CHECK(uncached() - before == 0);
+
+    // Exercise the connection's actual parameter budget, not the build-time default.
+    REQUIRE(pool.withConnection([](Database& db) -> Result<void> {
+                    sqlite3_limit(db.rawHandle(), SQLITE_LIMIT_VARIABLE_NUMBER, 16);
+                    return {};
+                })
+                .has_value());
+    auto repeatedIds = ids.value();
+    repeatedIds.insert(repeatedIds.end(), ids.value().begin(), ids.value().end());
+    SECTION("outgoing batches fit the connection variable limit") {
+        auto edges = store.getEdgesFromBatch(repeatedIds, std::string_view("REL"), 2);
+        REQUIRE(edges.has_value());
+        REQUIRE(edges.value().contains(ids.value()[0]));
+        CHECK(edges.value().at(ids.value()[0]).size() == 2);
+        auto unfiltered = store.getEdgesFromBatch(repeatedIds, std::nullopt, 2);
+        REQUIRE(unfiltered.has_value());
+        CHECK(unfiltered.value().at(ids.value()[0]).size() == 2);
+        CHECK(unfiltered.value().at(ids.value()[0])[0].id ==
+              edges.value().at(ids.value()[0])[0].id);
+    }
+    SECTION("incoming batches fit the connection variable limit") {
+        auto edges = store.getEdgesToBatch(repeatedIds, std::string_view("REL"), 2);
+        REQUIRE(edges.has_value());
+        CHECK(edges.value().size() == 63);
+        for (const auto& [id, selected] : edges.value()) {
+            CHECK(selected.size() == 1);
+        }
+        auto unfiltered = store.getEdgesToBatch(repeatedIds, std::nullopt, 2);
+        REQUIRE(unfiltered.has_value());
+        CHECK(unfiltered.value().size() == 63);
+    }
+    SECTION("a prepare failure rolls back the read savepoint") {
+        REQUIRE(pool.withConnection([](Database& db) -> Result<void> {
+                        sqlite3_limit(db.rawHandle(), SQLITE_LIMIT_SQL_LENGTH, 100);
+                        return {};
+                    })
+                    .has_value());
+        CHECK_FALSE(store.getEdgesFromBatch(repeatedIds, std::nullopt, 2).has_value());
+        CHECK_FALSE(store.getEdgesToBatch(repeatedIds, std::nullopt, 2).has_value());
+        REQUIRE(pool.withConnection([](Database& db) -> Result<void> {
+                        CHECK(sqlite3_get_autocommit(db.rawHandle()) != 0);
+                        return {};
+                    })
+                    .has_value());
+    }
+    SECTION("an impossible parameter budget fails without leaking a transaction") {
+        REQUIRE(pool.withConnection([](Database& db) -> Result<void> {
+                        sqlite3_limit(db.rawHandle(), SQLITE_LIMIT_VARIABLE_NUMBER, 1);
+                        return {};
+                    })
+                    .has_value());
+        CHECK_FALSE(store.getEdgesFromBatch(repeatedIds, std::nullopt, 2).has_value());
+        CHECK_FALSE(store.getEdgesToBatch(repeatedIds, std::string_view("REL"), 2).has_value());
+        REQUIRE(pool.withConnection([](Database& db) -> Result<void> {
+                        CHECK(sqlite3_get_autocommit(db.rawHandle()) != 0);
+                        return {};
+                    })
+                    .has_value());
+    }
     pool.shutdown();
     std::error_code ec;
     std::filesystem::remove(dbPath, ec);

--- a/tests/unit/metadata/kg_store_catch2_test.cpp
+++ b/tests/unit/metadata/kg_store_catch2_test.cpp
@@ -1472,3 +1472,72 @@ TEST_CASE("KG Store: write batch cleanup helpers commit scoped deletions", "[uni
     REQUIRE((validEntities.value().size() == 1));
     CHECK((validEntities.value()[0].entityText == "BatchEntity"));
 }
+
+TEST_CASE("KG Store hot lookups reuse prepared statements after warm-up",
+          "[unit][metadata][kg][statements][catch2]") {
+    // One connection so every call lands on the same statement cache.
+    const auto dbPath = tempDbPath("kg_store_prepared_");
+    {
+        auto bootstrap =
+            makeSqliteKnowledgeGraphStore(dbPath.string(), KnowledgeGraphStoreConfig{});
+        REQUIRE(bootstrap.has_value());
+    }
+    ConnectionPoolConfig poolCfg;
+    poolCfg.minConnections = 1;
+    poolCfg.maxConnections = 1;
+    ConnectionPool pool(dbPath.string(), poolCfg);
+    REQUIRE(pool.initialize().has_value());
+    auto storeRes = makeSqliteKnowledgeGraphStore(pool, KnowledgeGraphStoreConfig{});
+    REQUIRE(storeRes.has_value());
+    auto& store = *storeRes.value();
+
+    std::vector<KGNode> nodes;
+    for (int i = 0; i < 64; ++i) {
+        nodes.push_back(KGNode{.nodeKey = "ent:" + std::to_string(i),
+                               .label = std::string("N" + std::to_string(i)),
+                               .type = std::string("entity")});
+    }
+    auto ids = store.upsertNodes(nodes);
+    REQUIRE(ids.has_value());
+    REQUIRE(ids.value().size() == 64u);
+    for (std::size_t i = 1; i < ids.value().size(); ++i) {
+        REQUIRE(store
+                    .addEdge(KGEdge{.srcNodeId = ids.value()[0],
+                                    .dstNodeId = ids.value()[i],
+                                    .relation = std::string("REL")})
+                    .has_value());
+    }
+
+    const auto uncached = [&]() {
+        std::size_t count = 0;
+        auto r = pool.withConnection([&](Database& db) -> Result<void> {
+            count = db.getStatementCacheStats().uncachedPrepares;
+            return Result<void>();
+        });
+        REQUIRE(r.has_value());
+        return count;
+    };
+
+    // Warm every path once, then measure.
+    REQUIRE(store.neighbors(ids.value()[0], 100).has_value());
+    REQUIRE(store.getDocumentIdByHash("missing").has_value());
+    REQUIRE(store.ensureDocumentNode("deadbeef", "doc").has_value());
+    const auto before = uncached();
+    REQUIRE(store.neighbors(ids.value()[1], 100).has_value());
+    const auto afterOneNeighbors = uncached();
+    INFO("uncached prepares for one warmed neighbors() call: " << (afterOneNeighbors - before));
+    for (std::size_t i = 0; i < ids.value().size(); ++i) {
+        auto nb = store.neighbors(ids.value()[i], 100);
+        REQUIRE(nb.has_value());
+    }
+    for (int i = 0; i < 16; ++i) {
+        REQUIRE(store.getDocumentIdByHash("missing-" + std::to_string(i)).has_value());
+        // Existing node: the select path, not the insert path.
+        REQUIRE(store.ensureDocumentNode("deadbeef", "doc").has_value());
+    }
+    CHECK(afterOneNeighbors - before == 0);
+    CHECK(uncached() - before == 0);
+    pool.shutdown();
+    std::error_code ec;
+    std::filesystem::remove(dbPath, ec);
+}

--- a/tests/unit/search/kg_scorer_simple_catch2_test.cpp
+++ b/tests/unit/search/kg_scorer_simple_catch2_test.cpp
@@ -8,6 +8,9 @@
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <vector>
+#include <yams/metadata/connection_pool.h>
+#include <yams/metadata/database.h>
 #include <yams/metadata/knowledge_graph_store.h>
 #include <yams/metadata/metadata_repository.h>
 #include <yams/search/kg_scorer.h>
@@ -139,4 +142,75 @@ TEST_CASE("SimpleKGScorer - ScoresEntityAndStructuralOverlap", "[search][kg_scor
     // Explanations best-effort: should be available for the hit
     auto expl = scorer->getLastExplanations();
     CHECK_FALSE(expl.empty());
+}
+
+TEST_CASE("SimpleKGScorer - neighbor union is one batched fetch", "[search][kg_scorer][catch2]") {
+    auto dbPath = tempDbPath("kg_scorer_batch_");
+    {
+        auto bootstrap =
+            makeSqliteKnowledgeGraphStore(dbPath.string(), KnowledgeGraphStoreConfig{});
+        REQUIRE(bootstrap.has_value());
+    }
+    ConnectionPoolConfig pcfg;
+    pcfg.minConnections = 1;
+    pcfg.maxConnections = 1;
+    auto pool = std::make_shared<ConnectionPool>(dbPath.string(), pcfg);
+    REQUIRE(pool->initialize().has_value());
+    auto sres = makeSqliteKnowledgeGraphStore(*pool, KnowledgeGraphStoreConfig{});
+    REQUIRE(sres.has_value());
+    std::shared_ptr<KnowledgeGraphStore> store(sres.value().release());
+
+    // Eight query nodes, each aliased by one query token, each with one outgoing edge.
+    std::vector<KGNode> nodes;
+    for (int i = 0; i < 9; ++i) {
+        nodes.push_back(KGNode{.nodeKey = "ent:q" + std::to_string(i),
+                               .label = std::string("Q" + std::to_string(i)),
+                               .type = std::string("entity")});
+    }
+    auto ids = store->upsertNodes(nodes);
+    REQUIRE(ids.has_value());
+    std::string query;
+    for (int i = 0; i < 8; ++i) {
+        REQUIRE(store
+                    ->addAlias(KGAlias{.nodeId = ids.value()[i],
+                                       .alias = std::string("term" + std::to_string(i)),
+                                       .source = std::string("test"),
+                                       .confidence = 1.0f})
+                    .has_value());
+        REQUIRE(store
+                    ->addEdge(KGEdge{.srcNodeId = ids.value()[i],
+                                     .dstNodeId = ids.value()[8],
+                                     .relation = std::string("REL")})
+                    .has_value());
+        query += "term" + std::to_string(i) + " ";
+    }
+
+    auto scorer = makeSimpleKGScorer(store);
+    REQUIRE(scorer != nullptr);
+    KGScoringConfig scfg;
+    scfg.max_neighbors = 16;
+    scfg.max_hops = 1;
+    scfg.budget = std::chrono::milliseconds(1000);
+    scorer->setConfig(scfg);
+
+    const auto uncached = [&]() {
+        std::size_t count = 0;
+        auto r = pool->withConnection([&](Database& db) -> Result<void> {
+            count = db.getStatementCacheStats().uncachedPrepares;
+            return Result<void>();
+        });
+        REQUIRE(r.has_value());
+        return count;
+    };
+    std::vector<std::string> cands = {"1", "2"};
+    REQUIRE(scorer->score(query, cands).has_value()); // warm-up
+    const auto before = uncached();
+    REQUIRE(scorer->score(query, cands).has_value());
+    // Per-node neighbors() re-prepared once per query node (8); a batch is one IN query.
+    CHECK(uncached() - before < 8);
+    scorer.reset();
+    store.reset();
+    pool->shutdown();
+    std::error_code ec;
+    std::filesystem::remove(dbPath, ec);
 }


### PR DESCRIPTION
## Purpose

Measure and reduce repeated SQLite prepares

## Behavior changes

Cache statements and batch KG neighbor queries; disclose changed weighted/newest neighbor selection

## Compatibility impact

Ranking may differ under limited neighbors; SQLite variable limits depend on build/runtime configuration

## Structural evidence

Statement ownership remains inside leased connections; report measured prepares separately from latency

Pinned same-root Brick archive comparisons are available for all groups and the cumulative stack. Bounded extraction-seam review verified149 resolved includes. Final graph has1158 parser diagnostics across619 files and0.089 local dependency resolution; experimental score68.708 versus68.820 baseline. Partial heuristic coverage is not architecture quality or runtime correctness proof.

## Tests

Cache counts, constrained variable-limit batch test, connection-lifetime tests and neighbor-selection parity or approved quality comparison

Monitor35 nativeASan/UBSan KG andsearchfullbinariespassed; correctiondefc1969 signedDCO/normalhooks. Parameterlimit16 red524assertions2failures beforefix. Coversdedup/filter/no-filter/impossiblebudget/savepointcleanup. No measuredlatency claim.

Cumulative exact-final validation at `661e33c2273d7e684b41ad006e925912263dc9f5`: full canonical ASan/UBSan 204/0 and TSan 289/0; installed-only MemorySyncLoop publish/sync/read and TuneAdvisor consumer passed. These final-tip results do not certify each intermediate head independently. Policy checks found zero new portability/raw-environment/configuration violations or benchmark environment leaks.

Final-tip SciFact: 2000-document plan, 50 measured hybrid queries, k=10, three repeats per arm. Product/untraced, topology-off/untraced, and shadow/traced produced identical measured hybrid rankings (MRR 0.676667; recall@10 0.793333). Mean p50: 323.667/306.333/352 ms respectively. ASan/UBSan debug timings only; not production latency, a source-revision before/after comparison, or a performance-win claim.

## Dependencies

Group 6/14; base `grouped/05-configuration-authority`, prepared head `defc19697b6356886be19978c04a6bfe21197832`. group5

All42 newly prepared commits have valid signatures and exact trvon DCO trailers. Inherited PR115 commit5393a5a8 is unsigned and lacks DCO; the user explicitly approved retaining this inherited exception to preserve fast-forward history. No exception applies to newly prepared commits.

Source replay mapping:
- `648e49df` → `c1d9174e1b9f27ec6d0e13bb2fb9341e87b5e3b3`
- `59388552` → `77f130f4fb0f23128f556ec595367685ed250212`
