### PR TITLE
[07/14] Batch tag and topology hydration

### DIFF
--- a/src/app/services/search_service.cpp
+++ b/src/app/services/search_service.cpp
@@ -571,12 +571,11 @@ retryMetadataOp(Fn&& fn, std::size_t maxAttempts = 4,
     co_return attempt;
 }
 
-// Tags live in metadata as "tag:<name>" keys; MetadataRepository::batchGetDocumentTags returns
-// the names for many documents in one statement. Loading them once per request replaces the
-// getAllMetadata() round trip (with retries) that used to run for every candidate document.
+// Batch lookup supports normalized tag:<name> keys and legacy tag values, using bounded
+// queries. A lookup failure must be reported, not interpreted as an empty tag set.
 using TagsByDocument = std::unordered_map<int64_t, std::vector<std::string>>;
 
-static boost::asio::awaitable<TagsByDocument> loadTagsForDocuments(
+static boost::asio::awaitable<Result<TagsByDocument>> loadTagsForDocuments(
     metadata::MetadataRepository* repo, const std::vector<metadata::DocumentInfo>& docs,
     const std::vector<std::string>& requiredTags, MetadataTelemetry* telemetry = nullptr) {
     TagsByDocument tagsByDoc;
@@ -593,10 +592,7 @@ static boost::asio::awaitable<TagsByDocument> loadTagsForDocuments(
     auto loaded = co_await retryMetadataOp([&]() { return repo->batchGetDocumentTags(ids); }, 4,
                                            std::chrono::milliseconds(25), telemetry);
     if (!loaded) {
-        // Every document then fails the tag filter, as it did when its own lookup failed.
-        spdlog::debug("SearchService: tag lookup failed for {} docs: {}", ids.size(),
-                      loaded.error().message);
-        co_return tagsByDoc;
+        co_return loaded.error();
     }
     co_return std::move(loaded.value());
 }
@@ -881,7 +877,12 @@ public:
                 resp.queryInfo = "path/name contains match";
                 co_return Result<SearchResponse>(applyWorkspaceScope(std::move(resp)));
             }
-            // Fall through to standard paths on error.
+            // Required tag filtering could not be completed. Do not hide that failure
+            // behind a fallback search that can report an empty successful result.
+            if (!normalizedReq.tags.empty()) {
+                co_return pathResult.error();
+            }
+            // Untagged path heuristics may still fall back to the standard search paths.
         }
 
         if (type == "hybrid" || type == "semantic") {
@@ -1556,8 +1557,11 @@ private:
         }
 
         // Apply additional filters and shape results
-        const auto tagsByDoc =
+        auto loadedTags =
             co_await loadTagsForDocuments(ctx_.metadataRepo.get(), docs, req.tags, telemetry);
+        if (!loadedTags)
+            co_return loadedTags.error();
+        const auto& tagsByDoc = loadedTags.value();
         auto push_path = [&](const metadata::DocumentInfo& d) -> boost::asio::awaitable<void> {
             if (!req.extension.empty()) {
                 if (d.fileExtension != req.extension && d.fileExtension != ("." + req.extension))
@@ -1683,8 +1687,11 @@ private:
             return filePath.find(rawPattern) != std::string::npos;
         };
 
-        const auto tagsByDoc =
+        auto loadedTags =
             co_await loadTagsForDocuments(ctx_.metadataRepo.get(), docs, req.tags, telemetry);
+        if (!loadedTags)
+            co_return loadedTags.error();
+        const auto& tagsByDoc = loadedTags.value();
         for (const auto& doc : docs) {
             // Optional path and tag filters for CLI parity
             bool pathOk = effectivePathPatterns.empty();

--- a/src/app/services/search_service.cpp
+++ b/src/app/services/search_service.cpp
@@ -571,72 +571,51 @@ retryMetadataOp(Fn&& fn, std::size_t maxAttempts = 4,
     co_return attempt;
 }
 
-static boost::asio::awaitable<bool> metadataHasTags(metadata::MetadataRepository* repo,
-                                                    int64_t docId,
-                                                    const std::vector<std::string>& tags,
-                                                    bool matchAll,
-                                                    MetadataTelemetry* telemetry = nullptr) {
-    if (!repo || tags.empty()) {
-        co_return true;
+// Tags live in metadata as "tag:<name>" keys; MetadataRepository::batchGetDocumentTags returns
+// the names for many documents in one statement. Loading them once per request replaces the
+// getAllMetadata() round trip (with retries) that used to run for every candidate document.
+using TagsByDocument = std::unordered_map<int64_t, std::vector<std::string>>;
+
+static boost::asio::awaitable<TagsByDocument> loadTagsForDocuments(
+    metadata::MetadataRepository* repo, const std::vector<metadata::DocumentInfo>& docs,
+    const std::vector<std::string>& requiredTags, MetadataTelemetry* telemetry = nullptr) {
+    TagsByDocument tagsByDoc;
+    if (!repo || requiredTags.empty() || docs.empty()) {
+        co_return tagsByDoc;
     }
-
-    auto md = co_await retryMetadataOp([&]() { return repo->getAllMetadata(docId); }, 4,
-                                       std::chrono::milliseconds(25), telemetry);
-
-    if (!md) {
-        spdlog::debug("SearchService: metadata lookup failed for doc {}: {}", docId,
-                      md.error().message);
-        co_return false;
+    std::vector<int64_t> ids;
+    ids.reserve(docs.size());
+    for (const auto& d : docs) {
+        if (d.id > 0) {
+            ids.push_back(d.id);
+        }
     }
-
-    auto& all = md.value();
-
-    // Debug: log all metadata keys for this document
-    if (!tags.empty()) {
-        std::string keys;
-        for (const auto& [k, v] : all) {
-            if (!keys.empty())
-                keys += ", ";
-            keys += k + "=" + v.asString();
-        }
-        spdlog::info(
-            "metadataHasTags: docId={} searching for tags=[{}] matchAll={} found_metadata=[{}]",
-            docId, tags.size(), matchAll, keys);
+    auto loaded = co_await retryMetadataOp([&]() { return repo->batchGetDocumentTags(ids); }, 4,
+                                           std::chrono::milliseconds(25), telemetry);
+    if (!loaded) {
+        // Every document then fails the tag filter, as it did when its own lookup failed.
+        spdlog::debug("SearchService: tag lookup failed for {} docs: {}", ids.size(),
+                      loaded.error().message);
+        co_return tagsByDoc;
     }
+    co_return std::move(loaded.value());
+}
 
-    auto hasTag = [&](const std::string& t) {
-        // Check for normalized storage (key="tag:<name>")
-        auto it = all.find("tag:" + t);
-        if (it != all.end()) {
-            spdlog::debug("metadataHasTags: found tag:{}", t);
-            return true;
-        }
-        // Fallback: check for legacy storage (key="tag", value="<name>")
-        for (const auto& [k, v] : all) {
-            if (k == "tag" && v.asString() == t) {
-                spdlog::debug("metadataHasTags: found legacy tag {}", t);
-                return true;
-            }
-        }
-        spdlog::debug("metadataHasTags: tag '{}' not found", t);
+static bool hasRequiredTags(const TagsByDocument& tagsByDoc, int64_t docId,
+                            const std::vector<std::string>& required, bool matchAll) {
+    if (required.empty()) {
+        return true;
+    }
+    const auto it = tagsByDoc.find(docId);
+    if (it == tagsByDoc.end()) {
         return false;
-    };
-
-    if (matchAll) {
-        for (const auto& t : tags) {
-            if (!hasTag(t)) {
-                co_return false;
-            }
-        }
-        co_return true;
-    } else {
-        for (const auto& t : tags) {
-            if (hasTag(t)) {
-                co_return true;
-            }
-        }
-        co_return false;
     }
+    const auto& tags = it->second;
+    const auto has = [&](const std::string& t) {
+        return std::find(tags.begin(), tags.end(), t) != tags.end();
+    };
+    return matchAll ? std::all_of(required.begin(), required.end(), has)
+                    : std::any_of(required.begin(), required.end(), has);
 }
 
 // Compute recommended worker count based on hardware, load and caps
@@ -1577,6 +1556,8 @@ private:
         }
 
         // Apply additional filters and shape results
+        const auto tagsByDoc =
+            co_await loadTagsForDocuments(ctx_.metadataRepo.get(), docs, req.tags, telemetry);
         auto push_path = [&](const metadata::DocumentInfo& d) -> boost::asio::awaitable<void> {
             if (!req.extension.empty()) {
                 if (d.fileExtension != req.extension && d.fileExtension != ("." + req.extension))
@@ -1584,8 +1565,7 @@ private:
             }
             if (!req.mimeType.empty() && d.mimeType != req.mimeType)
                 co_return;
-            if (!(co_await metadataHasTags(ctx_.metadataRepo.get(), d.id, req.tags,
-                                           req.matchAllTags, telemetry)))
+            if (!hasRequiredTags(tagsByDoc, d.id, req.tags, req.matchAllTags))
                 co_return;
             const std::string resolvedPath = !d.filePath.empty() ? d.filePath : d.fileName;
             const double score = computePathMatchScore(d, pathQuery, wildcard);
@@ -1703,6 +1683,8 @@ private:
             return filePath.find(rawPattern) != std::string::npos;
         };
 
+        const auto tagsByDoc =
+            co_await loadTagsForDocuments(ctx_.metadataRepo.get(), docs, req.tags, telemetry);
         for (const auto& doc : docs) {
             // Optional path and tag filters for CLI parity
             bool pathOk = effectivePathPatterns.empty();
@@ -1733,8 +1715,7 @@ private:
             }
 
             if (!pathOk || !metaFiltersOk ||
-                !(co_await metadataHasTags(ctx_.metadataRepo.get(), doc.id, req.tags,
-                                           req.matchAllTags, telemetry))) {
+                !hasRequiredTags(tagsByDoc, doc.id, req.tags, req.matchAllTags)) {
                 continue;
             }
 

--- a/src/daemon/components/RepairService.cpp
+++ b/src/daemon/components/RepairService.cpp
@@ -1917,13 +1917,15 @@ RepairOperationResult RepairService::repairDownloads(bool dryRun, bool verbose,
 
         try {
             metaFacade.setMetadata(doc.id, "source_url", metadata::MetadataValue(sourceUrl));
-            metaFacade.setMetadata(doc.id, "tag", metadata::MetadataValue("downloaded"));
+            metaFacade.setMetadata(doc.id, "tag:downloaded", metadata::MetadataValue("downloaded"));
             auto host = extract_host(sourceUrl);
             auto scheme = extract_scheme(sourceUrl);
             if (!host.empty())
-                metaFacade.setMetadata(doc.id, "tag", metadata::MetadataValue("host:" + host));
+                metaFacade.setMetadata(doc.id, "tag:host:" + host,
+                                       metadata::MetadataValue("host:" + host));
             if (!scheme.empty())
-                metaFacade.setMetadata(doc.id, "tag", metadata::MetadataValue("scheme:" + scheme));
+                metaFacade.setMetadata(doc.id, "tag:scheme:" + scheme,
+                                       metadata::MetadataValue("scheme:" + scheme));
         } catch (const std::exception& e) {
             spdlog::debug("RepairService: failed to persist download metadata for {}: {}",
                           sourceUrl, e.what());

--- a/src/metadata/metadata_repository.cpp
+++ b/src/metadata/metadata_repository.cpp
@@ -1989,62 +1989,92 @@ MetadataRepository::batchGetDocumentsByHash(const std::vector<std::string>& hash
 
     return executeReadQuery<std::unordered_map<std::string, DocumentInfo>>(
         [&](Database& db) -> Result<std::unordered_map<std::string, DocumentInfo>> {
-            std::string sql = "SELECT id, file_path, file_name, file_extension, file_size, "
-                              "sha256_hash, mime_type, created_time, modified_time, indexed_time, "
-                              "content_extracted, extraction_status, extraction_error "
-                              "FROM documents WHERE sha256_hash IN (";
-            for (size_t i = 0; i < hashes.size(); ++i) {
-                if (i > 0)
-                    sql += ",";
-                sql += "?";
+            const int variableLimit =
+                sqlite3_limit(db.rawHandle(), SQLITE_LIMIT_VARIABLE_NUMBER, -1);
+            if (variableLimit < 1) {
+                return Error{ErrorCode::InvalidArgument,
+                             "SQLite variable limit cannot fit a document query"};
             }
-            sql += ")";
-
-            auto stmtResult = db.prepare(sql);
-            if (!stmtResult) {
-                return stmtResult.error();
-            }
-
-            Statement stmt = std::move(stmtResult).value();
-
-            // Bind hashes
-            for (size_t i = 0; i < hashes.size(); ++i) {
-                if (auto bindResult = stmt.bind(static_cast<int>(i + 1), hashes[i]); !bindResult) {
-                    return bindResult.error();
+            auto uniqueHashes = hashes;
+            std::sort(uniqueHashes.begin(), uniqueHashes.end());
+            uniqueHashes.erase(std::unique(uniqueHashes.begin(), uniqueHashes.end()),
+                               uniqueHashes.end());
+            const auto batchSize = std::min<std::size_t>(500, variableLimit);
+            auto started = db.execute("SAVEPOINT yams_document_batch_read");
+            if (!started)
+                return started.error();
+            bool released = false;
+            auto rollback = scope_exit([&] {
+                if (!released) {
+                    (void)db.execute("ROLLBACK TO yams_document_batch_read");
+                    (void)db.execute("RELEASE yams_document_batch_read");
                 }
-            }
-
+            });
             std::unordered_map<std::string, DocumentInfo> result;
+            for (std::size_t offset = 0; offset < uniqueHashes.size();) {
+                const auto count = std::min(batchSize, uniqueHashes.size() - offset);
+                std::string sql =
+                    "SELECT id, file_path, file_name, file_extension, file_size, "
+                    "sha256_hash, mime_type, created_time, modified_time, indexed_time, "
+                    "content_extracted, extraction_status, extraction_error "
+                    "FROM documents WHERE sha256_hash IN (";
+                for (size_t i = 0; i < count; ++i) {
+                    if (i > 0)
+                        sql += ",";
+                    sql += "?";
+                }
+                sql += ")";
 
-            while (true) {
-                auto stepResult = stmt.step();
-                if (!stepResult) {
-                    return stepResult.error();
+                auto stmtResult = db.prepare(sql);
+                if (!stmtResult) {
+                    return stmtResult.error();
                 }
 
-                if (!stepResult.value()) {
-                    break;
+                Statement stmt = std::move(stmtResult).value();
+
+                // Bind only this chunk; each distinct hash belongs to exactly one chunk.
+                for (size_t i = 0; i < count; ++i) {
+                    if (auto bindResult =
+                            stmt.bind(static_cast<int>(i + 1), uniqueHashes[offset + i]);
+                        !bindResult) {
+                        return bindResult.error();
+                    }
                 }
 
-                DocumentInfo info;
-                info.id = stmt.getInt64(0);
-                info.filePath = stmt.getString(1);
-                info.fileName = stmt.getString(2);
-                info.fileExtension = stmt.getString(3);
-                info.fileSize = stmt.getInt64(4);
-                info.sha256Hash = stmt.getString(5);
-                info.mimeType = stmt.getString(6);
-                info.setCreatedTime(stmt.getInt64(7));
-                info.setModifiedTime(stmt.getInt64(8));
-                info.setIndexedTime(stmt.getInt64(9));
-                info.contentExtracted = stmt.getInt(10) != 0;
-                info.extractionStatus = ExtractionStatusUtils::fromString(stmt.getString(11));
-                info.extractionError = stmt.getString(12);
+                while (true) {
+                    auto stepResult = stmt.step();
+                    if (!stepResult) {
+                        return stepResult.error();
+                    }
 
-                auto hash = info.sha256Hash;
-                result.emplace(std::move(hash), std::move(info));
+                    if (!stepResult.value()) {
+                        break;
+                    }
+
+                    DocumentInfo info;
+                    info.id = stmt.getInt64(0);
+                    info.filePath = stmt.getString(1);
+                    info.fileName = stmt.getString(2);
+                    info.fileExtension = stmt.getString(3);
+                    info.fileSize = stmt.getInt64(4);
+                    info.sha256Hash = stmt.getString(5);
+                    info.mimeType = stmt.getString(6);
+                    info.setCreatedTime(stmt.getInt64(7));
+                    info.setModifiedTime(stmt.getInt64(8));
+                    info.setIndexedTime(stmt.getInt64(9));
+                    info.contentExtracted = stmt.getInt(10) != 0;
+                    info.extractionStatus = ExtractionStatusUtils::fromString(stmt.getString(11));
+                    info.extractionError = stmt.getString(12);
+
+                    auto hash = info.sha256Hash;
+                    result.emplace(std::move(hash), std::move(info));
+                }
+                offset += count;
             }
-
+            auto release = db.execute("RELEASE yams_document_batch_read");
+            if (!release)
+                return release.error();
+            released = true;
             return result;
         });
 }
@@ -4460,17 +4490,26 @@ MetadataRepository::batchGetDocumentTags(std::span<const int64_t> documentIds) {
         return std::unordered_map<int64_t, std::vector<std::string>>{};
     }
 
-    // One placeholder per id, chunked below SQLite's variable limit (999 on older builds)
-    // so an unbounded candidate set from a path pattern never fails the whole lookup.
-    constexpr std::size_t kMaxTagQueryIds = 500;
+    // Match tag-filter semantics for both current and legacy metadata, without
+    // repeating tags when the same document occurs in multiple input chunks.
+    std::vector<int64_t> uniqueIds(documentIds.begin(), documentIds.end());
+    std::sort(uniqueIds.begin(), uniqueIds.end());
+    uniqueIds.erase(std::unique(uniqueIds.begin(), uniqueIds.end()), uniqueIds.end());
     return executeReadQuery<std::unordered_map<int64_t, std::vector<std::string>>>(
         [&](Database& db) -> Result<std::unordered_map<int64_t, std::vector<std::string>>> {
             std::unordered_map<int64_t, std::vector<std::string>> out;
-            for (std::size_t offset = 0; offset < documentIds.size(); offset += kMaxTagQueryIds) {
-                const auto chunk = documentIds.subspan(
-                    offset, std::min(kMaxTagQueryIds, documentIds.size() - offset));
-                std::string query = "SELECT document_id, key FROM metadata WHERE key LIKE 'tag:%' "
-                                    "AND document_id IN (";
+            const int variableLimit =
+                sqlite3_limit(db.rawHandle(), SQLITE_LIMIT_VARIABLE_NUMBER, -1);
+            if (variableLimit < 1) {
+                return Error{ErrorCode::InvalidArgument,
+                             "SQLite variable limit cannot fit a tag query"};
+            }
+            const auto batchSize = std::min<std::size_t>(500, variableLimit);
+            const std::span<const int64_t> ids(uniqueIds);
+            for (std::size_t offset = 0; offset < ids.size();) {
+                const auto chunk = ids.subspan(offset, std::min(batchSize, ids.size() - offset));
+                std::string query = "SELECT document_id, key, value FROM metadata "
+                                    "WHERE (key = 'tag' OR key LIKE 'tag:%') AND document_id IN (";
                 for (std::size_t i = 0; i < chunk.size(); ++i) {
                     if (i)
                         query += ",";
@@ -4500,8 +4539,15 @@ MetadataRepository::batchGetDocumentTags(std::span<const int64_t> documentIds) {
                     std::string fullKey = stmt.getString(1);
                     if (fullKey.starts_with("tag:")) {
                         out[stmt.getInt64(0)].push_back(fullKey.substr(4));
+                    } else if (fullKey == "tag" && !stmt.isNull(2)) {
+                        out[stmt.getInt64(0)].push_back(stmt.getString(2));
                     }
                 }
+                offset += chunk.size();
+            }
+            for (auto& [id, tags] : out) {
+                std::sort(tags.begin(), tags.end());
+                tags.erase(std::unique(tags.begin(), tags.end()), tags.end());
             }
 
             return out;

--- a/src/metadata/metadata_repository.cpp
+++ b/src/metadata/metadata_repository.cpp
@@ -4460,40 +4460,47 @@ MetadataRepository::batchGetDocumentTags(std::span<const int64_t> documentIds) {
         return std::unordered_map<int64_t, std::vector<std::string>>{};
     }
 
+    // One placeholder per id, chunked below SQLite's variable limit (999 on older builds)
+    // so an unbounded candidate set from a path pattern never fails the whole lookup.
+    constexpr std::size_t kMaxTagQueryIds = 500;
     return executeReadQuery<std::unordered_map<int64_t, std::vector<std::string>>>(
         [&](Database& db) -> Result<std::unordered_map<int64_t, std::vector<std::string>>> {
-            std::string query =
-                "SELECT document_id, key FROM metadata WHERE key LIKE 'tag:%' AND document_id IN (";
-            for (std::size_t i = 0; i < documentIds.size(); ++i) {
-                if (i)
-                    query += ",";
-                query += "?";
-            }
-            query += ") ORDER BY document_id, key";
-
-            auto stmtResult = db.prepare(query);
-            if (!stmtResult)
-                return stmtResult.error();
-
-            Statement stmt = std::move(stmtResult).value();
-            int bindIndex = 1;
-            for (auto id : documentIds) {
-                auto b = stmt.bind(bindIndex++, id);
-                if (!b)
-                    return b.error();
-            }
-
             std::unordered_map<int64_t, std::vector<std::string>> out;
-            while (true) {
-                auto stepResult = stmt.step();
-                if (!stepResult)
-                    return stepResult.error();
-                if (!stepResult.value())
-                    break;
+            for (std::size_t offset = 0; offset < documentIds.size(); offset += kMaxTagQueryIds) {
+                const auto chunk = documentIds.subspan(
+                    offset, std::min(kMaxTagQueryIds, documentIds.size() - offset));
+                std::string query = "SELECT document_id, key FROM metadata WHERE key LIKE 'tag:%' "
+                                    "AND document_id IN (";
+                for (std::size_t i = 0; i < chunk.size(); ++i) {
+                    if (i)
+                        query += ",";
+                    query += "?";
+                }
+                query += ") ORDER BY document_id, key";
 
-                std::string fullKey = stmt.getString(1);
-                if (fullKey.starts_with("tag:")) {
-                    out[stmt.getInt64(0)].push_back(fullKey.substr(4));
+                auto stmtResult = db.prepare(query);
+                if (!stmtResult)
+                    return stmtResult.error();
+
+                Statement stmt = std::move(stmtResult).value();
+                int bindIndex = 1;
+                for (auto id : chunk) {
+                    auto b = stmt.bind(bindIndex++, id);
+                    if (!b)
+                        return b.error();
+                }
+
+                while (true) {
+                    auto stepResult = stmt.step();
+                    if (!stepResult)
+                        return stepResult.error();
+                    if (!stepResult.value())
+                        break;
+
+                    std::string fullKey = stmt.getString(1);
+                    if (fullKey.starts_with("tag:")) {
+                        out[stmt.getInt64(0)].push_back(fullKey.substr(4));
+                    }
                 }
             }
 

--- a/src/search/topology_routing_session.cpp
+++ b/src/search/topology_routing_session.cpp
@@ -349,6 +349,10 @@ void collectGraphNeighborStageTrace(
             for (auto& [hash, document] : hydrated.value()) {
                 documentIds[hash] = documentIdForTrace(document.filePath, hash);
             }
+        } else {
+            // A failed batch is not a cache of confirmed misses. Retain the existing
+            // per-document diagnostic fallback without changing routing decisions.
+            documentIds.clear();
         }
     }
     auto resolveDocumentId = [&](const std::string& hash) -> const std::optional<std::string>& {
@@ -523,6 +527,22 @@ tryMedoidGraphExpansion(const TopologyRoutingSessionRequest& request,
     return out;
 }
 
+void rejectMetadataHydration(TopologyRoutingSessionResult& result, const Error& error) {
+    result.skipReason = "metadata_lookup_failed:" + error.message;
+    result.applied = false;
+    result.artifactAdmitted = false;
+    result.acceptedRoutes = 0;
+    result.addedCandidates = 0;
+    result.duplicateCandidates = 0;
+    result.certificate = {};
+    result.routeEvidence.clear();
+    result.addedCandidateHashes.clear();
+    result.routedCandidateHashes.clear();
+    result.routedCandidateDocIds.clear();
+    result.medoidHashes.clear();
+    result.candidateStructureEvidence.clear();
+}
+
 void admitRankedCandidates(TopologyRoutingSessionResult& result,
                            const TopologyRoutingSessionRequest& request,
                            const std::shared_ptr<yams::metadata::MetadataRepository>& metadataRepo,
@@ -535,10 +555,14 @@ void admitRankedCandidates(TopologyRoutingSessionResult& result,
     }
     candidateHashes.reserve(candidateHashes.size() + ranked.size());
 
-    // One statement for the whole ranked set; a hash the corpus no longer holds is stale.
+    // One bounded batch call; only a successful lookup can establish that a hash is stale.
     const auto docLookupStart = std::chrono::steady_clock::now();
     auto hydrated = metadataRepo->batchGetDocumentsByHash(ranked);
     result.timings.docLookupMicros += microsSince(docLookupStart);
+    if (!hydrated) {
+        rejectMetadataHydration(result, hydrated.error());
+        return;
+    }
     for (const auto& hash : ranked) {
         const yams::metadata::DocumentInfo* document = nullptr;
         if (hydrated) {
@@ -632,7 +656,7 @@ bool tryRunGraphNeighborExpansion(
     }
 
     admitRankedCandidates(result, request, metadataRepo, ranked);
-    if (!result.applied) {
+    if (!result.applied && result.skipReason.empty()) {
         result.skipReason = "graph_all_duplicates";
     } else if (result.skipReason.empty()) {
         result.skipReason = "graph_seed_neighbors";
@@ -1111,6 +1135,11 @@ runClusterArtifactExpansion(const TopologyRoutingSessionRequest& request,
                             ? decltype(metadataRepo->batchGetDocumentsByHash(expansionHashes)){}
                             : metadataRepo->batchGetDocumentsByHash(expansionHashes);
         result.timings.docLookupMicros += microsSince(docLookupStart);
+        if (!expansionHashes.empty() && !hydrated) {
+            rejectMetadataHydration(result, hydrated.error());
+            result.timings.totalMicros = microsSince(totalStart);
+            return result;
+        }
         for (const auto& hash : expansionHashes) {
             ++result.routedDocs;
             const yams::metadata::DocumentInfo* document = nullptr;

--- a/src/search/topology_routing_session.cpp
+++ b/src/search/topology_routing_session.cpp
@@ -332,7 +332,25 @@ void collectGraphNeighborStageTrace(
     trace.eligibleCandidateCount = eligibleCandidates.size();
 
     std::unordered_map<std::string, std::optional<std::string>> documentIds;
-    documentIds.reserve(request.seedDocumentHashes.size() + relationCandidates.size());
+    documentIds.reserve(request.seedDocumentHashes.size() + relationCandidates.size() +
+                        fetchedCandidates.size() + eligibleCandidates.size());
+    {
+        std::vector<std::string> allHashes;
+        allHashes.reserve(documentIds.bucket_count());
+        for (const auto* stage : {&request.seedDocumentHashes, &relationCandidates,
+                                  &fetchedCandidates, &eligibleCandidates}) {
+            for (const auto& hash : *stage) {
+                if (documentIds.try_emplace(hash).second) {
+                    allHashes.push_back(hash);
+                }
+            }
+        }
+        if (auto hydrated = metadataRepo->batchGetDocumentsByHash(allHashes)) {
+            for (auto& [hash, document] : hydrated.value()) {
+                documentIds[hash] = documentIdForTrace(document.filePath, hash);
+            }
+        }
+    }
     auto resolveDocumentId = [&](const std::string& hash) -> const std::optional<std::string>& {
         auto [it, inserted] = documentIds.try_emplace(hash);
         if (!inserted) {
@@ -517,11 +535,18 @@ void admitRankedCandidates(TopologyRoutingSessionResult& result,
     }
     candidateHashes.reserve(candidateHashes.size() + ranked.size());
 
+    // One statement for the whole ranked set; a hash the corpus no longer holds is stale.
+    const auto docLookupStart = std::chrono::steady_clock::now();
+    auto hydrated = metadataRepo->batchGetDocumentsByHash(ranked);
+    result.timings.docLookupMicros += microsSince(docLookupStart);
     for (const auto& hash : ranked) {
-        const auto docLookupStart = std::chrono::steady_clock::now();
-        auto docLookup = metadataRepo->getDocumentByHash(hash);
-        result.timings.docLookupMicros += microsSince(docLookupStart);
-        if (!docLookup || !docLookup.value().has_value()) {
+        const yams::metadata::DocumentInfo* document = nullptr;
+        if (hydrated) {
+            if (const auto it = hydrated.value().find(hash); it != hydrated.value().end()) {
+                document = &it->second;
+            }
+        }
+        if (!document) {
             ++result.staleCandidates;
             continue;
         }
@@ -529,8 +554,7 @@ void admitRankedCandidates(TopologyRoutingSessionResult& result,
             result.certificate.allowedDocumentHashes.insert(hash);
         }
         result.routedCandidateHashes.insert(hash);
-        result.routedCandidateDocIds.push_back(
-            documentIdForTrace(docLookup.value()->filePath, hash));
+        result.routedCandidateDocIds.push_back(documentIdForTrace(document->filePath, hash));
         const auto insertStart = std::chrono::steady_clock::now();
         const auto [_, inserted] = candidateHashes.insert(hash);
         result.timings.candidateInsertMicros += microsSince(insertStart);
@@ -1072,16 +1096,30 @@ runClusterArtifactExpansion(const TopologyRoutingSessionRequest& request,
         if (request.options.collectRouteMembership) {
             continue;
         }
-        const auto expansionHashes = selectClusterExpansionHashes(route);
-        for (const auto& hash : expansionHashes) {
-            if (request.options.maxDocs > 0 && result.routedDocs >= request.options.maxDocs) {
-                break;
+        auto expansionHashes = selectClusterExpansionHashes(route);
+        if (request.options.maxDocs > 0) {
+            // Same cut the per-document loop applied, taken before hydration.
+            const std::size_t remaining = result.routedDocs >= request.options.maxDocs
+                                              ? 0
+                                              : request.options.maxDocs - result.routedDocs;
+            if (expansionHashes.size() > remaining) {
+                expansionHashes.resize(remaining);
             }
+        }
+        const auto docLookupStart = std::chrono::steady_clock::now();
+        auto hydrated = expansionHashes.empty()
+                            ? decltype(metadataRepo->batchGetDocumentsByHash(expansionHashes)){}
+                            : metadataRepo->batchGetDocumentsByHash(expansionHashes);
+        result.timings.docLookupMicros += microsSince(docLookupStart);
+        for (const auto& hash : expansionHashes) {
             ++result.routedDocs;
-            const auto docLookupStart = std::chrono::steady_clock::now();
-            auto docLookup = metadataRepo->getDocumentByHash(hash);
-            result.timings.docLookupMicros += microsSince(docLookupStart);
-            if (!docLookup || !docLookup.value().has_value()) {
+            const yams::metadata::DocumentInfo* document = nullptr;
+            if (hydrated) {
+                if (const auto it = hydrated.value().find(hash); it != hydrated.value().end()) {
+                    document = &it->second;
+                }
+            }
+            if (!document) {
                 ++result.staleCandidates;
                 continue;
             }
@@ -1089,8 +1127,7 @@ runClusterArtifactExpansion(const TopologyRoutingSessionRequest& request,
                 continue;
             }
             result.routedCandidateHashes.insert(hash);
-            result.routedCandidateDocIds.push_back(
-                documentIdForTrace(docLookup.value()->filePath, hash));
+            result.routedCandidateDocIds.push_back(documentIdForTrace(document->filePath, hash));
             const auto insertStart = std::chrono::steady_clock::now();
             const auto [_, inserted] = candidateHashes.insert(hash);
             result.timings.candidateInsertMicros += microsSince(insertStart);

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -82,8 +82,8 @@ plugins/symbol_extractor_treesitter/grammar_loader.cpp:402:portability/env-read 
 plugins/symbol_extractor_treesitter/grammar_loader.cpp:411:portability/env-read # reviewed raw environment read
 plugins/symbol_extractor_treesitter/grammar_loader.cpp:413:portability/env-read # reviewed raw environment read
 src/app/services/document_service.cpp:1207:portability/env-read # reviewed raw environment read
-src/app/services/search_service.cpp:655:portability/env-read # reviewed raw environment read
-src/app/services/search_service.cpp:736:portability/env-read # reviewed raw environment read
+src/app/services/search_service.cpp:634:portability/env-read # reviewed raw environment read
+src/app/services/search_service.cpp:715:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:18:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:20:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:71:portability/env-read # reviewed raw environment read

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -501,7 +501,7 @@ tests/unit/search/graph_expansion_catch2_test.cpp:18:portability/env-read # revi
 tests/unit/search/hybrid_search_comprehensive_test.cpp:272:portability/env-read # reviewed raw environment read
 tests/unit/search/kg_scorer_simple_catch2_test.cpp:35:portability/env-read # reviewed raw environment read
 tests/unit/search/search_engine_simeon_lexical_catch2_test.cpp:25:portability/env-read # reviewed raw environment read
-tests/unit/search/search_engine_topology_catch2_test.cpp:43:portability/env-read # reviewed raw environment read
+tests/unit/search/search_engine_topology_catch2_test.cpp:44:portability/env-read # reviewed raw environment read
 tests/unit/search/simeon_bandit_backend_catch2_test.cpp:30:portability/env-read # reviewed raw environment read
 tests/unit/search/simeon_lexical_backend_catch2_test.cpp:27:portability/env-read # reviewed raw environment read
 tests/unit/topology/topology_baseline_catch2_test.cpp:64:portability/env-read # reviewed raw environment read

--- a/tests/scripts/portability_allowlist.txt
+++ b/tests/scripts/portability_allowlist.txt
@@ -82,8 +82,8 @@ plugins/symbol_extractor_treesitter/grammar_loader.cpp:402:portability/env-read 
 plugins/symbol_extractor_treesitter/grammar_loader.cpp:411:portability/env-read # reviewed raw environment read
 plugins/symbol_extractor_treesitter/grammar_loader.cpp:413:portability/env-read # reviewed raw environment read
 src/app/services/document_service.cpp:1207:portability/env-read # reviewed raw environment read
-src/app/services/search_service.cpp:634:portability/env-read # reviewed raw environment read
-src/app/services/search_service.cpp:715:portability/env-read # reviewed raw environment read
+src/app/services/search_service.cpp:630:portability/env-read # reviewed raw environment read
+src/app/services/search_service.cpp:711:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:18:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:20:portability/env-read # reviewed raw environment read
 src/app/services/session_service.cpp:71:portability/env-read # reviewed raw environment read

--- a/tests/unit/app/services/search_service_catch2_test.cpp
+++ b/tests/unit/app/services/search_service_catch2_test.cpp
@@ -84,11 +84,14 @@ public:
     Result<std::unordered_map<int64_t, std::vector<std::string>>>
     batchGetDocumentTags(std::span<const int64_t> documentIds) override {
         ++batchTagCalls;
+        if (failTagLookup)
+            return Error{ErrorCode::InternalError, "injected tag lookup failure"};
         return MetadataRepository::batchGetDocumentTags(documentIds);
     }
 
     std::atomic<int> allMetadataCalls{0};
     std::atomic<int> batchTagCalls{0};
+    bool failTagLookup{false};
 };
 
 class SlowSnippetMetadataRepository : public MetadataRepository {
@@ -491,7 +494,7 @@ TEST_CASE("SearchService: tag filtering loads tags once per request, not per doc
           "[unit][services][search][tags]") {
     SearchServiceFixture f;
     REQUIRE(f.testHashes.size() >= 3);
-    f.setMetadataForHash(f.testHashes[0], "tag:tutorial", "1");
+    f.setMetadataForHash(f.testHashes[0], "tag", "tutorial");
     f.setMetadataForHash(f.testHashes[1], "tag:example", "1");
     f.setMetadataForHash(f.testHashes[1], "tag:tutorial", "1");
 
@@ -500,6 +503,19 @@ TEST_CASE("SearchService: tag filtering loads tags once per request, not per doc
     f.appContext.metadataRepo = counting;
     f.searchService = makeSearchService(f.appContext);
 
+    SECTION("tag lookup failure is reported rather than an empty successful search") {
+        counting->failTagLookup = true;
+        for (bool byHash : {true, false}) {
+            auto request = f.createBasicSearchRequest(byHash ? "" : "*.txt");
+            if (byHash)
+                request.hash = f.testHashes[1].substr(0, 12);
+            request.tags = {"tutorial"};
+            auto result = runAwait(f.searchService->search(request));
+            CHECK_FALSE(result.has_value());
+            if (!result)
+                CHECK(result.error().message == "injected tag lookup failure");
+        }
+    }
     SECTION("hash prefix search") {
         auto request = f.createBasicSearchRequest("");
         request.hash = f.testHashes[1].substr(0, 12);

--- a/tests/unit/app/services/search_service_catch2_test.cpp
+++ b/tests/unit/app/services/search_service_catch2_test.cpp
@@ -12,10 +12,12 @@
 #define getpid _getpid
 #endif
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <filesystem>
 #include <optional>
+#include <span>
 #include <thread>
 #include <unordered_set>
 
@@ -67,6 +69,26 @@ public:
 
 private:
     std::size_t getDocumentByHashFailures_{0};
+};
+
+class TagLookupCountingRepository : public MetadataRepository {
+public:
+    explicit TagLookupCountingRepository(ConnectionPool& pool) : MetadataRepository(pool) {}
+
+    Result<std::unordered_map<std::string, MetadataValue>>
+    getAllMetadata(int64_t documentId) override {
+        ++allMetadataCalls;
+        return MetadataRepository::getAllMetadata(documentId);
+    }
+
+    Result<std::unordered_map<int64_t, std::vector<std::string>>>
+    batchGetDocumentTags(std::span<const int64_t> documentIds) override {
+        ++batchTagCalls;
+        return MetadataRepository::batchGetDocumentTags(documentIds);
+    }
+
+    std::atomic<int> allMetadataCalls{0};
+    std::atomic<int> batchTagCalls{0};
 };
 
 class SlowSnippetMetadataRepository : public MetadataRepository {
@@ -463,6 +485,44 @@ TEST_CASE("SearchService: tag filter", "[unit][services][search]") {
     auto result = runAwait(f.searchService->search(request));
     REQUIRE(result);
     CHECK(result.value().total >= kZeroTotal);
+}
+
+TEST_CASE("SearchService: tag filtering loads tags once per request, not per document",
+          "[unit][services][search][tags]") {
+    SearchServiceFixture f;
+    REQUIRE(f.testHashes.size() >= 3);
+    f.setMetadataForHash(f.testHashes[0], "tag:tutorial", "1");
+    f.setMetadataForHash(f.testHashes[1], "tag:example", "1");
+    f.setMetadataForHash(f.testHashes[1], "tag:tutorial", "1");
+
+    auto counting = std::make_shared<TagLookupCountingRepository>(*f.pool);
+    f.metadataRepo = counting;
+    f.appContext.metadataRepo = counting;
+    f.searchService = makeSearchService(f.appContext);
+
+    SECTION("hash prefix search") {
+        auto request = f.createBasicSearchRequest("");
+        request.hash = f.testHashes[1].substr(0, 12);
+        request.tags = {"tutorial", "example"};
+        request.matchAllTags = true;
+        auto result = runAwait(f.searchService->search(request));
+        INFO(std::string(result ? "ok" : result.error().message.c_str()));
+        REQUIRE(result);
+        CHECK(result.value().results.size() == 1);
+        CHECK(counting->batchTagCalls.load() == 1);
+        CHECK(counting->allMetadataCalls.load() == 0);
+    }
+    SECTION("path search") {
+        auto request = f.createBasicSearchRequest("*.txt");
+        request.tags = {"tutorial"};
+        request.matchAllTags = false;
+        auto result = runAwait(f.searchService->search(request));
+        INFO(std::string(result ? "ok" : result.error().message.c_str()));
+        REQUIRE(result);
+        CHECK(result.value().results.size() == 2);
+        CHECK(counting->batchTagCalls.load() == 1);
+        CHECK(counting->allMetadataCalls.load() == 0);
+    }
 }
 
 TEST_CASE("SearchService: file type filter", "[unit][services][search]") {

--- a/tests/unit/metadata/metadata_repository_catch2_test.cpp
+++ b/tests/unit/metadata/metadata_repository_catch2_test.cpp
@@ -596,14 +596,57 @@ TEST_CASE("MetadataRepository: session and tag helpers round-trip",
     REQUIRE((docCTags.has_value()));
     CHECK((docCTags.value() == std::vector<std::string>{"alpha", "beta"}));
 
-    auto batchTags = fix.repository_->batchGetDocumentTags(
-        std::vector<int64_t>{cId.value(), dId.value(), 999999});
+    std::vector<int64_t> tagIds{cId.value(), dId.value(), 999999};
+    SECTION("legacy tag values are retained") {}
+    SECTION("bounded queries deduplicate IDs across chunks") {
+        REQUIRE(fix.pool_
+                    ->withConnection([](Database& db) -> Result<void> {
+                        sqlite3_limit(db.rawHandle(), SQLITE_LIMIT_VARIABLE_NUMBER, 16);
+                        return {};
+                    })
+                    .has_value());
+        for (int64_t i = 1; i < 40; ++i)
+            tagIds.push_back(999999 + i);
+        tagIds.push_back(cId.value());
+        tagIds.push_back(dId.value());
+    }
+    auto batchTags = fix.repository_->batchGetDocumentTags(tagIds);
     REQUIRE((batchTags.has_value()));
     REQUIRE((batchTags.value().contains(cId.value())));
     REQUIRE((batchTags.value().contains(dId.value())));
     CHECK((batchTags.value().at(cId.value()) == std::vector<std::string>{"alpha", "beta"}));
-    CHECK((batchTags.value().at(dId.value()) == std::vector<std::string>{"alpha"}));
+    CHECK((batchTags.value().at(dId.value()) == std::vector<std::string>{"alpha", "legacy"}));
     CHECK_FALSE(batchTags.value().contains(999999));
+    std::vector<std::string> lookupHashes{docC.sha256Hash, docD.sha256Hash, docC.sha256Hash};
+    for (int i = 0; i < 40; ++i)
+        lookupHashes.push_back("missing-batch-hash-" + std::to_string(i));
+    auto hydrated = fix.repository_->batchGetDocumentsByHash(lookupHashes);
+    REQUIRE(hydrated.has_value());
+    REQUIRE(hydrated.value().size() == 2);
+    CHECK(hydrated.value().at(docC.sha256Hash).id == cId.value());
+    CHECK(hydrated.value().at(docD.sha256Hash).id == dId.value());
+
+    // Failed preparation must release the read savepoint and leave the connection reusable.
+    int previousSqlLimit = 0;
+    REQUIRE(fix.pool_
+                ->withConnection([&](Database& db) -> Result<void> {
+                    CHECK(sqlite3_get_autocommit(db.rawHandle()) == 1);
+                    previousSqlLimit = sqlite3_limit(db.rawHandle(), SQLITE_LIMIT_SQL_LENGTH, 64);
+                    return {};
+                })
+                .has_value());
+    auto prepareFailure = fix.repository_->batchGetDocumentsByHash(lookupHashes);
+    REQUIRE(fix.pool_
+                ->withConnection([&](Database& db) -> Result<void> {
+                    sqlite3_limit(db.rawHandle(), SQLITE_LIMIT_SQL_LENGTH, previousSqlLimit);
+                    CHECK(sqlite3_get_autocommit(db.rawHandle()) == 1);
+                    return {};
+                })
+                .has_value());
+    CHECK_FALSE(prepareFailure.has_value());
+    auto retryHydration = fix.repository_->batchGetDocumentsByHash(lookupHashes);
+    REQUIRE(retryHydration.has_value());
+    CHECK(retryHydration.value().size() == 2);
 
     auto allTags = fix.repository_->getAllTags();
     REQUIRE((allTags.has_value()));

--- a/tests/unit/search/search_engine_topology_catch2_test.cpp
+++ b/tests/unit/search/search_engine_topology_catch2_test.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
@@ -80,6 +81,25 @@ public:
 private:
     std::vector<float> embedding_;
     bool initialized_{false};
+};
+
+class HashLookupCountingRepository : public MetadataRepository {
+public:
+    explicit HashLookupCountingRepository(ConnectionPool& pool) : MetadataRepository(pool) {}
+
+    Result<std::optional<DocumentInfo>> getDocumentByHash(const std::string& hash) override {
+        ++singleLookups;
+        return MetadataRepository::getDocumentByHash(hash);
+    }
+
+    Result<std::unordered_map<std::string, DocumentInfo>>
+    batchGetDocumentsByHash(const std::vector<std::string>& hashes) override {
+        ++batchLookups;
+        return MetadataRepository::batchGetDocumentsByHash(hashes);
+    }
+
+    std::atomic<int> singleLookups{0};
+    std::atomic<int> batchLookups{0};
 };
 
 struct TopologySearchFixture {
@@ -2208,4 +2228,48 @@ TEST_CASE("Graph-neighbor trace separates stored relation from the selected cap"
           std::vector<std::string>{"near", "far"});
     REQUIRE(result.routedCandidateDocIds.size() == 1);
     CHECK(result.routedCandidateDocIds.front() == "near");
+}
+
+TEST_CASE("Topology routing hydrates ranked candidates and trace stages in batches",
+          "[unit][search][topology][graph_neighbors][hydration]") {
+    TopologySearchFixture fix;
+    auto counting = std::make_shared<HashLookupCountingRepository>(*fix.pool);
+    fix.repo = counting;
+    fix.addDocument("seed", "seed", {1.0F, 0.0F});
+    std::vector<KGNode> nodes{KGNode{.nodeKey = "doc:seed", .type = "document"}};
+    for (int i = 0; i < 8; ++i) {
+        const auto hash = "near" + std::to_string(i);
+        fix.addDocument(hash, hash, {0.9F, 0.1F});
+        nodes.push_back(KGNode{.nodeKey = "doc:" + hash, .type = "document"});
+    }
+    const auto nodeIds = fix.kgStore->upsertNodes(nodes);
+    REQUIRE(nodeIds.has_value());
+    REQUIRE(nodeIds.value().size() == 9);
+    for (std::size_t i = 1; i < nodeIds.value().size(); ++i) {
+        REQUIRE(fix.kgStore
+                    ->addEdge(KGEdge{.srcNodeId = nodeIds.value()[0],
+                                     .dstNodeId = nodeIds.value()[i],
+                                     .relation = "semantic_neighbor",
+                                     .weight = 0.9F})
+                    .has_value());
+    }
+    TopologyRoutingSessionRequest request;
+    request.seedDocumentHashes = {"seed"};
+    request.options.routingMode = SearchEngineConfig::TopologyRoutingMode::HybridAssist;
+    request.options.expansionSource = SearchEngineConfig::TopologyExpansionSource::GraphNeighbors;
+    request.options.maxDocs = 8;
+    request.options.collectRouteMembership = true;
+    request.options.collectGraphDiagnostics = true;
+    request.options.graphNeighborMinScore = 0.0F;
+    request.options.graphNeighborReciprocalOnly = false;
+
+    counting->singleLookups = 0;
+    counting->batchLookups = 0;
+    const auto result = runTopologyRoutingSession(request, fix.repo, fix.kgStore);
+    REQUIRE(result.graphNeighborTrace.collected);
+    CHECK(result.graphNeighborTrace.relationCandidateCount == 8);
+    REQUIRE(result.routedCandidateDocIds.size() == 8);
+    // Trace stages resolve in one batch and ranked admission in another; nothing goes per hash.
+    CHECK(counting->batchLookups.load() >= 1);
+    CHECK(counting->singleLookups.load() == 0);
 }

--- a/tests/unit/search/search_engine_topology_catch2_test.cpp
+++ b/tests/unit/search/search_engine_topology_catch2_test.cpp
@@ -94,12 +94,17 @@ public:
 
     Result<std::unordered_map<std::string, DocumentInfo>>
     batchGetDocumentsByHash(const std::vector<std::string>& hashes) override {
-        ++batchLookups;
+        const auto call = ++batchLookups;
+        if (failBatchLookups || (failBatchAt > 0 && call == failBatchAt)) {
+            return Error{ErrorCode::InternalError, "injected metadata lookup failure"};
+        }
         return MetadataRepository::batchGetDocumentsByHash(hashes);
     }
 
     std::atomic<int> singleLookups{0};
     std::atomic<int> batchLookups{0};
+    bool failBatchLookups{false};
+    int failBatchAt{0};
 };
 
 struct TopologySearchFixture {
@@ -2230,6 +2235,44 @@ TEST_CASE("Graph-neighbor trace separates stored relation from the selected cap"
     CHECK(result.routedCandidateDocIds.front() == "near");
 }
 
+TEST_CASE("Topology cluster hydration failure discards partial admission",
+          "[unit][search][topology][hydration]") {
+    TopologySearchFixture fix;
+    auto counting = std::make_shared<HashLookupCountingRepository>(*fix.pool);
+    fix.repo = counting;
+    seedTopologyDocuments(fix);
+    const auto batch = buildTwoClusterTopologyBatch();
+    TopologyRoutingSessionRequest request;
+    request.seedDocumentHashes = {"x1", "y1"};
+    request.options.routingMode = SearchEngineConfig::TopologyRoutingMode::HybridAssist;
+    request.options.expansionSource = SearchEngineConfig::TopologyExpansionSource::Clusters;
+    request.options.maxClusters = 2;
+    request.options.maxDocs = 8;
+    request.options.minRouteScore = 0.0F;
+    request.snapshotCache = std::make_shared<TopologyRoutingSnapshotCache>(
+        [batch] { return Result<std::optional<yams::topology::TopologyArtifactBatch>>{batch}; });
+    counting->batchLookups = 0;
+    SECTION("all cluster lookups succeed") {
+        const auto result = runTopologyRoutingSession(request, fix.repo, fix.kgStore);
+        CHECK(result.applied);
+        // Non-membership expansion materializes one medoid per selected cluster.
+        CHECK(result.addedCandidateHashes.size() == 2);
+        CHECK(counting->batchLookups.load() == 2);
+    }
+    SECTION("second cluster lookup fails after the first was admitted") {
+        counting->failBatchAt = 2;
+        const auto result = runTopologyRoutingSession(request, fix.repo, fix.kgStore);
+        CHECK(counting->batchLookups.load() == 2);
+        CHECK_FALSE(result.applied);
+        CHECK(result.staleCandidates == 0);
+        CHECK(result.skipReason.starts_with("metadata_lookup_failed"));
+        CHECK(result.certificate.allowedDocumentHashes.empty());
+        CHECK(result.routedCandidateHashes.empty());
+        CHECK(result.addedCandidateHashes.empty());
+        CHECK(result.addedCandidates == 0);
+    }
+}
+
 TEST_CASE("Topology routing hydrates ranked candidates and trace stages in batches",
           "[unit][search][topology][graph_neighbors][hydration]") {
     TopologySearchFixture fix;
@@ -2265,11 +2308,30 @@ TEST_CASE("Topology routing hydrates ranked candidates and trace stages in batch
 
     counting->singleLookups = 0;
     counting->batchLookups = 0;
-    const auto result = runTopologyRoutingSession(request, fix.repo, fix.kgStore);
-    REQUIRE(result.graphNeighborTrace.collected);
-    CHECK(result.graphNeighborTrace.relationCandidateCount == 8);
-    REQUIRE(result.routedCandidateDocIds.size() == 8);
-    // Trace stages resolve in one batch and ranked admission in another; nothing goes per hash.
-    CHECK(counting->batchLookups.load() >= 1);
-    CHECK(counting->singleLookups.load() == 0);
+    SECTION("successful hydration remains batched") {
+        const auto result = runTopologyRoutingSession(request, fix.repo, fix.kgStore);
+        REQUIRE(result.graphNeighborTrace.collected);
+        CHECK(result.graphNeighborTrace.relationCandidateCount == 8);
+        REQUIRE(result.routedCandidateDocIds.size() == 8);
+        CHECK(counting->batchLookups.load() >= 1);
+        CHECK(counting->singleLookups.load() == 0);
+    }
+    SECTION("a diagnostic batch failure retains per-document fallback") {
+        counting->failBatchAt = 1;
+        const auto result = runTopologyRoutingSession(request, fix.repo, fix.kgStore);
+        CHECK(result.applied);
+        CHECK(result.staleCandidates == 0);
+        CHECK(result.graphNeighborTrace.eligibleUnresolvedCount == 0);
+        CHECK(result.graphNeighborTrace.eligibleCandidateDocumentIds.size() == 8);
+        CHECK(counting->singleLookups.load() > 0);
+    }
+    SECTION("metadata failure is not evidence of stale documents") {
+        counting->failBatchLookups = true;
+        const auto result = runTopologyRoutingSession(request, fix.repo, fix.kgStore);
+        CHECK_FALSE(result.applied);
+        CHECK(result.staleCandidates == 0);
+        CHECK(result.skipReason.starts_with("metadata_lookup_failed"));
+        CHECK(result.certificate.allowedDocumentHashes.empty());
+        CHECK(result.addedCandidateHashes.empty());
+    }
 }


### PR DESCRIPTION
## Purpose

Batch tag and topology hydration

## Behavior changes

Batch request hydration with deduplicated IDs/hashes and actual SQLite parameter budgets (cap500). Include legacy tag values alongside normalized keys. Hash chunks share a read savepoint. Reject metadata failures rather than classifying candidates as stale; discard partial cluster admission. Diagnostic batch failures retain scalar fallback.

## Compatibility impact

Legacy tag filtering restored without changing getAllTags/getDocumentTags. Tagged path/hash lookup failure now returns an error instead of successful empty results; tagged path errors no longer fall through, while untagged path fallback remains. No new public signature/config knob. Failed routing adds no candidates/certificate; successful lookup absence remains stale.

## Structural evidence

Source-verified repository/service/routing boundaries: existing batch APIs remain unchanged; private awaitable<Result<TagsByDocument>> propagates errors through both callers and outer tagged path dispatcher. Shared private routing rejection helper clears partial materialized results. Counting fixtures prove batched success, diagnostic fallback, and second-cluster failure. No claimed measured speedup or new Brick score.

Pinned same-root Brick archive comparisons are available for all groups and the cumulative stack. Bounded extraction-seam review verified149 resolved includes. Final graph has1158 parser diagnostics across619 files and0.089 local dependency resolution; experimental score68.708 versus68.820 baseline. Partial heuristic coverage is not architecture quality or runtime correctness proof.

## Tests

Monitor40 full native ASan/UBSan metadata_repository156.62s/search_service9.12s/search_submodule76.31s allpassed. Red legacytag/budget, hashbudget, eight false-stale, and servicefalse-empty cases recorded. SQLitelimit16, duplicated IDs/hashes, preparefailure/savepointcleanup/retry, mixedtagformats, two-cluster partialdiscard andtracefallback covered.

build/quality/group07-full-green-retry.log monitor40 all3passed; monitor39 rawlog preserved. Portability573reviewed/0new. Focused native binaries, not cumulative normal publication gate. Lens auxiliary compilation context remains missing headers; no source workaround. Correction84493aeb signedGPG/exactDCO/fivehooks. Opengrep0findingsbut5partiallyparsedfiles; notfullanalysiscoverage.

Cumulative exact-final validation at `661e33c2273d7e684b41ad006e925912263dc9f5`: full canonical ASan/UBSan 204/0 and TSan 289/0; installed-only MemorySyncLoop publish/sync/read and TuneAdvisor consumer passed. These final-tip results do not certify each intermediate head independently. Policy checks found zero new portability/raw-environment/configuration violations or benchmark environment leaks.

Final-tip SciFact: 2000-document plan, 50 measured hybrid queries, k=10, three repeats per arm. Product/untraced, topology-off/untraced, and shadow/traced produced identical measured hybrid rankings (MRR 0.676667; recall@10 0.793333). Mean p50: 323.667/306.333/352 ms respectively. ASan/UBSan debug timings only; not production latency, a source-revision before/after comparison, or a performance-win claim.

## Dependencies

Group 7/14; base `grouped/06-sqlite-batching`, prepared head `84493aebd04f77cace21d0544f02528aa0f0aeea`. group6

All42 newly prepared commits have valid signatures and exact trvon DCO trailers. Inherited PR115 commit5393a5a8 is unsigned and lacks DCO; the user explicitly approved retaining this inherited exception to preserve fast-forward history. No exception applies to newly prepared commits.

Source replay mapping:
- `c3518af8` → `47331e2516548284a6f86fa6feca44538fde26cc`
- `4d3a2021` → `3bbfd48f22d450789d638d8d04a37a591a98631d`
